### PR TITLE
Use bfd instead of gold linker on aarch64

### DIFF
--- a/mason.sh
+++ b/mason.sh
@@ -127,7 +127,9 @@ elif [ ${MASON_PLATFORM} = 'android' ]; then
         export MASON_HOST_ARG="--host=${MASON_ANDROID_TOOLCHAIN}"
 
         export CFLAGS="-target aarch64-none-linux-android -D_LITTLE_ENDIAN ${CFLAGS}"
-        export LDFLAGS="-target aarch64-none-linux-android -fuse-ld=gold ${LDFLAGS}"
+
+        # Using bfd for aarch64: https://code.google.com/p/android/issues/detail?id=204151
+        export LDFLAGS="-target aarch64-none-linux-android -fuse-ld=bfd ${LDFLAGS}"
 
         export JNIDIR="arm64-v8a"
         MASON_ANDROID_ARCH="arm64"


### PR DESCRIPTION
We were getting segmentation faults and illegal instructions. My take is support for aarch64 + C++14 symbols is fresh. I didn't find anyone else reporting similar issues so I created one on AOP.

AOP issue:
https://code.google.com/p/android/issues/detail?id=204151

Mapbox GL Native issues:
https://github.com/mapbox/mapbox-gl-native/issues/1956
https://github.com/mapbox/mapbox-gl-native/issues/3128