### PR TITLE
Don't exit on missing distribution version

### DIFF
--- a/mason.sh
+++ b/mason.sh
@@ -68,7 +68,6 @@ elif [ ${MASON_PLATFORM} = 'linux' ]; then
     MASON_PLATFORM_DISTRIBUTION_VERSION=${DISTRIB_RELEASE:-${VERSION_ID}}
     if [ -z "${MASON_PLATFORM_DISTRIBUTION_VERSION}" ]; then
         mason_error "Cannot determine distribution version"
-        exit 1
     fi
 
     export MASON_PLATFORM_VERSION=${MASON_PLATFORM_DISTRIBUTION}-${MASON_PLATFORM_DISTRIBUTION_VERSION}-`uname -m`


### PR DESCRIPTION
Rolling release based distributions like Arch Linux don't have a versioning scheme and therefore don't set any version in `/etc/os-release`. Currently mason just exits if no version is set, but I think this could easily be changed into a warning.
