### PR TITLE
Boost 1.57.0

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=1.57.0
 
 . ${MASON_DIR:-~/.mason}/mason.sh
 
-BOOST_ROOT='${MASON_PREFIX}'
+BOOST_ROOT=${MASON_PREFIX}
 
 function mason_load_source {
     mason_download \


### PR DESCRIPTION
This mason script  downloads boost then copies only the headers to an include folder.

Allows use of non-system boost.

Avoids problems with Android build on Linux.

Still needs a travis script.

Needs to be put in boost-1.57.0 branch, but github won't let me select that.
