### PR TITLE
add /lib to MASON_OPENSSL path

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -22,7 +22,7 @@ function mason_load_source {
 
 function mason_prepare_compile {
     ${MASON_DIR:-~/.mason}/mason install boringssl d3bcf13
-    MASON_OPENSSL=`~/.mason/mason prefix boringssl d3bcf13`
+    MASON_OPENSSL=`~/.mason/mason prefix boringssl d3bcf13`/lib
 
     if [ ${MASON_PLATFORM} = 'linux' ]; then
         LIBS="-ldl ${LIBS=}"


### PR DESCRIPTION
I think this is why OpenSSL symbols were missing in `libcurl` on the `libcurl-7.38.0-boringssl` branch @ljbade, not able to test this locally though because of https://github.com/mapbox/mason/issues/44. Wonder if this is enough to fix https://github.com/mapbox/mapbox-gl-native/pull/754