### PR TITLE
OSX compile flag improvements

### DIFF
--- a/mason.sh
+++ b/mason.sh
@@ -40,8 +40,13 @@ if [ ${MASON_PLATFORM} = 'osx' ]; then
     MIN_SDK_VERSION_FLAG="-mmacosx-version-min=10.8"
     SYSROOT_FLAGS="-isysroot ${MASON_SDK_PATH} -arch x86_64 ${MIN_SDK_VERSION_FLAG}"
     export CFLAGS="${SYSROOT_FLAGS}"
-    export CXXFLAGS="${CFLAGS} -fvisibility-inlines-hidden"
-    export LDFLAGS="-Wl,-search_paths_first -Wl,-bind_at_load ${SYSROOT_FLAGS}"
+    export CXXFLAGS="${CFLAGS} -fvisibility-inlines-hidden -stdlib=libc++ -std=c++11"
+    # NOTE: OSX needs '-stdlib=libc++ -std=c++11' in both CXXFLAGS and LDFLAGS
+    # to correctly target c++11 for build systems that don't know about it yet (like libgeos 3.4.2)
+    # But because LDFLAGS is also for C libs we can only put these flags into LDFLAGS per package
+    export LDFLAGS="-Wl,-search_paths_first ${SYSROOT_FLAGS}"
+    export CXX="${MASON_XCODE_ROOT}/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++"
+    export CC="${MASON_XCODE_ROOT}/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang"
 
 elif [ ${MASON_PLATFORM} = 'ios' ]; then
     export MASON_HOST_ARG="--host=arm-apple-darwin"


### PR DESCRIPTION

  - Set CC/CXX to avoid the odd default of `gcc` and `g++` which are just symlinks to clang anyway. This also fixes breakages in some old autotools checks that think clang is gcc and looks fof incompatible flags (hit with libgeos)
  - Puts c++11 flags in CXXFLAGS. Without this libgeos would still link to libstdc++ causing all sorts of problems. This is overall a good idea to set globally even though it should be the default in recent clang.

All tests passing: https://travis-ci.org/mapbox/mason/builds/48970026