### PR TITLE
OS X 10.11 fix: /usr/bin/clang

### DIFF
--- a/mason.sh
+++ b/mason.sh
@@ -58,8 +58,8 @@ if [ ${MASON_PLATFORM} = 'osx' ]; then
     # to correctly target c++11 for build systems that don't know about it yet (like libgeos 3.4.2)
     # But because LDFLAGS is also for C libs we can only put these flags into LDFLAGS per package
     export LDFLAGS="-Wl,-search_paths_first ${SYSROOT_FLAGS}"
-    export CXX="${MASON_XCODE_ROOT}/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++"
-    export CC="${MASON_XCODE_ROOT}/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang"
+    export CXX="/usr/bin/clang++"
+    export CC="/usr/bin/clang"
 
 elif [ ${MASON_PLATFORM} = 'ios' ]; then
     export MASON_HOST_ARG="--host=arm-apple-darwin"


### PR DESCRIPTION
I've found that upgrading to El Cap (OS X 10.11) broke my ability to compile C programs like:

```
In file included from cryptlib.c:117:
./cryptlib.h:62:11: fatal error: 'stdlib.h' file not found
# include <stdlib.h>
          ^
1 error generated.
make[1]: *** [cryptlib.o] Error 1
make: *** [build_crypto] Error 1
```

^^ that was seen doing `brew install wget` which needed openssl.

But upgrading to the latest XCode via the app store (v7.0.1) fixed that issue.

However the same error persists now for another reason even with updated Xcode and impacts the viability of Mason on 10.11:

```
configure:20620: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -E -I/Users/dane/projects/mason/postgis-2.1.7/mason_packages/osx-10.11/gdal/1.11.2/include conftest.c
In file included from conftest.c:65:
In file included from /Users/dane/projects/mason/postgis-2.1.7/mason_packages/osx-10.11/gdal/1.11.2/include/gdal.h:42:
/Users/dane/projects/mason/postgis-2.1.7/mason_packages/osx-10.11/gdal/1.11.2/include/cpl_port.h:144:10: fatal error: 'stdio.h' file not found
#include <stdio.h>
         ^
1 error generated.
```

Seen trying to build `postgis` from source with mason.

The above pull request works around this issue for reasons that I can only guess at. Perhaps Apple has broken the `/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang` and don't have plans to fix it since `/usr/bin/clang` is preferable. Mason was using `/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang` just because I saw xcodebuild using back it the day and figured it was best practice.