### PR TITLE
Revert "Call mason program at correct path"

### DIFF
--- a/mason.sh
+++ b/mason.sh
@@ -192,9 +192,9 @@ elif [ ${MASON_PLATFORM} = 'android' ]; then
 
     # Installs the native SDK
     MASON_NDK_PACKAGE_VERSION=${MASON_ANDROID_ARCH}-${MASON_ANDROID_PLATFORM}-r10d
-    MASON_SDK_ROOT=$(MASON_PLATFORM= ${ROOTDIR}/mason prefix android-ndk ${MASON_NDK_PACKAGE_VERSION})
+    MASON_SDK_ROOT=$(MASON_PLATFORM= mason prefix android-ndk ${MASON_NDK_PACKAGE_VERSION})
     if [ ! -d ${MASON_SDK_ROOT} ] ; then
-        MASON_PLATFORM= ${ROOTDIR}/mason install android-ndk ${MASON_NDK_PACKAGE_VERSION}
+        MASON_PLATFORM= mason install android-ndk ${MASON_NDK_PACKAGE_VERSION}
     fi
     MASON_SDK_PATH="${MASON_SDK_ROOT}/sysroot"
     export PATH=${MASON_SDK_ROOT}/bin:${PATH}


### PR DESCRIPTION
Reverts mapbox/mason#78, which lead to a different error:

```
$ ./script.sh build
/home/travis/.mason/mason.sh: line 195: /mason: No such file or directory
```