### PR TITLE
Add tests and more android arch to zlib-system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ script:
 - ./script.sh build
 - ./script.sh link
 - ./test.sh
+- ./script.sh version
 
 after_success:
 #- ./script.sh publish

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,20 +6,25 @@ matrix:
   include:
     - os: osx
       compiler: clang
+      env: MASON_PLATFORM=osx
+    - os: osx
+      compiler: clang
+      env: MASON_PLATFORM=ios
     - os: linux
       compiler: clang
+      env: MASON_PLATFORM=linux
     - os: linux
-      env: MASON_PLATFORM=android MASON_ANDROID_ARCH=arm-v5
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v5
     - os: linux
-      env: MASON_PLATFORM=android MASON_ANDROID_ARCH=arm-v7
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v7
     - os: linux
-      env: MASON_PLATFORM=android MASON_ANDROID_ARCH=arm-v8
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v8
     - os: linux
-      env: MASON_PLATFORM=android MASON_ANDROID_ARCH=x86
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=x86
     - os: linux
-      env: MASON_PLATFORM=android MASON_ANDROID_ARCH=mips
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=mips
     - os: linux
-      env: MASON_PLATFORM=android MASON_ANDROID_ARCH=mips-64
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=mips-64
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,24 @@ language: cpp
 
 sudo: false
 
-compiler: clang
-
 matrix:
   include:
     - os: osx
+      compiler: clang
     - os: linux
+      compiler: clang
     - os: linux
-      env: MASON_PLATFORM=android MASON_ANDROID_ARCH=arm
+      env: MASON_PLATFORM=android MASON_ANDROID_ARCH=arm-v5
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ARCH=arm-v7
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ARCH=arm-v8
     - os: linux
       env: MASON_PLATFORM=android MASON_ANDROID_ARCH=x86
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ARCH=mips
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ARCH=mips-64
 
 env:
   global:
@@ -24,6 +32,8 @@ before_install:
 
 script:
 - ./script.sh build
+- ./script.sh link
+- ./test.sh
 
 after_success:
 #- ./script.sh publish

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,12 +28,13 @@ matrix:
 
 env:
   global:
+   - ANDROID_NDK_VERSION=10d
    - secure: "clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFnWLtmF3stlft5YWyc2kI+FI="
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
 - git clone --depth=1 https://github.com/mapbox/mason.git ~/.mason
-- if [[ "${MASON_PLATFORM}" == "android" ]]; then MASON_PLATFORM= ~/.mason/mason install 7z 9.20; export PATH=$(MASON_PLATFORM= ~/.mason/mason prefix 7z 9.20)/bin:${PATH}; wget http://dl.google.com/android/ndk/android-ndk-r10c-linux-x86_64.bin; chmod a+x ./android-ndk-r10c-linux-x86_64.bin; 7za x ./android-ndk-r10c-linux-x86_64.bin > /dev/null; export ANDROID_NDK_PATH=$(pwd)/android-ndk-r10c; fi;
+- if [[ "${MASON_PLATFORM}" == "android" ]]; then MASON_PLATFORM= ~/.mason/mason install 7z 9.20; export PATH=$(MASON_PLATFORM= ~/.mason/mason prefix 7z 9.20)/bin:${PATH}; wget http://dl.google.com/android/ndk/android-ndk-r${ANDROID_NDK_VERSION}-linux-x86_64.bin; chmod a+x ./android-ndk-r${ANDROID_NDK_VERSION}-linux-x86_64.bin; 7za x ./android-ndk-r${ANDROID_NDK_VERSION}-linux-x86_64.bin > /dev/null; export ANDROID_NDK_PATH=$(pwd)/android-ndk-r${ANDROID_NDK_VERSION}; fi;
 
 script:
 - ./script.sh build

--- a/script.sh
+++ b/script.sh
@@ -12,7 +12,7 @@ MASON_LDFLAGS="-L${MASON_PREFIX}/lib"
 
 if [[ ${MASON_PLATFORM} = 'osx' || ${MASON_PLATFORM} = 'ios' || ${MASON_PLATFORM} = 'android' ]]; then
     ZLIB_INCLUDE_PREFIX="${MASON_SDK_PATH}/usr/include"
