### PR TITLE
Issue 81

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
     - TEST="unit"
     - TEST="c_install"
     - TEST="c_build"
+    - TEST="cpp11_header_install"
     - TEST="cpp11_install"
     - TEST="cpp11_build"
 

--- a/mason.sh
+++ b/mason.sh
@@ -339,7 +339,8 @@ function link_dir {
     if [[ -d ${MASON_PREFIX}/$1 ]]; then
         FOUND_SUBDIR=$(find ${MASON_PREFIX}/$1 -maxdepth 1 -mindepth 1 -name "*" -type d -print)
         # for headers like boost that use include/boost it is most efficient to symlink just the directory
-        if [[ ${FOUND_SUBDIR} ]]; then
+        # skip linking include/google due to https://github.com/mapbox/mason/issues/81
+        if [[ ${FOUND_SUBDIR} ]] && [[ ! ${FOUND_SUBDIR} =~ "google" ]]; then
             for dir in ${FOUND_SUBDIR}; do
                 local SUBDIR_BASENAME=$(basename $dir)
                 # skip man entries to avoid conflicts

--- a/test/cpp11_header_install.sh
+++ b/test/cpp11_header_install.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -e -u
+set -o pipefail
+
+./mason install boost 1.57.0
+./mason link boost 1.57.0
+
+failure=0
+
+# boost and packages other we symlink the directory 
+if [[ ! -d mason_packages/.link/include/boost ]]; then
+    echo "could not find expected include/boost"
+    failure=1
+fi
+
+if [[ ! -L mason_packages/.link/include/boost ]]; then
+    echo "include/boost is not a symlink like expected"
+    failure=1
+fi
+
+./mason install sparsehash 2.0.2
+./mason link sparsehash 2.0.2
+
+failure=0
+
+# google packages we symlink the files to avoid conflicts
+if [[ ! -d mason_packages/.link/include/google ]]; then
+    echo "could not find expected include/google"
+    failure=1
+fi
+
+if [[ -L mason_packages/.link/include/google ]]; then
+    echo "include/google is not expected to be a symlink"
+    failure=1
+fi
+
+

--- a/test/cpp11_install.sh
+++ b/test/cpp11_install.sh
@@ -4,4 +4,17 @@ set -e -u
 set -o pipefail
 
 ./mason install boost_libregex 1.57.0
+./mason link boost_libregex 1.57.0
 
+
+failure=0
+
+if [[ ! -f mason_packages/.link/lib/libboost_regex.a ]]; then
+    echo "could not find expected lib/libboost_regex.a"
+    failure=1
+fi
+
+if [[ ! -L mason_packages/.link/lib/libboost_regex.a ]]; then
+    echo "lib/libboost_regex.a is not a symlink like expected"
+    failure=1
+fi


### PR DESCRIPTION
This is a quick hack to avoid the conflict between two deps that both install headers in `./include/google` when they are linked. Closes #81