### PR TITLE
Fix linking for minjur package

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -47,10 +47,10 @@ function mason_compile {
         -DOSMIUM_INCLUDE_DIR=${OSMIUM_INCLUDE_DIR} \
         ..
     make
-    mkdir -p ${MASON_PREFIX}
-    mv minjur ${MASON_PREFIX}/minjur
-    mv minjur-mp ${MASON_PREFIX}/minjur-mp
-    mv minjur-generate-tilelist ${MASON_PREFIX}/minjur-generate-tilelist
+    mkdir -p ${MASON_PREFIX}/bin
+    mv minjur ${MASON_PREFIX}/bin/minjur
+    mv minjur-mp ${MASON_PREFIX}/bin/minjur-mp
+    mv minjur-generate-tilelist ${MASON_PREFIX}/bin/minjur-generate-tilelist
 }
 
 function mason_clean {


### PR DESCRIPTION
`mason link minjur <version>` was not working. This fixes it. /cc @rclark to merge if this looks good. I presume it might require a bit of adjustment upstream for you.

/cc @camillacaros (who I got running with minjur from mason)