-    if [[ ${MASON_ANDROID_ARCH} =~ "64" ]]; then
+    if [[ -d "${MASON_SDK_PATH}/usr/lib64" ]]; then
         ZLIB_LIBRARY="${MASON_SDK_PATH}/usr/lib64/libz.${MASON_DYNLIB_SUFFIX}"
     else
         ZLIB_LIBRARY="${MASON_SDK_PATH}/usr/lib/libz.${MASON_DYNLIB_SUFFIX}"

--- a/script.sh
+++ b/script.sh
@@ -12,7 +12,11 @@ MASON_LDFLAGS="-L${MASON_PREFIX}/lib"
 
 if [[ ${MASON_PLATFORM} = 'osx' || ${MASON_PLATFORM} = 'ios' || ${MASON_PLATFORM} = 'android' ]]; then
     ZLIB_INCLUDE_PREFIX="${MASON_SDK_PATH}/usr/include"
-    ZLIB_LIBRARY="${MASON_SDK_PATH}/usr/lib/libz.${MASON_DYNLIB_SUFFIX}"
+    if [[ ${MASON_ANDROID_ARCH} =~ "64" ]]; then
+        ZLIB_LIBRARY="${MASON_SDK_PATH}/usr/lib64/libz.${MASON_DYNLIB_SUFFIX}"
+    else
+        ZLIB_LIBRARY="${MASON_SDK_PATH}/usr/lib/libz.${MASON_DYNLIB_SUFFIX}"
+    fi
     MASON_LDFLAGS="${MASON_LDFLAGS} -lz"
 else
     ZLIB_INCLUDE_PREFIX="`pkg-config zlib --variable=includedir`"

