### PR TITLE
Don't subversion for different releases of OS X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+mason_packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,14 @@ os:
 
 env:
   matrix:
-    - TEST="unit"
-    - TEST="c_install"
-    - TEST="c_build"
-    - TEST="c_install_symlink_includes"
-    - TEST="cpp11_header_install"
-    - TEST="cpp11_install"
-    - TEST="cpp11_build"
-    - TEST="c_build_android"
+    - MASON_TEST="unit"
+    - MASON_TEST="c_install"
+    - MASON_TEST="c_build"
+    - MASON_TEST="c_install_symlink_includes"
+    - MASON_TEST="cpp11_header_install"
+    - MASON_TEST="cpp11_install"
+    - MASON_TEST="cpp11_build"
+    - MASON_TEST="c_build_android"
 
 install:
 # NOTE: must be absolute path for predictable behavior
@@ -23,4 +23,4 @@ install:
 - export MASON_DIR=$(pwd)
 
 script:
-- ./test/${TEST}.sh
+- ./test/${MASON_TEST}.sh

--- a/mason.sh
+++ b/mason.sh
@@ -40,16 +40,18 @@ esac
 
 if [ ${MASON_PLATFORM} = 'osx' ]; then
     export MASON_HOST_ARG="--host=x86_64-apple-darwin"
-    export MASON_PLATFORM_VERSION=`xcrun --sdk macosx --show-sdk-version`
+    export MASON_PLATFORM_VERSION=`uname -m`
 
-    if [[  ${MASON_PLATFORM_VERSION%%.*} -ge 10 && ${MASON_PLATFORM_VERSION##*.} -ge 11 ]]; then
+    MASON_SDK_VERSION=`xcrun --sdk macosx --show-sdk-version`
+    MASON_SDK_ROOT=${MASON_XCODE_ROOT}/Platforms/MacOSX.platform/Developer
+    MASON_SDK_PATH="${MASON_SDK_ROOT}/SDKs/MacOSX${MASON_SDK_VERSION}.sdk"
+
+    if [[  ${MASON_SDK_VERSION%%.*} -ge 10 && ${MASON_SDK_VERSION##*.} -ge 11 ]]; then
         export MASON_DYNLIB_SUFFIX="tbd"
     else
         export MASON_DYNLIB_SUFFIX="dylib"
     fi
 
-    MASON_SDK_ROOT=${MASON_XCODE_ROOT}/Platforms/MacOSX.platform/Developer
-    MASON_SDK_PATH="${MASON_SDK_ROOT}/SDKs/MacOSX${MASON_PLATFORM_VERSION}.sdk"
     MIN_SDK_VERSION_FLAG="-mmacosx-version-min=10.8"
     SYSROOT_FLAGS="-isysroot ${MASON_SDK_PATH} -arch x86_64 ${MIN_SDK_VERSION_FLAG}"
     export CFLAGS="${SYSROOT_FLAGS}"


### PR DESCRIPTION
Instead of building for `osx-10.10`, `osx-10.11`, etc., build a single `osx-all` version. Continue to use `-mmacosx-version-min=10.8`.

Fixes #118

Before testing this, I'll need to copy existing `osx-10.10` / `osx-10.11` packages to `osx-all` on S3. @springmeyer @kkaefer, should I copy one or the other, or both? And if both, should the `osx-10.10` or `osx-10.11` package get priority when they both exist?