--- a/test.sh
+++ b/test.sh
@@ -63,7 +63,7 @@ function check_file_links() {
                 # TODO: what about iPhone???
                 expected_keyword="iPhoneSimulator"
             elif [[ ${MASON_PLATFORM} == 'linux' ]]; then
-                expected_keyword="/usr/lib"
+                expected_keyword="/lib/x86_64-linux-gnu/"
             elif [[ ${MASON_PLATFORM} == 'android' ]]; then
                 MASON_ANDROID_ABI=$(${MASON_DIR:-~/.mason}/mason env MASON_ANDROID_ABI)
                 expected_keyword=".android-platform/${MASON_ANDROID_ABI}"

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -u
+
+CODE=0
+
+function check_cflags() {
+    MASON_CFLAGS=$(./script.sh cflags)
+    MASON_CFLAGS=${MASON_CFLAGS/-I/}
+    if [[ ! -d ${MASON_CFLAGS} ]]; then
+        echo "not ok: Path for cflags not found: ${MASON_CFLAGS}"
+        CODE=1
+    else
+        echo "ok: path to cflags found: ${MASON_CFLAGS}"
+    fi
+}
+
+function check_ldflags() {
+    MASON_LDFLAGS=$(./script.sh ldflags)
+    for var in $MASON_LDFLAGS; do
+        if [[ "${var}" =~ "-L" ]]; then
+            vpath=${var/-L/}
+            if [[ ! -d ${vpath} ]]; then
+                echo "not ok: Path for ldflags not found: ${vpath}"
+                CODE=1
+            else
+                echo "ok: path to ldflags found: ${vpath}"
+            fi
+        fi
+    done
+}
+
+function check_file_links() {
+    if [[ ! -L ./mason_packages/.link/$1 ]]; then
+        echo "not ok: ./mason_packages/.link/$1 is not a symlink"
+        CODE=1
+    else
+        echo "ok: ./mason_packages/.link/$1 is a symlink"
+    fi
+
+    if [[ ! -f ./mason_packages/.link/$1 ]]; then
+        echo "not ok: ./mason_packages/.link/$1 is not a file"
+        CODE=1
+    else
+        echo "ok: ./mason_packages/.link/$1 is a file"
+    fi
+
+}
+
+check_cflags
+check_ldflags
+check_file_links "include/zlib.h"
+check_file_links "include/zconf.h"
+check_file_links "lib/libz.$(${MASON_DIR:-~/.mason}/mason env MASON_DYNLIB_SUFFIX)"
+
+exit ${CODE}
+

--- a/test.sh
+++ b/test.sh
@@ -51,11 +51,15 @@ function check_file_links() {
             CODE=1
         else
             echo "ok: $resolved is a symlink"
+            # resolve osx symlinks further
+            if [[ -L $resolved ]]; then
+                resolved=$(read_link $resolved)
+            fi
             if [[ ! -f $resolved ]]; then
                 echo "not ok: $resolved is not a file"
                 CODE=1
             else
-                echo "ok: $resolved is a non-symlink file"
+                echo "ok: $resolved is a file"
                 expected_keyword="zlib"
                 if [[ ${MASON_PLATFORM} == 'osx' ]]; then
                     expected_keyword="MacOSX.platform"

--- a/test.sh
+++ b/test.sh
@@ -30,21 +30,58 @@ function check_ldflags() {
     done
 }
 
+function read_link() {
+    # number of processors on the current system
+    case "$(uname -s)" in
+        'Linux')    readlink -f $1;;
+        'Darwin')   readlink $1;;
+        *)          echo 1;;
+    esac
+}
+
 function check_file_links() {
     if [[ ! -L ./mason_packages/.link/$1 ]]; then
         echo "not ok: ./mason_packages/.link/$1 is not a symlink"
         CODE=1
     else
         echo "ok: ./mason_packages/.link/$1 is a symlink"
+        if [[ ! -f ./mason_packages/.link/$1 ]]; then
+            echo "not ok: ./mason_packages/.link/$1 is not a file"
+            CODE=1
+        else
+            echo "ok: ./mason_packages/.link/$1 is a file"
+        fi
     fi
 
-    if [[ ! -f ./mason_packages/.link/$1 ]]; then
-        echo "not ok: ./mason_packages/.link/$1 is not a file"
-        CODE=1
+}
+
+function check_shared_lib_info() {
+    resolved=$(read_link ./mason_packages/.link/$1)
+    if [[ -f $resolved ]]; then
+        echo "ok: resolved to $resolved"
+        if [[ ${MASON_PLATFORM} == 'osx' ]]; then
+            file $resolved
+            otool -L $resolved
+            lipo -info $resolved
+        elif [[ ${MASON_PLATFORM} == 'ios' ]]; then
+            file $resolved
+            otool -L $resolved
+            lipo -info $resolved
+        elif [[ ${MASON_PLATFORM} == 'linux' ]]; then
+            file $resolved
+            ldd $resolved
+            readelf -d $resolved
+        elif [[ ${MASON_PLATFORM} == 'android' ]]; then
+            file $resolved
+            BIN_PATH=$(~/.mason/mason env MASON_SDK_ROOT)/bin
+            MASON_ANDROID_TOOLCHAIN=$(${MASON_DIR:-~/.mason}/mason env MASON_ANDROID_TOOLCHAIN)
+            ${BIN_PATH}/${MASON_ANDROID_TOOLCHAIN}-readelf -d $resolved
+        fi
+
     else
-        echo "ok: ./mason_packages/.link/$1 is a file"
+        echo "not okay: could not resolve to file: $resolved"
+        CODE=1
     fi
-
 }
 
 check_cflags
@@ -52,6 +89,7 @@ check_ldflags
 check_file_links "include/zlib.h"
 check_file_links "include/zconf.h"
 check_file_links "lib/libz.$(${MASON_DIR:-~/.mason}/mason env MASON_DYNLIB_SUFFIX)"
+check_shared_lib_info "lib/libz.$(${MASON_DIR:-~/.mason}/mason env MASON_DYNLIB_SUFFIX)"
 
 exit ${CODE}
 

--- a/test.sh
+++ b/test.sh
@@ -56,14 +56,18 @@ function check_file_links() {
             CODE=1
         else
             echo "ok: $resolved is a file"
-            expected_keyword="zlib"
+            expected_keyword=""
             if [[ ${MASON_PLATFORM} == 'osx' ]]; then
                 expected_keyword="MacOSX.platform"
             elif [[ ${MASON_PLATFORM} == 'ios' ]]; then
                 # TODO: what about iPhone???
                 expected_keyword="iPhoneSimulator"
             elif [[ ${MASON_PLATFORM} == 'linux' ]]; then
-                expected_keyword="/lib/x86_64-linux-gnu/"
+                if [[ ${1} =~ "libz" ]]; then
+                    expected_keyword="/lib/x86_64-linux-gnu/"
+                elif [[ ${1} =~ "include" ]]; then
+                    expected_keyword="/usr/include/"
+                fi
             elif [[ ${MASON_PLATFORM} == 'android' ]]; then
                 MASON_ANDROID_ABI=$(${MASON_DIR:-~/.mason}/mason env MASON_ANDROID_ABI)
                 expected_keyword=".android-platform/${MASON_ANDROID_ABI}"

--- a/test.sh
+++ b/test.sh
@@ -55,31 +55,24 @@ function check_file_links() {
                 echo "not ok: $resolved is not a file"
                 CODE=1
             else
-                # resolve last symlink
-                resolved2=$(read_link $resolved)
-                if [[ ! -f $resolved2 ]]; then
-                    echo "not ok: $resolved2 is not a file"
-                    CODE=1
+                echo "ok: $resolved is a non-symlink file"
+                expected_keyword="zlib"
+                if [[ ${MASON_PLATFORM} == 'osx' ]]; then
+                    expected_keyword="MacOSX.platform"
+                elif [[ ${MASON_PLATFORM} == 'ios' ]]; then
+                    # TODO: what about iPhone???
+                    expected_keyword="iPhoneSimulator"
+                elif [[ ${MASON_PLATFORM} == 'linux' ]]; then
+                    expected_keyword="/usr/lib"
+                elif [[ ${MASON_PLATFORM} == 'android' ]]; then
+                    MASON_ANDROID_ABI=$(${MASON_DIR:-~/.mason}/mason env MASON_ANDROID_ABI)
+                    expected_keyword=".android-platform/${MASON_ANDROID_ABI}"
+                fi
+                if [[ "$resolved" =~ "${expected_keyword}" ]]; then
+                    echo "ok: '${expected_keyword}' found in path $resolved"
                 else
-                    echo "ok: $resolved2 is a non-symlink file"
-                    expected_keyword="zlib"
-                    if [[ ${MASON_PLATFORM} == 'osx' ]]; then
-                        expected_keyword="MacOSX.platform"
-                    elif [[ ${MASON_PLATFORM} == 'ios' ]]; then
-                        # TODO: what about iPhone???
-                        expected_keyword="iPhoneSimulator"
-                    elif [[ ${MASON_PLATFORM} == 'linux' ]]; then
-                        expected_keyword="/usr/lib"
-                    elif [[ ${MASON_PLATFORM} == 'android' ]]; then
-                        MASON_ANDROID_ABI=$(${MASON_DIR:-~/.mason}/mason env MASON_ANDROID_ABI)
-                        expected_keyword=".android-platform/${MASON_ANDROID_ABI}"
-                    fi
-                    if [[ "$resolved2" =~ "${expected_keyword}" ]]; then
-                        echo "ok: '${expected_keyword}' found in path $resolved2"
-                    else
-                        echo "not ok: '${expected_keyword}' not found in path $resolved2"
-                        CODE=1
-                    fi
+                    echo "not ok: '${expected_keyword}' not found in path $resolved"
+                    CODE=1
                 fi
             fi
         fi
@@ -88,7 +81,7 @@ function check_file_links() {
 }
 
 function check_shared_lib_info() {
-    resolved=$(read_link $(read_link ./mason_packages/.link/$1))
+    resolved=$(read_link ./mason_packages/.link/$1)
     if [[ -f $resolved ]]; then
         echo "ok: resolved to $resolved"
         if [[ ${MASON_PLATFORM} == 'osx' ]]; then


### PR DESCRIPTION
 - Adds variety of tests for the zlib package.
 - Fixes reporting of paths on android for arch's that use `lib64` (like mips64)