### PR TITLE
MASON_DIR != ~/.mason

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Declare these variables first. `MASON_NAME` and `MASON_VERSION` are mandatory. I
 Then, we're loading the build system with
 
 ```bash
-. ~/.mason/mason.sh
+. ${MASON_DIR}/mason.sh
 ```
 
 Next, we're defining a function that obtains the source code and unzips it:
@@ -276,7 +276,7 @@ MASON_NAME=libpng
 MASON_VERSION=system
 MASON_SYSTEM_PACKAGE=true
 
-. ~/.mason/mason.sh
+. ${MASON_DIR}/mason.sh
 
 if [ ! $(pkg-config libpng --exists; echo $?) = 0 ]; then
     mason_error "Cannot find libpng with pkg-config"

--- a/mason
+++ b/mason
@@ -72,4 +72,5 @@ fi
 
 . ${MASON_DIR}/mason.sh
 
+export MASON_DIR
 bash "${MASON_DIR}/scripts/${MASON_NAME}/${MASON_VERSION}/script.sh" "${MASON_COMMAND}" "$@"

--- a/mason.sh
+++ b/mason.sh
@@ -4,7 +4,6 @@ set -o pipefail
 
 MASON_ROOT=${MASON_ROOT:-`pwd`/mason_packages}
 MASON_BUCKET=${MASON_BUCKET:-mason-binaries}
-MASON_DIR=${MASON_DIR:-~/.mason}
 
 MASON_UNAME=`uname -s`
 if [ ${MASON_UNAME} = 'Darwin' ]; then

--- a/scripts/7z/9.20.1/script.sh
+++ b/scripts/7z/9.20.1/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=7z
 MASON_VERSION=9.20.1
 MASON_LIB_FILE=bin/7z
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/Qt/system/script.sh
+++ b/scripts/Qt/system/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=Qt
 MASON_VERSION=system
 MASON_SYSTEM_PACKAGE=true
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 QT_LIBS=(${2:-QtCore})
 

--- a/scripts/android-ndk/arm-9-r10e/script.sh
+++ b/scripts/android-ndk/arm-9-r10e/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=android-ndk
 MASON_VERSION=arm-9-r10e
 MASON_LIB_FILE=
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then

--- a/scripts/android-ndk/arm64-21-r10e-gcc/script.sh
+++ b/scripts/android-ndk/arm64-21-r10e-gcc/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=android-ndk
 MASON_VERSION=arm64-21-r10e-gcc
 MASON_LIB_FILE=
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then

--- a/scripts/android-ndk/arm64-21-r10e/script.sh
+++ b/scripts/android-ndk/arm64-21-r10e/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=android-ndk
 MASON_VERSION=arm64-21-r10e
 MASON_LIB_FILE=
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then

--- a/scripts/android-ndk/mips-9-r10e/script.sh
+++ b/scripts/android-ndk/mips-9-r10e/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=android-ndk
 MASON_VERSION=mips-9-r10e
 MASON_LIB_FILE=
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then

--- a/scripts/android-ndk/mips64-21-r10e/script.sh
+++ b/scripts/android-ndk/mips64-21-r10e/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=android-ndk
 MASON_VERSION=mips64-21-r10e
 MASON_LIB_FILE=
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then

--- a/scripts/android-ndk/x86-9-r10e/script.sh
+++ b/scripts/android-ndk/x86-9-r10e/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=android-ndk
 MASON_VERSION=x86-9-r10e
 MASON_LIB_FILE=
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then

--- a/scripts/android-ndk/x86_64-21-r10e/script.sh
+++ b/scripts/android-ndk/x86_64-21-r10e/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=android-ndk
 MASON_VERSION=x86_64-21-r10e
 MASON_LIB_FILE=
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then

--- a/scripts/benchmark/1.0.0/script.sh
+++ b/scripts/benchmark/1.0.0/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=benchmark
 MASON_VERSION=1.0.0
 MASON_LIB_FILE=lib/libbenchmark.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/binutils/2.26/script.sh
+++ b/scripts/binutils/2.26/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=binutils
 MASON_VERSION=2.26
 MASON_LIB_FILE=bin/ld
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/boost/1.57.0/script.sh
+++ b/scripts/boost/1.57.0/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=boost
 MASON_VERSION=1.57.0
 MASON_HEADER_ONLY=true
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 BOOST_ROOT=${MASON_PREFIX}
 

--- a/scripts/boost/1.58.0/script.sh
+++ b/scripts/boost/1.58.0/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=boost
 MASON_VERSION=1.58.0
 MASON_HEADER_ONLY=true
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 BOOST_ROOT=${MASON_PREFIX}
 

--- a/scripts/boost/1.59.0/script.sh
+++ b/scripts/boost/1.59.0/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=boost
 MASON_VERSION=1.59.0
 MASON_HEADER_ONLY=true
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 BOOST_ROOT=${MASON_PREFIX}
 

--- a/scripts/boost/1.60.0/script.sh
+++ b/scripts/boost/1.60.0/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=boost
 MASON_VERSION=1.60.0
 MASON_HEADER_ONLY=true
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 BOOST_ROOT=${MASON_PREFIX}
 

--- a/scripts/boost/system/script.sh
+++ b/scripts/boost/system/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=boost
 MASON_VERSION=system
 MASON_SYSTEM_PACKAGE=true
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 if [ -d '/usr/local/include/boost' ]; then
     BOOST_ROOT='/usr/local'

--- a/scripts/boost_liball/1.49.0/.travis.yml
+++ b/scripts/boost_liball/1.49.0/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_liball/1.49.0/script.sh
+++ b/scripts/boost_liball/1.49.0/script.sh
@@ -17,7 +17,7 @@ MASON_VERSION=1.49.0
 # reference this empty file as a placeholder for all of them
 MASON_LIB_FILE=lib/libboost_placeholder.txt
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -44,8 +44,8 @@ function gen_config() {
 }
 
 function mason_prepare_compile {
-    ${MASON_DIR:-~/.mason}/mason install icu 54.1
-    MASON_ICU=$(${MASON_DIR:-~/.mason}/mason prefix icu 54.1)
+    ${MASON_DIR}/mason install icu 54.1
+    MASON_ICU=$(${MASON_DIR}/mason prefix icu 54.1)
     BOOST_LDFLAGS="-L${MASON_ICU}/lib -licuuc -licui18n -licudata"
 }
 

--- a/scripts/boost_liball/1.58.0/.travis.yml
+++ b/scripts/boost_liball/1.58.0/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_liball/1.58.0/script.sh
+++ b/scripts/boost_liball/1.58.0/script.sh
@@ -12,7 +12,7 @@ MASON_VERSION=1.58.0
 # reference this empty file as a placeholder for all of them
 MASON_LIB_FILE=lib/libboost_placeholder.txt
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -40,8 +40,8 @@ function gen_config() {
 }
 
 function mason_prepare_compile {
-    ${MASON_DIR:-~/.mason}/mason install icu 54.1
-    MASON_ICU=$(${MASON_DIR:-~/.mason}/mason prefix icu 54.1)
+    ${MASON_DIR}/mason install icu 54.1
+    MASON_ICU=$(${MASON_DIR}/mason prefix icu 54.1)
     BOOST_LDFLAGS="-L${MASON_ICU}/lib -licuuc -licui18n -licudata"
 }
 

--- a/scripts/boost_liball/1.59.0/.travis.yml
+++ b/scripts/boost_liball/1.59.0/.travis.yml
@@ -19,7 +19,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_liball/1.59.0/script.sh
+++ b/scripts/boost_liball/1.59.0/script.sh
@@ -12,7 +12,7 @@ MASON_VERSION=1.59.0
 # reference this empty file as a placeholder for all of them
 MASON_LIB_FILE=lib/libboost_placeholder.txt
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -40,8 +40,8 @@ function gen_config() {
 }
 
 function mason_prepare_compile {
-    ${MASON_DIR:-~/.mason}/mason install icu 55.1
-    MASON_ICU=$(${MASON_DIR:-~/.mason}/mason prefix icu 55.1)
+    ${MASON_DIR}/mason install icu 55.1
+    MASON_ICU=$(${MASON_DIR}/mason prefix icu 55.1)
     BOOST_LDFLAGS="-L${MASON_ICU}/lib -licuuc -licui18n -licudata"
 }
 

--- a/scripts/boost_liball_osrm/1.59.0/script.sh
+++ b/scripts/boost_liball_osrm/1.59.0/script.sh
@@ -12,7 +12,7 @@ MASON_VERSION=1.59.0
 # reference this empty file as a placeholder for all of them
 MASON_LIB_FILE=lib/libboost_placeholder.txt
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 export CXX=${CXX:-clang++}
 export MASON_CONCURRENCY_OVERRIDE=${MASON_CONCURRENCY_OVERRIDE:-${MASON_CONCURRENCY}}

--- a/scripts/boost_libdate_time/1.57.0/.travis.yml
+++ b/scripts/boost_libdate_time/1.57.0/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libdate_time/1.57.0/script.sh
+++ b/scripts/boost_libdate_time/1.57.0/script.sh
@@ -10,7 +10,7 @@ MASON_NAME=boost_lib${BOOST_LIBRARY}
 MASON_VERSION=1.57.0
 MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/boost_libeverything/1.59.0/script.sh
+++ b/scripts/boost_libeverything/1.59.0/script.sh
@@ -12,7 +12,7 @@ MASON_VERSION=1.59.0
 # reference this empty file as a placeholder for all of them
 MASON_LIB_FILE=lib/libboost_placeholder.txt
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -40,8 +40,8 @@ function gen_config() {
 }
 
 function mason_prepare_compile {
-    ${MASON_DIR:-~/.mason}/mason install icu 55.1
-    MASON_ICU=$(${MASON_DIR:-~/.mason}/mason prefix icu 55.1)
+    ${MASON_DIR}/mason install icu 55.1
+    MASON_ICU=$(${MASON_DIR}/mason prefix icu 55.1)
     BOOST_LDFLAGS="-L${MASON_ICU}/lib -licuuc -licui18n -licudata"
 }
 

--- a/scripts/boost_libfilesystem/1.57.0/.travis.yml
+++ b/scripts/boost_libfilesystem/1.57.0/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libfilesystem/1.57.0/script.sh
+++ b/scripts/boost_libfilesystem/1.57.0/script.sh
@@ -10,7 +10,7 @@ MASON_NAME=boost_lib${BOOST_LIBRARY}
 MASON_VERSION=1.57.0
 MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/boost_libiostreams/1.57.0/.travis.yml
+++ b/scripts/boost_libiostreams/1.57.0/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libiostreams/1.57.0/script.sh
+++ b/scripts/boost_libiostreams/1.57.0/script.sh
@@ -10,7 +10,7 @@ MASON_NAME=boost_lib${BOOST_LIBRARY}
 MASON_VERSION=1.57.0
 MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/boost_libprogram_options/1.57.0/.travis.yml
+++ b/scripts/boost_libprogram_options/1.57.0/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libprogram_options/1.57.0/script.sh
+++ b/scripts/boost_libprogram_options/1.57.0/script.sh
@@ -10,7 +10,7 @@ MASON_NAME=boost_lib${BOOST_LIBRARY}
 MASON_VERSION=1.57.0
 MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/boost_libprogram_options/1.59.0/.travis.yml
+++ b/scripts/boost_libprogram_options/1.59.0/.travis.yml
@@ -16,7 +16,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libprogram_options/1.59.0/script.sh
+++ b/scripts/boost_libprogram_options/1.59.0/script.sh
@@ -10,7 +10,7 @@ MASON_NAME=boost_lib${BOOST_LIBRARY}
 MASON_VERSION=${BOOST_VERSION1}
 MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/boost_libprogram_options/1.60.0/script.sh
+++ b/scripts/boost_libprogram_options/1.60.0/script.sh
@@ -10,7 +10,7 @@ MASON_NAME=boost_lib${BOOST_LIBRARY}
 MASON_VERSION=${BOOST_VERSION1}
 MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/boost_libpython/1.57.0/.travis.yml
+++ b/scripts/boost_libpython/1.57.0/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libpython/1.57.0/script.sh
+++ b/scripts/boost_libpython/1.57.0/script.sh
@@ -10,7 +10,7 @@ MASON_NAME=boost_lib${BOOST_LIBRARY}
 MASON_VERSION=1.57.0
 MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/boost_libregex/1.57.0/.travis.yml
+++ b/scripts/boost_libregex/1.57.0/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libregex/1.57.0/script.sh
+++ b/scripts/boost_libregex/1.57.0/script.sh
@@ -10,7 +10,7 @@ MASON_NAME=boost_lib${BOOST_LIBRARY}
 MASON_VERSION=1.57.0
 MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -37,8 +37,8 @@ function gen_config() {
 }
 
 function mason_prepare_compile {
-    ${MASON_DIR:-~/.mason}/mason install icu 54.1
-    MASON_ICU=$(${MASON_DIR:-~/.mason}/mason prefix icu 54.1)
+    ${MASON_DIR}/mason install icu 54.1
+    MASON_ICU=$(${MASON_DIR}/mason prefix icu 54.1)
     BOOST_LDFLAGS="-L${MASON_ICU}/lib -licuuc -licui18n -licudata"
 }
 

--- a/scripts/boost_libsystem/1.57.0/.travis.yml
+++ b/scripts/boost_libsystem/1.57.0/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libsystem/1.57.0/script.sh
+++ b/scripts/boost_libsystem/1.57.0/script.sh
@@ -10,7 +10,7 @@ MASON_NAME=boost_lib${BOOST_LIBRARY}
 MASON_VERSION=1.57.0
 MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/boost_libtest/1.57.0/.travis.yml
+++ b/scripts/boost_libtest/1.57.0/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libtest/1.57.0/script.sh
+++ b/scripts/boost_libtest/1.57.0/script.sh
@@ -10,7 +10,7 @@ MASON_NAME=boost_lib${BOOST_LIBRARY}
 MASON_VERSION=1.57.0
 MASON_LIB_FILE=lib/libboost_unit_test_framework.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/boost_libtest_shared/1.57.0/.travis.yml
+++ b/scripts/boost_libtest_shared/1.57.0/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libtest_shared/1.57.0/script.sh
+++ b/scripts/boost_libtest_shared/1.57.0/script.sh
@@ -9,7 +9,7 @@ BOOST_ARCH="x86"
 MASON_NAME=boost_lib${BOOST_LIBRARY}_shared
 MASON_VERSION=1.57.0
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 MASON_LIB_FILE=lib/libboost_unit_test_framework.${MASON_DYNLIB_SUFFIX}
 

--- a/scripts/boost_libthread/1.57.0/.travis.yml
+++ b/scripts/boost_libthread/1.57.0/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libthread/1.57.0/script.sh
+++ b/scripts/boost_libthread/1.57.0/script.sh
@@ -10,7 +10,7 @@ MASON_NAME=boost_lib${BOOST_LIBRARY}
 MASON_VERSION=1.57.0
 MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/boringssl/a6aabff2e6e95a71b2f966447eebd53e57d8bf83/script.sh
+++ b/scripts/boringssl/a6aabff2e6e95a71b2f966447eebd53e57d8bf83/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=boringssl
 MASON_VERSION=a6aabff2e6e95a71b2f966447eebd53e57d8bf83
 MASON_LIB_FILE=lib/libboringssl.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 MASON_PWD=$(pwd)
 

--- a/scripts/bzip2/1.0.6/script.sh
+++ b/scripts/bzip2/1.0.6/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=bzip2
 MASON_VERSION=1.0.6
 MASON_LIB_FILE=lib/libbz2.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/cairo/1.12.18/script.sh
+++ b/scripts/cairo/1.12.18/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=cairo
 MASON_VERSION=1.12.18
 MASON_LIB_FILE=lib/libcairo.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -18,12 +18,12 @@ function mason_load_source {
 
 function mason_prepare_compile {
     cd $(dirname ${MASON_ROOT})
-    ${MASON_DIR:-~/.mason}/mason install libpng 1.6.16
-    MASON_PNG=$(${MASON_DIR:-~/.mason}/mason prefix libpng 1.6.16)
-    ${MASON_DIR:-~/.mason}/mason install freetype 2.5.5
-    MASON_FREETYPE=$(${MASON_DIR:-~/.mason}/mason prefix freetype 2.5.5)
-    ${MASON_DIR:-~/.mason}/mason install pixman 0.32.6
-    MASON_PIXMAN=$(${MASON_DIR:-~/.mason}/mason prefix pixman 0.32.6)
+    ${MASON_DIR}/mason install libpng 1.6.16
+    MASON_PNG=$(${MASON_DIR}/mason prefix libpng 1.6.16)
+    ${MASON_DIR}/mason install freetype 2.5.5
+    MASON_FREETYPE=$(${MASON_DIR}/mason prefix freetype 2.5.5)
+    ${MASON_DIR}/mason install pixman 0.32.6
+    MASON_PIXMAN=$(${MASON_DIR}/mason prefix pixman 0.32.6)
     # set up to fix libtool .la files
     # https://github.com/mapbox/mason/issues/61
     if [[ $(uname -s) == 'Darwin' ]]; then

--- a/scripts/cairo/1.14.0/script.sh
+++ b/scripts/cairo/1.14.0/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=cairo
 MASON_VERSION=1.14.0
 MASON_LIB_FILE=lib/libcairo.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -18,12 +18,12 @@ function mason_load_source {
 
 function mason_prepare_compile {
     cd $(dirname ${MASON_ROOT})
-    ${MASON_DIR:-~/.mason}/mason install libpng 1.6.16
-    MASON_PNG=$(${MASON_DIR:-~/.mason}/mason prefix libpng 1.6.16)
-    ${MASON_DIR:-~/.mason}/mason install freetype 2.5.4
-    MASON_FREETYPE=$(${MASON_DIR:-~/.mason}/mason prefix freetype 2.5.4)
-    ${MASON_DIR:-~/.mason}/mason install pixman 0.32.6
-    MASON_PIXMAN=$(${MASON_DIR:-~/.mason}/mason prefix pixman 0.32.6)
+    ${MASON_DIR}/mason install libpng 1.6.16
+    MASON_PNG=$(${MASON_DIR}/mason prefix libpng 1.6.16)
+    ${MASON_DIR}/mason install freetype 2.5.4
+    MASON_FREETYPE=$(${MASON_DIR}/mason prefix freetype 2.5.4)
+    ${MASON_DIR}/mason install pixman 0.32.6
+    MASON_PIXMAN=$(${MASON_DIR}/mason prefix pixman 0.32.6)
 }
 
 function mason_compile {

--- a/scripts/cairo/1.14.2/script.sh
+++ b/scripts/cairo/1.14.2/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=cairo
 MASON_VERSION=1.14.2
 MASON_LIB_FILE=lib/libcairo.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -18,12 +18,12 @@ function mason_load_source {
 
 function mason_prepare_compile {
     cd $(dirname ${MASON_ROOT})
-    ${MASON_DIR:-~/.mason}/mason install libpng 1.6.17
-    MASON_PNG=$(${MASON_DIR:-~/.mason}/mason prefix libpng 1.6.17)
-    ${MASON_DIR:-~/.mason}/mason install freetype 2.6
-    MASON_FREETYPE=$(${MASON_DIR:-~/.mason}/mason prefix freetype 2.6)
-    ${MASON_DIR:-~/.mason}/mason install pixman 0.32.6
-    MASON_PIXMAN=$(${MASON_DIR:-~/.mason}/mason prefix pixman 0.32.6)
+    ${MASON_DIR}/mason install libpng 1.6.17
+    MASON_PNG=$(${MASON_DIR}/mason prefix libpng 1.6.17)
+    ${MASON_DIR}/mason install freetype 2.6
+    MASON_FREETYPE=$(${MASON_DIR}/mason prefix freetype 2.6)
+    ${MASON_DIR}/mason install pixman 0.32.6
+    MASON_PIXMAN=$(${MASON_DIR}/mason prefix pixman 0.32.6)
 }
 
 function mason_compile {

--- a/scripts/cairo/1.14.4/script.sh
+++ b/scripts/cairo/1.14.4/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=cairo
 MASON_VERSION=1.14.4
 MASON_LIB_FILE=lib/libcairo.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -18,12 +18,12 @@ function mason_load_source {
 
 function mason_prepare_compile {
     cd $(dirname ${MASON_ROOT})
-    ${MASON_DIR:-~/.mason}/mason install libpng 1.6.17
-    MASON_PNG=$(${MASON_DIR:-~/.mason}/mason prefix libpng 1.6.17)
-    ${MASON_DIR:-~/.mason}/mason install freetype 2.6
-    MASON_FREETYPE=$(${MASON_DIR:-~/.mason}/mason prefix freetype 2.6)
-    ${MASON_DIR:-~/.mason}/mason install pixman 0.32.6
-    MASON_PIXMAN=$(${MASON_DIR:-~/.mason}/mason prefix pixman 0.32.6)
+    ${MASON_DIR}/mason install libpng 1.6.17
+    MASON_PNG=$(${MASON_DIR}/mason prefix libpng 1.6.17)
+    ${MASON_DIR}/mason install freetype 2.6
+    MASON_FREETYPE=$(${MASON_DIR}/mason prefix freetype 2.6)
+    ${MASON_DIR}/mason install pixman 0.32.6
+    MASON_PIXMAN=$(${MASON_DIR}/mason prefix pixman 0.32.6)
 }
 
 function mason_compile {

--- a/scripts/ccache/3.2.4/script.sh
+++ b/scripts/ccache/3.2.4/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=ccache
 MASON_VERSION=3.2.4
 MASON_LIB_FILE=bin/ccache
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/clang-tidy/3.8/script.sh
+++ b/scripts/clang-tidy/3.8/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=clang-tidy
 MASON_VERSION=3.8
 MASON_LIB_FILE=bin/clang-tidy
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_build {
     mkdir -p "${MASON_PREFIX}/bin"

--- a/scripts/cmake/3.2.2/.travis.yml
+++ b/scripts/cmake/3.2.2/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/cmake/3.2.2/script.sh
+++ b/scripts/cmake/3.2.2/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=cmake
 MASON_VERSION=3.2.2
 MASON_LIB_FILE=bin/cmake
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/earcut/0.10.1/script.sh
+++ b/scripts/earcut/0.10.1/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=earcut
 MASON_VERSION=0.10.1
 MASON_HEADER_ONLY=true
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/earcut/0.10.2/script.sh
+++ b/scripts/earcut/0.10.2/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=earcut
 MASON_VERSION=0.10.2
 MASON_HEADER_ONLY=true
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/earcut/0.10.3/script.sh
+++ b/scripts/earcut/0.10.3/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=earcut
 MASON_VERSION=0.10.3
 MASON_HEADER_ONLY=true
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/earcut/0.10/script.sh
+++ b/scripts/earcut/0.10/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=earcut
 MASON_VERSION=0.10
 MASON_HEADER_ONLY=true
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/earcut/0.11/script.sh
+++ b/scripts/earcut/0.11/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=earcut
 MASON_VERSION=0.11
 MASON_HEADER_ONLY=true
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/earcut/0.9-pool/script.sh
+++ b/scripts/earcut/0.9-pool/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=earcut
 MASON_VERSION=0.9-pool
 MASON_HEADER_ONLY=true
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/earcut/0.9/script.sh
+++ b/scripts/earcut/0.9/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=earcut
 MASON_VERSION=0.9
 MASON_HEADER_ONLY=true
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/expat/2.1.0/script.sh
+++ b/scripts/expat/2.1.0/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=2.1.0
 MASON_LIB_FILE=lib/libexpat.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/expat.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/expat/2.1.1/script.sh
+++ b/scripts/expat/2.1.1/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=2.1.1
 MASON_LIB_FILE=lib/libexpat.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/expat.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/freetype/2.5.4/script.sh
+++ b/scripts/freetype/2.5.4/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=2.5.4
 MASON_LIB_FILE=lib/libfreetype.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/freetype2.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/freetype/2.5.5/script.sh
+++ b/scripts/freetype/2.5.5/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=2.5.5
 MASON_LIB_FILE=lib/libfreetype.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/freetype2.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/freetype/2.6/script.sh
+++ b/scripts/freetype/2.6/script.sh
@@ -6,7 +6,7 @@ MASON_VERSION=2.6
 MASON_LIB_FILE=lib/libfreetype.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/freetype2.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/freetype/2.6/script.sh
+++ b/scripts/freetype/2.6/script.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-#export PATH=~/.mason:$PATH
 MASON_NAME=freetype
 MASON_VERSION=2.6
 MASON_LIB_FILE=lib/libfreetype.a

--- a/scripts/gcc/4.9.2-cortex_a9-hf/script.sh
+++ b/scripts/gcc/4.9.2-cortex_a9-hf/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=gcc
 MASON_VERSION=4.9.2-cortex_a9-hf
 MASON_LIB_FILE=root/bin/arm-cortex_a9-linux-gnueabihf-gcc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 if [ -f ${MASON_PREFIX}/setup.sh ]; then
     . ${MASON_PREFIX}/setup.sh

--- a/scripts/gcc/4.9.2-cortex_a9/script.sh
+++ b/scripts/gcc/4.9.2-cortex_a9/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=gcc
 MASON_VERSION=4.9.2-cortex_a9
 MASON_LIB_FILE=root/bin/arm-cortex_a9-linux-gnueabi-gcc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 if [ -f ${MASON_PREFIX}/setup.sh ]; then
     . ${MASON_PREFIX}/setup.sh

--- a/scripts/gcc/4.9.2-i686/script.sh
+++ b/scripts/gcc/4.9.2-i686/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=gcc
 MASON_VERSION=4.9.2-i686
 MASON_LIB_FILE=root/bin/i686-pc-linux-gnu-gcc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 if [ -f ${MASON_PREFIX}/setup.sh ]; then
     . ${MASON_PREFIX}/setup.sh

--- a/scripts/gdal/1.11.1-big-pants/.travis.yml
+++ b/scripts/gdal/1.11.1-big-pants/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/gdal/1.11.1-big-pants/script.sh
+++ b/scripts/gdal/1.11.1-big-pants/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=gdal
 MASON_VERSION=1.11.1-big-pants
 MASON_LIB_FILE=lib/libgdal.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     GIT_HASH=54cf139
@@ -28,29 +28,29 @@ function mason_prepare_compile {
     fi
     REPLACE="$(pwd)"
     REPLACE=${REPLACE////\\/}
-    ${MASON_DIR:-~/.mason}/mason install libtiff 4.0.4beta
-    MASON_TIFF=$(${MASON_DIR:-~/.mason}/mason prefix libtiff 4.0.4beta)
+    ${MASON_DIR}/mason install libtiff 4.0.4beta
+    MASON_TIFF=$(${MASON_DIR}/mason prefix libtiff 4.0.4beta)
     perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_TIFF}/lib/libtiff.la
-    ${MASON_DIR:-~/.mason}/mason install proj 4.8.0
-    MASON_PROJ=$(${MASON_DIR:-~/.mason}/mason prefix proj 4.8.0)
+    ${MASON_DIR}/mason install proj 4.8.0
+    MASON_PROJ=$(${MASON_DIR}/mason prefix proj 4.8.0)
     perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_PROJ}/lib/libproj.la
-    ${MASON_DIR:-~/.mason}/mason install jpeg_turbo 1.4.0
-    MASON_JPEG=$(${MASON_DIR:-~/.mason}/mason prefix jpeg_turbo 1.4.0)
+    ${MASON_DIR}/mason install jpeg_turbo 1.4.0
+    MASON_JPEG=$(${MASON_DIR}/mason prefix jpeg_turbo 1.4.0)
     perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_JPEG}/lib/libjpeg.la
-    ${MASON_DIR:-~/.mason}/mason install libpng 1.6.16
-    MASON_PNG=$(${MASON_DIR:-~/.mason}/mason prefix libpng 1.6.16)
+    ${MASON_DIR}/mason install libpng 1.6.16
+    MASON_PNG=$(${MASON_DIR}/mason prefix libpng 1.6.16)
     perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_PNG}/lib/libpng.la
-    ${MASON_DIR:-~/.mason}/mason install expat 2.1.0
-    MASON_EXPAT=$(${MASON_DIR:-~/.mason}/mason prefix expat 2.1.0)
+    ${MASON_DIR}/mason install expat 2.1.0
+    MASON_EXPAT=$(${MASON_DIR}/mason prefix expat 2.1.0)
     perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_EXPAT}/lib/libexpat.la
-    ${MASON_DIR:-~/.mason}/mason install libpq 9.4.0
-    MASON_LIBPQ=$(${MASON_DIR:-~/.mason}/mason prefix libpq 9.4.0)
+    ${MASON_DIR}/mason install libpq 9.4.0
+    MASON_LIBPQ=$(${MASON_DIR}/mason prefix libpq 9.4.0)
     # depends on sudo apt-get install zlib1g-dev
-    ${MASON_DIR:-~/.mason}/mason install zlib system
-    MASON_ZLIB=$(${MASON_DIR:-~/.mason}/mason prefix zlib system)
+    ${MASON_DIR}/mason install zlib system
+    MASON_ZLIB=$(${MASON_DIR}/mason prefix zlib system)
     # depends on sudo apt-get install libc6-dev
-    #${MASON_DIR:-~/.mason}/mason install iconv system
-    #MASON_ICONV=$(${MASON_DIR:-~/.mason}/mason prefix iconv system)
+    #${MASON_DIR}/mason install iconv system
+    #MASON_ICONV=$(${MASON_DIR}/mason prefix iconv system)
     export LIBRARY_PATH=${MASON_LIBPQ}/lib:$LIBRARY_PATH
 }
 

--- a/scripts/gdal/1.11.1/.travis.yml
+++ b/scripts/gdal/1.11.1/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/gdal/1.11.1/script.sh
+++ b/scripts/gdal/1.11.1/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=gdal
 MASON_VERSION=1.11.1
 MASON_LIB_FILE=lib/libgdal.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -23,24 +23,24 @@ function mason_prepare_compile {
     FIND="\/Users\/travis\/build\/mapbox\/mason"
     REPLACE="$(pwd)"
     REPLACE=${REPLACE////\\/}
-    ${MASON_DIR:-~/.mason}/mason install libtiff 4.0.4beta
-    MASON_TIFF=$(${MASON_DIR:-~/.mason}/mason prefix libtiff 4.0.4beta)
+    ${MASON_DIR}/mason install libtiff 4.0.4beta
+    MASON_TIFF=$(${MASON_DIR}/mason prefix libtiff 4.0.4beta)
     perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_TIFF}/lib/libtiff.la
-    ${MASON_DIR:-~/.mason}/mason install proj 4.8.0
-    MASON_PROJ=$(${MASON_DIR:-~/.mason}/mason prefix proj 4.8.0)
+    ${MASON_DIR}/mason install proj 4.8.0
+    MASON_PROJ=$(${MASON_DIR}/mason prefix proj 4.8.0)
     perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_PROJ}/lib/libproj.la
-    ${MASON_DIR:-~/.mason}/mason install jpeg_turbo 1.4.0
-    MASON_JPEG=$(${MASON_DIR:-~/.mason}/mason prefix jpeg_turbo 1.4.0)
+    ${MASON_DIR}/mason install jpeg_turbo 1.4.0
+    MASON_JPEG=$(${MASON_DIR}/mason prefix jpeg_turbo 1.4.0)
     perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_JPEG}/lib/libjpeg.la
-    ${MASON_DIR:-~/.mason}/mason install libpng 1.6.16
-    MASON_PNG=$(${MASON_DIR:-~/.mason}/mason prefix libpng 1.6.16)
+    ${MASON_DIR}/mason install libpng 1.6.16
+    MASON_PNG=$(${MASON_DIR}/mason prefix libpng 1.6.16)
     perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_PNG}/lib/libpng.la
-    ${MASON_DIR:-~/.mason}/mason install expat 2.1.0
-    MASON_EXPAT=$(${MASON_DIR:-~/.mason}/mason prefix expat 2.1.0)
+    ${MASON_DIR}/mason install expat 2.1.0
+    MASON_EXPAT=$(${MASON_DIR}/mason prefix expat 2.1.0)
     perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_EXPAT}/lib/libexpat.la
     # depends on sudo apt-get install zlib1g-dev
-    ${MASON_DIR:-~/.mason}/mason install zlib system
-    MASON_ZLIB=$(${MASON_DIR:-~/.mason}/mason prefix zlib system)
+    ${MASON_DIR}/mason install zlib system
+    MASON_ZLIB=$(${MASON_DIR}/mason prefix zlib system)
 }
 
 function mason_compile {

--- a/scripts/gdal/1.11.2/.travis.yml
+++ b/scripts/gdal/1.11.2/.travis.yml
@@ -19,7 +19,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/gdal/1.11.2/script.sh
+++ b/scripts/gdal/1.11.2/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=gdal
 MASON_VERSION=1.11.2
 MASON_LIB_FILE=lib/libgdal.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -23,24 +23,24 @@ function mason_prepare_compile {
     FIND="\/Users\/travis\/build\/mapbox\/mason"
     REPLACE="$(pwd)"
     REPLACE=${REPLACE////\\/}
-    ${MASON_DIR:-~/.mason}/mason install libtiff 4.0.4beta
-    MASON_TIFF=$(${MASON_DIR:-~/.mason}/mason prefix libtiff 4.0.4beta)
+    ${MASON_DIR}/mason install libtiff 4.0.4beta
+    MASON_TIFF=$(${MASON_DIR}/mason prefix libtiff 4.0.4beta)
     perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_TIFF}/lib/libtiff.la
-    ${MASON_DIR:-~/.mason}/mason install proj 4.8.0
-    MASON_PROJ=$(${MASON_DIR:-~/.mason}/mason prefix proj 4.8.0)
+    ${MASON_DIR}/mason install proj 4.8.0
+    MASON_PROJ=$(${MASON_DIR}/mason prefix proj 4.8.0)
     perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_PROJ}/lib/libproj.la
-    ${MASON_DIR:-~/.mason}/mason install jpeg_turbo 1.4.0
-    MASON_JPEG=$(${MASON_DIR:-~/.mason}/mason prefix jpeg_turbo 1.4.0)
+    ${MASON_DIR}/mason install jpeg_turbo 1.4.0
+    MASON_JPEG=$(${MASON_DIR}/mason prefix jpeg_turbo 1.4.0)
     perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_JPEG}/lib/libjpeg.la
-    ${MASON_DIR:-~/.mason}/mason install libpng 1.6.20
-    MASON_PNG=$(${MASON_DIR:-~/.mason}/mason prefix libpng 1.6.20)
+    ${MASON_DIR}/mason install libpng 1.6.20
+    MASON_PNG=$(${MASON_DIR}/mason prefix libpng 1.6.20)
     perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_PNG}/lib/libpng.la
-    ${MASON_DIR:-~/.mason}/mason install expat 2.1.0
-    MASON_EXPAT=$(${MASON_DIR:-~/.mason}/mason prefix expat 2.1.0)
+    ${MASON_DIR}/mason install expat 2.1.0
+    MASON_EXPAT=$(${MASON_DIR}/mason prefix expat 2.1.0)
     perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_EXPAT}/lib/libexpat.la
     # depends on sudo apt-get install zlib1g-dev
-    ${MASON_DIR:-~/.mason}/mason install zlib system
-    MASON_ZLIB=$(${MASON_DIR:-~/.mason}/mason prefix zlib system)
+    ${MASON_DIR}/mason install zlib system
+    MASON_ZLIB=$(${MASON_DIR}/mason prefix zlib system)
 }
 
 function mason_compile {

--- a/scripts/gdal/2.0.2/script.sh
+++ b/scripts/gdal/2.0.2/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=gdal
 MASON_VERSION=2.0.2
 MASON_LIB_FILE=lib/libgdal.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -27,29 +27,29 @@ function mason_prepare_compile {
     fi
     REPLACE="$(pwd)"
     REPLACE=${REPLACE////\\/}
-    ${MASON_DIR:-~/.mason}/mason install libtiff 4.0.6
-    MASON_TIFF=$(${MASON_DIR:-~/.mason}/mason prefix libtiff 4.0.6)
+    ${MASON_DIR}/mason install libtiff 4.0.6
+    MASON_TIFF=$(${MASON_DIR}/mason prefix libtiff 4.0.6)
     perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_TIFF}/lib/libtiff.la
-    ${MASON_DIR:-~/.mason}/mason install proj 4.9.2
-    MASON_PROJ=$(${MASON_DIR:-~/.mason}/mason prefix proj 4.9.2)
+    ${MASON_DIR}/mason install proj 4.9.2
+    MASON_PROJ=$(${MASON_DIR}/mason prefix proj 4.9.2)
     perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_PROJ}/lib/libproj.la
-    ${MASON_DIR:-~/.mason}/mason install jpeg_turbo 1.4.2
-    MASON_JPEG=$(${MASON_DIR:-~/.mason}/mason prefix jpeg_turbo 1.4.2)
+    ${MASON_DIR}/mason install jpeg_turbo 1.4.2
+    MASON_JPEG=$(${MASON_DIR}/mason prefix jpeg_turbo 1.4.2)
     perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_JPEG}/lib/libjpeg.la
-    ${MASON_DIR:-~/.mason}/mason install libpng 1.6.21
-    MASON_PNG=$(${MASON_DIR:-~/.mason}/mason prefix libpng 1.6.21)
+    ${MASON_DIR}/mason install libpng 1.6.21
+    MASON_PNG=$(${MASON_DIR}/mason prefix libpng 1.6.21)
     perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_PNG}/lib/libpng.la
-    ${MASON_DIR:-~/.mason}/mason install expat 2.1.1
-    MASON_EXPAT=$(${MASON_DIR:-~/.mason}/mason prefix expat 2.1.1)
+    ${MASON_DIR}/mason install expat 2.1.1
+    MASON_EXPAT=$(${MASON_DIR}/mason prefix expat 2.1.1)
     perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_EXPAT}/lib/libexpat.la
-    ${MASON_DIR:-~/.mason}/mason install libpq 9.5.2
-    MASON_LIBPQ=$(${MASON_DIR:-~/.mason}/mason prefix libpq 9.5.2)
+    ${MASON_DIR}/mason install libpq 9.5.2
+    MASON_LIBPQ=$(${MASON_DIR}/mason prefix libpq 9.5.2)
     # depends on sudo apt-get install zlib1g-dev
-    ${MASON_DIR:-~/.mason}/mason install zlib system
-    MASON_ZLIB=$(${MASON_DIR:-~/.mason}/mason prefix zlib system)
+    ${MASON_DIR}/mason install zlib system
+    MASON_ZLIB=$(${MASON_DIR}/mason prefix zlib system)
     # depends on sudo apt-get install libc6-dev
-    #${MASON_DIR:-~/.mason}/mason install iconv system
-    #MASON_ICONV=$(${MASON_DIR:-~/.mason}/mason prefix iconv system)
+    #${MASON_DIR}/mason install iconv system
+    #MASON_ICONV=$(${MASON_DIR}/mason prefix iconv system)
     export LIBRARY_PATH=${MASON_LIBPQ}/lib:$LIBRARY_PATH
 }
 

--- a/scripts/gdal/dev/.travis.yml
+++ b/scripts/gdal/dev/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/gdal/dev/script.sh
+++ b/scripts/gdal/dev/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=gdal
 MASON_VERSION=dev
 MASON_LIB_FILE=lib/libgdal.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     export MASON_BUILD_PATH=${MASON_ROOT}/.build/gdal-2.x
@@ -26,9 +26,9 @@ function install_dep {
     # https://github.com/mapbox/mason/issues/61
     REPLACE="$(pwd)"
     REPLACE=${REPLACE////\\/}
-    ${MASON_DIR:-~/.mason}/mason install $1 $2
-    ${MASON_DIR:-~/.mason}/mason link $1 $2
-    LA_FILE=$(${MASON_DIR:-~/.mason}/mason prefix $1 $2)/lib/$3.la
+    ${MASON_DIR}/mason install $1 $2
+    ${MASON_DIR}/mason link $1 $2
+    LA_FILE=$(${MASON_DIR}/mason prefix $1 $2)/lib/$3.la
     if [[ -f ${LA_FILE} ]]; then
        perl -i -p -e "s/${FIND_PATTERN}/${REPLACE}/g;" ${LA_FILE}
     else
@@ -45,11 +45,11 @@ function mason_prepare_compile {
     install_dep expat 2.1.0 libexpat
     install_dep libpq 9.4.0 libpq
     # depends on sudo apt-get install zlib1g-dev
-    ${MASON_DIR:-~/.mason}/mason install zlib system
-    MASON_ZLIB=$(${MASON_DIR:-~/.mason}/mason prefix zlib system)
+    ${MASON_DIR}/mason install zlib system
+    MASON_ZLIB=$(${MASON_DIR}/mason prefix zlib system)
     # depends on sudo apt-get install libc6-dev
-    #${MASON_DIR:-~/.mason}/mason install iconv system
-    #MASON_ICONV=$(${MASON_DIR:-~/.mason}/mason prefix iconv system)
+    #${MASON_DIR}/mason install iconv system
+    #MASON_ICONV=$(${MASON_DIR}/mason prefix iconv system)
 }
 
 function mason_compile {

--- a/scripts/geojsonvt/1.1.0/script.sh
+++ b/scripts/geojsonvt/1.1.0/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=geojsonvt
 MASON_VERSION=1.1.0
 MASON_LIB_FILE=lib/libgeojsonvt.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -19,7 +19,7 @@ function mason_load_source {
 function mason_compile {
     # setup mason
     rm -rf .mason
-    ln -s ${MASON_DIR:-~/.mason} .mason
+    ln -s ${MASON_DIR} .mason
 
     # build
     INSTALL_PREFIX=${MASON_PREFIX} ./configure

--- a/scripts/geojsonvt/2.1.0/script.sh
+++ b/scripts/geojsonvt/2.1.0/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=geojsonvt
 MASON_VERSION=2.1.0
 MASON_LIB_FILE=lib/libgeojsonvt.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -19,7 +19,7 @@ function mason_load_source {
 function mason_compile {
     # setup mason
     rm -rf .mason
-    ln -s ${MASON_DIR:-~/.mason} .mason
+    ln -s ${MASON_DIR} .mason
 
     # build
     INSTALL_PREFIX=${MASON_PREFIX} ./configure

--- a/scripts/geojsonvt/2.1.6.1/script.sh
+++ b/scripts/geojsonvt/2.1.6.1/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=2.1.6.1
 MASON_LIB_FILE=lib/libgeojsonvt.a
 MASON_CXX_PACKAGE=true
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -20,7 +20,7 @@ function mason_load_source {
 function mason_compile {
     # setup mason
     rm -rf .mason
-    ln -s ${MASON_DIR:-~/.mason} .mason
+    ln -s ${MASON_DIR} .mason
 
     # build
     INSTALL_PREFIX=${MASON_PREFIX} ./configure

--- a/scripts/geojsonvt/2.1.6.2/script.sh
+++ b/scripts/geojsonvt/2.1.6.2/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=geojsonvt
 MASON_VERSION=2.1.6.2
 MASON_LIB_FILE=lib/libgeojsonvt.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -19,7 +19,7 @@ function mason_load_source {
 function mason_compile {
     # setup mason
     rm -rf .mason
-    ln -s ${MASON_DIR:-~/.mason} .mason
+    ln -s ${MASON_DIR} .mason
 
     # build
     INSTALL_PREFIX=${MASON_PREFIX} ./configure

--- a/scripts/geojsonvt/2.1.6.3/script.sh
+++ b/scripts/geojsonvt/2.1.6.3/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=geojsonvt
 MASON_VERSION=2.1.6.3
 MASON_LIB_FILE=lib/libgeojsonvt.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -19,7 +19,7 @@ function mason_load_source {
 function mason_compile {
     # setup mason
     rm -rf .mason
-    ln -s ${MASON_DIR:-~/.mason} .mason
+    ln -s ${MASON_DIR} .mason
 
     # build
     INSTALL_PREFIX=${MASON_PREFIX} ./configure

--- a/scripts/geojsonvt/2.1.6/script.sh
+++ b/scripts/geojsonvt/2.1.6/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=2.1.6
 MASON_LIB_FILE=lib/libgeojsonvt.a
 MASON_CXX_PACKAGE=true
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -20,7 +20,7 @@ function mason_load_source {
 function mason_compile {
     # setup mason
     rm -rf .mason
-    ln -s ${MASON_DIR:-~/.mason} .mason
+    ln -s ${MASON_DIR} .mason
 
     # build
     INSTALL_PREFIX=${MASON_PREFIX} ./configure

--- a/scripts/geojsonvt/3.0.0/script.sh
+++ b/scripts/geojsonvt/3.0.0/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=geojsonvt
 MASON_VERSION=3.0.0
 MASON_LIB_FILE=lib/libgeojsonvt.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -19,7 +19,7 @@ function mason_load_source {
 function mason_compile {
     # setup mason
     rm -rf .mason
-    ln -s ${MASON_DIR:-~/.mason} .mason
+    ln -s ${MASON_DIR} .mason
 
     # build
     INSTALL_PREFIX=${MASON_PREFIX} ./configure

--- a/scripts/geojsonvt/3.0.1/script.sh
+++ b/scripts/geojsonvt/3.0.1/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=geojsonvt
 MASON_VERSION=3.0.1
 MASON_LIB_FILE=lib/libgeojsonvt.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -19,7 +19,7 @@ function mason_load_source {
 function mason_compile {
     # setup mason
     rm -rf .mason
-    ln -s ${MASON_DIR:-~/.mason} .mason
+    ln -s ${MASON_DIR} .mason
 
     # build
     INSTALL_PREFIX=${MASON_PREFIX} ./configure

--- a/scripts/geojsonvt/3.1.0/script.sh
+++ b/scripts/geojsonvt/3.1.0/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=geojsonvt
 MASON_VERSION=3.1.0
 MASON_LIB_FILE=lib/libgeojsonvt.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -19,7 +19,7 @@ function mason_load_source {
 function mason_compile {
     # setup mason
     rm -rf .mason
-    ln -s ${MASON_DIR:-~/.mason} .mason
+    ln -s ${MASON_DIR} .mason
 
     # build
     INSTALL_PREFIX=${MASON_PREFIX} ./configure

--- a/scripts/geojsonvt/4.0.0/script.sh
+++ b/scripts/geojsonvt/4.0.0/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=geojsonvt
 MASON_VERSION=4.0.0
 MASON_LIB_FILE=lib/libgeojsonvt.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -19,7 +19,7 @@ function mason_load_source {
 function mason_compile {
     # setup mason
     rm -rf .mason
-    ln -s ${MASON_DIR:-~/.mason} .mason
+    ln -s ${MASON_DIR} .mason
 
     # build
     INSTALL_PREFIX=${MASON_PREFIX} ./configure

--- a/scripts/geojsonvt/4.1.0/script.sh
+++ b/scripts/geojsonvt/4.1.0/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=geojsonvt
 MASON_VERSION=4.1.0
 MASON_LIB_FILE=lib/libgeojsonvt.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -19,7 +19,7 @@ function mason_load_source {
 function mason_compile {
     # setup mason
     rm -rf .mason
-    ln -s ${MASON_DIR:-~/.mason} .mason
+    ln -s ${MASON_DIR} .mason
 
     # build
     INSTALL_PREFIX=${MASON_PREFIX} ./configure

--- a/scripts/geojsonvt/4.1.2-cxx11abi/script.sh
+++ b/scripts/geojsonvt/4.1.2-cxx11abi/script.sh
@@ -6,7 +6,7 @@ MASON_NAME=geojsonvt
 MASON_VERSION=${LIB_VERSION}-cxx11abi
 MASON_LIB_FILE=lib/libgeojsonvt.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -21,7 +21,7 @@ function mason_load_source {
 function mason_compile {
     # setup mason
     rm -rf .mason
-    ln -s ${MASON_DIR:-~/.mason} .mason
+    ln -s ${MASON_DIR} .mason
 
     # build
     INSTALL_PREFIX=${MASON_PREFIX} ./configure

--- a/scripts/geojsonvt/4.1.2/script.sh
+++ b/scripts/geojsonvt/4.1.2/script.sh
@@ -6,7 +6,7 @@ MASON_NAME=geojsonvt
 MASON_VERSION=${LIB_VERSION}
 MASON_LIB_FILE=lib/libgeojsonvt.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -21,7 +21,7 @@ function mason_load_source {
 function mason_compile {
     # setup mason
     rm -rf .mason
-    ln -s ${MASON_DIR:-~/.mason} .mason
+    ln -s ${MASON_DIR} .mason
 
     # build
     INSTALL_PREFIX=${MASON_PREFIX} ./configure

--- a/scripts/geojsonvt/5.0.0/script.sh
+++ b/scripts/geojsonvt/5.0.0/script.sh
@@ -6,7 +6,7 @@ MASON_NAME=geojsonvt
 MASON_VERSION=${LIB_VERSION}
 MASON_LIB_FILE=lib/libgeojsonvt.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -21,7 +21,7 @@ function mason_load_source {
 function mason_compile {
     # setup mason
     rm -rf .mason
-    ln -s ${MASON_DIR:-~/.mason} .mason
+    ln -s ${MASON_DIR} .mason
 
     # build
     INSTALL_PREFIX=${MASON_PREFIX} ./configure

--- a/scripts/geometry/0.1.0/script.sh
+++ b/scripts/geometry/0.1.0/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=geometry
 MASON_VERSION=0.1.0
 MASON_HEADER_ONLY=true
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/geometry/0.2.0/script.sh
+++ b/scripts/geometry/0.2.0/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=geometry
 MASON_VERSION=0.2.0
 MASON_HEADER_ONLY=true
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/geometry/0.3.0/script.sh
+++ b/scripts/geometry/0.3.0/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=geometry
 MASON_VERSION=0.3.0
 MASON_HEADER_ONLY=true
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/geometry/0.4.0/script.sh
+++ b/scripts/geometry/0.4.0/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=geometry
 MASON_VERSION=0.4.0
 MASON_HEADER_ONLY=true
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/geos/3.4.2/script.sh
+++ b/scripts/geos/3.4.2/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=geos
 MASON_VERSION=3.4.2
 MASON_LIB_FILE=lib/libgeos.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/geos/3.5.0/script.sh
+++ b/scripts/geos/3.5.0/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=geos
 MASON_VERSION=3.5.0
 MASON_LIB_FILE=lib/libgeos.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/geowave-jace/0.8.7/.travis.yml
+++ b/scripts/geowave-jace/0.8.7/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 install:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/geowave-jace/0.8.7/script.sh
+++ b/scripts/geowave-jace/0.8.7/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=geowave-jace
 MASON_VERSION=0.8.7
 MASON_LIB_FILE=lib/libjace.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download http://s3.amazonaws.com/geowave-rpms/release/TARBALL/geowave-0.8.7-c8ef40c-jace-source.tar.gz \
@@ -16,8 +16,8 @@ function mason_load_source {
 }
 
 function dep() {
-    ${MASON_DIR:-~/.mason}/mason install $1 $2
-    ${MASON_DIR:-~/.mason}/mason link $1 $2
+    ${MASON_DIR}/mason install $1 $2
+    ${MASON_DIR}/mason link $1 $2
 }
 
 function all_deps() {

--- a/scripts/glfw/3.1.2/script.sh
+++ b/scripts/glfw/3.1.2/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=3.1.2
 MASON_LIB_FILE=lib/libglfw3.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/glfw3.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/gtest/1.7.0-cxx11abi/script.sh
+++ b/scripts/gtest/1.7.0-cxx11abi/script.sh
@@ -6,7 +6,7 @@ MASON_NAME=gtest
 MASON_VERSION=${LIB_VERSION}-cxx11abi
 MASON_LIB_FILE=lib/libgtest.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/gtest/1.7.0/script.sh
+++ b/scripts/gtest/1.7.0/script.sh
@@ -6,7 +6,7 @@ MASON_NAME=gtest
 MASON_VERSION=${LIB_VERSION}
 MASON_LIB_FILE=lib/libgtest.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/harfbuzz/0.9.40/.travis.yml
+++ b/scripts/harfbuzz/0.9.40/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/harfbuzz/0.9.40/script.sh
+++ b/scripts/harfbuzz/0.9.40/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=0.9.40
 MASON_LIB_FILE=lib/libharfbuzz.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/harfbuzz.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -19,11 +19,11 @@ function mason_load_source {
 
 function mason_prepare_compile {
     FREETYPE_VERSION="2.5.5"
-    ${MASON_DIR:-~/.mason}/mason install freetype ${FREETYPE_VERSION}
-    MASON_FREETYPE=$(${MASON_DIR:-~/.mason}/mason prefix freetype ${FREETYPE_VERSION})
-    MASON_PLATFORM= ${MASON_DIR:-~/.mason}/mason install ragel 6.9
-    export PATH=$(MASON_PLATFORM= ${MASON_DIR:-~/.mason}/mason prefix ragel 6.9)/bin:$PATH
-    export PKG_CONFIG_PATH="$(${MASON_DIR:-~/.mason}/mason prefix freetype ${FREETYPE_VERSION})/lib/pkgconfig":$PKG_CONFIG_PATH
+    ${MASON_DIR}/mason install freetype ${FREETYPE_VERSION}
+    MASON_FREETYPE=$(${MASON_DIR}/mason prefix freetype ${FREETYPE_VERSION})
+    MASON_PLATFORM= ${MASON_DIR}/mason install ragel 6.9
+    export PATH=$(MASON_PLATFORM= ${MASON_DIR}/mason prefix ragel 6.9)/bin:$PATH
+    export PKG_CONFIG_PATH="$(${MASON_DIR}/mason prefix freetype ${FREETYPE_VERSION})/lib/pkgconfig":$PKG_CONFIG_PATH
     export C_INCLUDE_PATH="${MASON_FREETYPE}/include/freetype2"
     export CPLUS_INCLUDE_PATH="${MASON_FREETYPE}/include/freetype2"
     export LIBRARY_PATH="${MASON_FREETYPE}/lib"

--- a/scripts/harfbuzz/0.9.41/.travis.yml
+++ b/scripts/harfbuzz/0.9.41/.travis.yml
@@ -19,7 +19,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/harfbuzz/0.9.41/script.sh
+++ b/scripts/harfbuzz/0.9.41/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=0.9.41
 MASON_LIB_FILE=lib/libharfbuzz.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/harfbuzz.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -19,11 +19,11 @@ function mason_load_source {
 
 function mason_prepare_compile {
     FREETYPE_VERSION="2.6"
-    ${MASON_DIR:-~/.mason}/mason install freetype ${FREETYPE_VERSION}
-    MASON_FREETYPE=$(${MASON_DIR:-~/.mason}/mason prefix freetype ${FREETYPE_VERSION})
-    MASON_PLATFORM= ${MASON_DIR:-~/.mason}/mason install ragel 6.9
-    export PATH=$(MASON_PLATFORM= ${MASON_DIR:-~/.mason}/mason prefix ragel 6.9)/bin:$PATH
-    export PKG_CONFIG_PATH="$(${MASON_DIR:-~/.mason}/mason prefix freetype ${FREETYPE_VERSION})/lib/pkgconfig":$PKG_CONFIG_PATH
+    ${MASON_DIR}/mason install freetype ${FREETYPE_VERSION}
+    MASON_FREETYPE=$(${MASON_DIR}/mason prefix freetype ${FREETYPE_VERSION})
+    MASON_PLATFORM= ${MASON_DIR}/mason install ragel 6.9
+    export PATH=$(MASON_PLATFORM= ${MASON_DIR}/mason prefix ragel 6.9)/bin:$PATH
+    export PKG_CONFIG_PATH="$(${MASON_DIR}/mason prefix freetype ${FREETYPE_VERSION})/lib/pkgconfig":$PKG_CONFIG_PATH
     export C_INCLUDE_PATH="${MASON_FREETYPE}/include/freetype2"
     export CPLUS_INCLUDE_PATH="${MASON_FREETYPE}/include/freetype2"
     export LIBRARY_PATH="${MASON_FREETYPE}/lib"

--- a/scripts/harfbuzz/1.1.2/.travis.yml
+++ b/scripts/harfbuzz/1.1.2/.travis.yml
@@ -19,7 +19,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/harfbuzz/1.1.2/script.sh
+++ b/scripts/harfbuzz/1.1.2/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=1.1.2
 MASON_LIB_FILE=lib/libharfbuzz.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/harfbuzz.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -19,11 +19,11 @@ function mason_load_source {
 
 function mason_prepare_compile {
     FREETYPE_VERSION="2.6"
-    ${MASON_DIR:-~/.mason}/mason install freetype ${FREETYPE_VERSION}
-    MASON_FREETYPE=$(${MASON_DIR:-~/.mason}/mason prefix freetype ${FREETYPE_VERSION})
-    MASON_PLATFORM= ${MASON_DIR:-~/.mason}/mason install ragel 6.9
-    export PATH=$(MASON_PLATFORM= ${MASON_DIR:-~/.mason}/mason prefix ragel 6.9)/bin:$PATH
-    export PKG_CONFIG_PATH="$(${MASON_DIR:-~/.mason}/mason prefix freetype ${FREETYPE_VERSION})/lib/pkgconfig":$PKG_CONFIG_PATH
+    ${MASON_DIR}/mason install freetype ${FREETYPE_VERSION}
+    MASON_FREETYPE=$(${MASON_DIR}/mason prefix freetype ${FREETYPE_VERSION})
+    MASON_PLATFORM= ${MASON_DIR}/mason install ragel 6.9
+    export PATH=$(MASON_PLATFORM= ${MASON_DIR}/mason prefix ragel 6.9)/bin:$PATH
+    export PKG_CONFIG_PATH="$(${MASON_DIR}/mason prefix freetype ${FREETYPE_VERSION})/lib/pkgconfig":$PKG_CONFIG_PATH
     export C_INCLUDE_PATH="${MASON_FREETYPE}/include/freetype2"
     export CPLUS_INCLUDE_PATH="${MASON_FREETYPE}/include/freetype2"
     export LIBRARY_PATH="${MASON_FREETYPE}/lib"

--- a/scripts/harfbuzz/1.2.1/.travis.yml
+++ b/scripts/harfbuzz/1.2.1/.travis.yml
@@ -19,7 +19,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/harfbuzz/1.2.1/script.sh
+++ b/scripts/harfbuzz/1.2.1/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=1.2.1
 MASON_LIB_FILE=lib/libharfbuzz.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/harfbuzz.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -19,11 +19,11 @@ function mason_load_source {
 
 function mason_prepare_compile {
     FREETYPE_VERSION="2.6"
-    ${MASON_DIR:-~/.mason}/mason install freetype ${FREETYPE_VERSION}
-    MASON_FREETYPE=$(${MASON_DIR:-~/.mason}/mason prefix freetype ${FREETYPE_VERSION})
-    MASON_PLATFORM= ${MASON_DIR:-~/.mason}/mason install ragel 6.9
-    export PATH=$(MASON_PLATFORM= ${MASON_DIR:-~/.mason}/mason prefix ragel 6.9)/bin:$PATH
-    export PKG_CONFIG_PATH="$(${MASON_DIR:-~/.mason}/mason prefix freetype ${FREETYPE_VERSION})/lib/pkgconfig":$PKG_CONFIG_PATH
+    ${MASON_DIR}/mason install freetype ${FREETYPE_VERSION}
+    MASON_FREETYPE=$(${MASON_DIR}/mason prefix freetype ${FREETYPE_VERSION})
+    MASON_PLATFORM= ${MASON_DIR}/mason install ragel 6.9
+    export PATH=$(MASON_PLATFORM= ${MASON_DIR}/mason prefix ragel 6.9)/bin:$PATH
+    export PKG_CONFIG_PATH="$(${MASON_DIR}/mason prefix freetype ${FREETYPE_VERSION})/lib/pkgconfig":$PKG_CONFIG_PATH
     export C_INCLUDE_PATH="${MASON_FREETYPE}/include/freetype2"
     export CPLUS_INCLUDE_PATH="${MASON_FREETYPE}/include/freetype2"
     export LIBRARY_PATH="${MASON_FREETYPE}/lib"

--- a/scripts/harfbuzz/1.2.6/.travis.yml
+++ b/scripts/harfbuzz/1.2.6/.travis.yml
@@ -19,7 +19,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/harfbuzz/1.2.6/script.sh
+++ b/scripts/harfbuzz/1.2.6/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=1.2.6
 MASON_LIB_FILE=lib/libharfbuzz.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/harfbuzz.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -19,11 +19,11 @@ function mason_load_source {
 
 function mason_prepare_compile {
     FREETYPE_VERSION="2.6"
-    ${MASON_DIR:-~/.mason}/mason install freetype ${FREETYPE_VERSION}
-    MASON_FREETYPE=$(${MASON_DIR:-~/.mason}/mason prefix freetype ${FREETYPE_VERSION})
-    MASON_PLATFORM= ${MASON_DIR:-~/.mason}/mason install ragel 6.9
-    export PATH=$(MASON_PLATFORM= ${MASON_DIR:-~/.mason}/mason prefix ragel 6.9)/bin:$PATH
-    export PKG_CONFIG_PATH="$(${MASON_DIR:-~/.mason}/mason prefix freetype ${FREETYPE_VERSION})/lib/pkgconfig":$PKG_CONFIG_PATH
+    ${MASON_DIR}/mason install freetype ${FREETYPE_VERSION}
+    MASON_FREETYPE=$(${MASON_DIR}/mason prefix freetype ${FREETYPE_VERSION})
+    MASON_PLATFORM= ${MASON_DIR}/mason install ragel 6.9
+    export PATH=$(MASON_PLATFORM= ${MASON_DIR}/mason prefix ragel 6.9)/bin:$PATH
+    export PKG_CONFIG_PATH="$(${MASON_DIR}/mason prefix freetype ${FREETYPE_VERSION})/lib/pkgconfig":$PKG_CONFIG_PATH
     export C_INCLUDE_PATH="${MASON_FREETYPE}/include/freetype2"
     export CPLUS_INCLUDE_PATH="${MASON_FREETYPE}/include/freetype2"
     export LIBRARY_PATH="${MASON_FREETYPE}/lib"

--- a/scripts/harfbuzz/2cd5323531dcd800549b2cb1cb51d708e72ab2d8/.travis.yml
+++ b/scripts/harfbuzz/2cd5323531dcd800549b2cb1cb51d708e72ab2d8/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/harfbuzz/2cd5323531dcd800549b2cb1cb51d708e72ab2d8/script.sh
+++ b/scripts/harfbuzz/2cd5323531dcd800549b2cb1cb51d708e72ab2d8/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=2cd5323531dcd800549b2cb1cb51d708e72ab2d8
 MASON_LIB_FILE=lib/libharfbuzz.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/harfbuzz.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -18,11 +18,11 @@ function mason_load_source {
 }
 
 function mason_prepare_compile {
-    ${MASON_DIR:-~/.mason}/mason install freetype 2.5.4
-    MASON_FREETYPE=$(${MASON_DIR:-~/.mason}/mason prefix freetype 2.5.4)
-    MASON_PLATFORM= ${MASON_DIR:-~/.mason}/mason install ragel 6.9
-    export PATH=$(MASON_PLATFORM= ${MASON_DIR:-~/.mason}/mason prefix ragel 6.9)/bin:$PATH
-    export PKG_CONFIG_PATH="$(${MASON_DIR:-~/.mason}/mason prefix freetype 2.5.4)/lib/pkgconfig":$PKG_CONFIG_PATH
+    ${MASON_DIR}/mason install freetype 2.5.4
+    MASON_FREETYPE=$(${MASON_DIR}/mason prefix freetype 2.5.4)
+    MASON_PLATFORM= ${MASON_DIR}/mason install ragel 6.9
+    export PATH=$(MASON_PLATFORM= ${MASON_DIR}/mason prefix ragel 6.9)/bin:$PATH
+    export PKG_CONFIG_PATH="$(${MASON_DIR}/mason prefix freetype 2.5.4)/lib/pkgconfig":$PKG_CONFIG_PATH
     export C_INCLUDE_PATH="${MASON_FREETYPE}/include/freetype2"
     export CPLUS_INCLUDE_PATH="${MASON_FREETYPE}/include/freetype2"
     export LIBRARY_PATH="${MASON_FREETYPE}/lib"

--- a/scripts/iconv/system/script.sh
+++ b/scripts/iconv/system/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=iconv
 MASON_VERSION=system
 MASON_SYSTEM_PACKAGE=true
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     :

--- a/scripts/icu/54.1/.travis.yml
+++ b/scripts/icu/54.1/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/icu/54.1/script.sh
+++ b/scripts/icu/54.1/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=54.1
 MASON_LIB_FILE=lib/libicuuc.a
 #MASON_PKGCONFIG_FILE=lib/pkgconfig/icu-uc.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/icu/55.1/.travis.yml
+++ b/scripts/icu/55.1/.travis.yml
@@ -19,7 +19,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/icu/55.1/script.sh
+++ b/scripts/icu/55.1/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=55.1
 MASON_LIB_FILE=lib/libicuuc.a
 #MASON_PKGCONFIG_FILE=lib/pkgconfig/icu-uc.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/icu/latest/.travis.yml
+++ b/scripts/icu/latest/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/icu/latest/script.sh
+++ b/scripts/icu/latest/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=latest
 MASON_LIB_FILE=lib/libicuuc.a
 #MASON_PKGCONFIG_FILE=lib/pkgconfig/icu-uc.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     export MASON_BUILD_PATH=${MASON_ROOT}/.build/icu-trunk

--- a/scripts/iojs/1.2.0/script.sh
+++ b/scripts/iojs/1.2.0/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=iojs
 MASON_VERSION=1.2.0
 MASON_LIB_FILE=bin/iojs
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then

--- a/scripts/iojs/2.0.1/script.sh
+++ b/scripts/iojs/2.0.1/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=iojs
 MASON_VERSION=2.0.1
 MASON_LIB_FILE=bin/iojs
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then

--- a/scripts/jni.hpp/1.0.0/script.sh
+++ b/scripts/jni.hpp/1.0.0/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=jni.hpp
 MASON_VERSION=1.0.0
 MASON_HEADER_ONLY=true
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/jni.hpp/2.0.0/script.sh
+++ b/scripts/jni.hpp/2.0.0/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=jni.hpp
 MASON_VERSION=2.0.0
 MASON_HEADER_ONLY=true
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/jpeg/v9a/script.sh
+++ b/scripts/jpeg/v9a/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=jpeg
 MASON_VERSION=v9a
 MASON_LIB_FILE=lib/libjpeg.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/jpeg_turbo/1.4.0/script.sh
+++ b/scripts/jpeg_turbo/1.4.0/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=jpeg_turbo
 MASON_VERSION=1.4.0
 MASON_LIB_FILE=lib/libjpeg.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -17,8 +17,8 @@ function mason_load_source {
 }
 
 function mason_prepare_compile {
-    MASON_PLATFORM= ${MASON_DIR:-~/.mason}/mason install nasm 2.11.06
-    MASON_NASM=$(MASON_PLATFORM= ${MASON_DIR:-~/.mason}/mason prefix nasm 2.11.06)
+    MASON_PLATFORM= ${MASON_DIR}/mason install nasm 2.11.06
+    MASON_NASM=$(MASON_PLATFORM= ${MASON_DIR}/mason prefix nasm 2.11.06)
 }
 
 function mason_compile {

--- a/scripts/jpeg_turbo/1.4.2/script.sh
+++ b/scripts/jpeg_turbo/1.4.2/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=jpeg_turbo
 MASON_VERSION=1.4.2
 MASON_LIB_FILE=lib/libjpeg.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -17,8 +17,8 @@ function mason_load_source {
 }
 
 function mason_prepare_compile {
-    MASON_PLATFORM= ${MASON_DIR:-~/.mason}/mason install nasm 2.11.06
-    MASON_NASM=$(MASON_PLATFORM= ${MASON_DIR:-~/.mason}/mason prefix nasm 2.11.06)
+    MASON_PLATFORM= ${MASON_DIR}/mason install nasm 2.11.06
+    MASON_NASM=$(MASON_PLATFORM= ${MASON_DIR}/mason prefix nasm 2.11.06)
 }
 
 function mason_compile {

--- a/scripts/kdbush/0.1.0/script.sh
+++ b/scripts/kdbush/0.1.0/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=kdbush
 MASON_VERSION=0.1.0
 MASON_HEADER_ONLY=true
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/lcov/1.12/script.sh
+++ b/scripts/lcov/1.12/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=lcov
 MASON_VERSION=1.12
 MASON_LIB_FILE=usr/bin/lcov
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/libcurl/7.38.0-boringssl/script.sh
+++ b/scripts/libcurl/7.38.0-boringssl/script.sh
@@ -7,7 +7,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/libcurl.pc
 
 MASON_PWD=`pwd`
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 
 function mason_load_source {
@@ -21,7 +21,7 @@ function mason_load_source {
 }
 
 function mason_prepare_compile {
-    ${MASON_DIR:-~/.mason}/mason install boringssl d3bcf13
+    ${MASON_DIR}/mason install boringssl d3bcf13
     MASON_OPENSSL=`~/.mason/mason prefix boringssl d3bcf13`
 
     if [ ${MASON_PLATFORM} = 'linux' ]; then

--- a/scripts/libcurl/7.38.0-boringssl/script.sh
+++ b/scripts/libcurl/7.38.0-boringssl/script.sh
@@ -22,7 +22,7 @@ function mason_load_source {
 
 function mason_prepare_compile {
     ${MASON_DIR}/mason install boringssl d3bcf13
-    MASON_OPENSSL=`~/.mason/mason prefix boringssl d3bcf13`
+    MASON_OPENSSL=`${MASON_DIR}/mason prefix boringssl d3bcf13`
 
     if [ ${MASON_PLATFORM} = 'linux' ]; then
         LIBS="-ldl ${LIBS=}"

--- a/scripts/libcurl/7.40.0/script.sh
+++ b/scripts/libcurl/7.40.0/script.sh
@@ -20,7 +20,7 @@ function mason_load_source {
 
 function mason_prepare_compile {
     ${MASON_DIR}/mason install openssl 1.0.1l
-    MASON_OPENSSL=`~/.mason/mason prefix openssl 1.0.1l`
+    MASON_OPENSSL=`${MASON_DIR}/mason prefix openssl 1.0.1l`
 
     if [ ${MASON_PLATFORM} = 'linux' ]; then
         LIBS="-ldl ${LIBS=}"

--- a/scripts/libcurl/7.40.0/script.sh
+++ b/scripts/libcurl/7.40.0/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=7.40.0
 MASON_LIB_FILE=lib/libcurl.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/libcurl.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 
 function mason_load_source {
@@ -19,7 +19,7 @@ function mason_load_source {
 }
 
 function mason_prepare_compile {
-    ${MASON_DIR:-~/.mason}/mason install openssl 1.0.1l
+    ${MASON_DIR}/mason install openssl 1.0.1l
     MASON_OPENSSL=`~/.mason/mason prefix openssl 1.0.1l`
 
     if [ ${MASON_PLATFORM} = 'linux' ]; then

--- a/scripts/libcurl/7.45.0/script.sh
+++ b/scripts/libcurl/7.45.0/script.sh
@@ -22,7 +22,7 @@ function mason_load_source {
 
 function mason_prepare_compile {
     ${MASON_DIR}/mason install openssl ${OPENSSL_VERSION}
-    MASON_OPENSSL=`~/.mason/mason prefix openssl ${OPENSSL_VERSION}`
+    MASON_OPENSSL=`${MASON_DIR}/mason prefix openssl ${OPENSSL_VERSION}`
 
     if [ ${MASON_PLATFORM} = 'linux' ]; then
         LIBS="-ldl ${LIBS=}"

--- a/scripts/libcurl/7.45.0/script.sh
+++ b/scripts/libcurl/7.45.0/script.sh
@@ -7,7 +7,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/libcurl.pc
 
 OPENSSL_VERSION=1.0.1p
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 
 function mason_load_source {
@@ -21,7 +21,7 @@ function mason_load_source {
 }
 
 function mason_prepare_compile {
-    ${MASON_DIR:-~/.mason}/mason install openssl ${OPENSSL_VERSION}
+    ${MASON_DIR}/mason install openssl ${OPENSSL_VERSION}
     MASON_OPENSSL=`~/.mason/mason prefix openssl ${OPENSSL_VERSION}`
 
     if [ ${MASON_PLATFORM} = 'linux' ]; then

--- a/scripts/libcurl/system/script.sh
+++ b/scripts/libcurl/system/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=libcurl
 MASON_VERSION=system
 MASON_SYSTEM_PACKAGE=true
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 
 if [[ ${MASON_PLATFORM} = 'ios' || ${MASON_PLATFORM} = 'android' ]]; then

--- a/scripts/libjpeg-turbo/1.4.2/script.sh
+++ b/scripts/libjpeg-turbo/1.4.2/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=libjpeg-turbo
 MASON_VERSION=1.4.2
 MASON_LIB_FILE=lib/libjpeg.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/libosmium/2.6.1/script.sh
+++ b/scripts/libosmium/2.6.1/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=libosmium
 MASON_VERSION=2.6.1
 MASON_HEADER_ONLY=true
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/libpng/1.6.16/script.sh
+++ b/scripts/libpng/1.6.16/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=1.6.16
 MASON_LIB_FILE=lib/libpng.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/libpng.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/libpng/1.6.17/script.sh
+++ b/scripts/libpng/1.6.17/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=1.6.17
 MASON_LIB_FILE=lib/libpng.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/libpng.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/libpng/1.6.18/script.sh
+++ b/scripts/libpng/1.6.18/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=1.6.18
 MASON_LIB_FILE=lib/libpng.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/libpng.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/libpng/1.6.20/script.sh
+++ b/scripts/libpng/1.6.20/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=1.6.20
 MASON_LIB_FILE=lib/libpng.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/libpng.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/libpng/1.6.21/script.sh
+++ b/scripts/libpng/1.6.21/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=1.6.21
 MASON_LIB_FILE=lib/libpng.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/libpng.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/libpng/system/script.sh
+++ b/scripts/libpng/system/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=libpng
 MASON_VERSION=system
 MASON_SYSTEM_PACKAGE=true
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 if [ ! $(pkg-config libpng --exists; echo $?) = 0 ]; then
     mason_error "Cannot find libpng with pkg-config"

--- a/scripts/libpq/9.4.0/script.sh
+++ b/scripts/libpq/9.4.0/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=9.4.0
 MASON_LIB_FILE=lib/libpq.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/libpq.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/libpq/9.4.1/script.sh
+++ b/scripts/libpq/9.4.1/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=9.4.1
 MASON_LIB_FILE=lib/libpq.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/libpq.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/libpq/9.5.2/script.sh
+++ b/scripts/libpq/9.5.2/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=9.5.2
 MASON_LIB_FILE=lib/libpq.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/libpq.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/libtiff/4.0.4beta/script.sh
+++ b/scripts/libtiff/4.0.4beta/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=4.0.4beta
 MASON_LIB_FILE=lib/libtiff.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/libtiff-4.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -19,8 +19,8 @@ function mason_load_source {
 
 function mason_prepare_compile {
     cd $(dirname ${MASON_ROOT})
-    ${MASON_DIR:-~/.mason}/mason install jpeg_turbo 1.4.0
-    MASON_JPEG=$(${MASON_DIR:-~/.mason}/mason prefix jpeg_turbo 1.4.0)
+    ${MASON_DIR}/mason install jpeg_turbo 1.4.0
+    MASON_JPEG=$(${MASON_DIR}/mason prefix jpeg_turbo 1.4.0)
     SYSTEM_ZLIB="/usr"
 }
 

--- a/scripts/libtiff/4.0.6/script.sh
+++ b/scripts/libtiff/4.0.6/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=4.0.6
 MASON_LIB_FILE=lib/libtiff.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/libtiff-4.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -19,8 +19,8 @@ function mason_load_source {
 
 function mason_prepare_compile {
     cd $(dirname ${MASON_ROOT})
-    ${MASON_DIR:-~/.mason}/mason install jpeg_turbo 1.4.2
-    MASON_JPEG=$(${MASON_DIR:-~/.mason}/mason prefix jpeg_turbo 1.4.2)
+    ${MASON_DIR}/mason install jpeg_turbo 1.4.2
+    MASON_JPEG=$(${MASON_DIR}/mason prefix jpeg_turbo 1.4.2)
     SYSTEM_ZLIB="/usr"
 }
 

--- a/scripts/libtiff/46346a6b570b6084be53063216fbd2825d311675/script.sh
+++ b/scripts/libtiff/46346a6b570b6084be53063216fbd2825d311675/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=46346a6b570b6084be53063216fbd2825d311675
 MASON_LIB_FILE=lib/libtiff.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/libtiff-4.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -18,8 +18,8 @@ function mason_load_source {
 }
 
 function mason_prepare_compile {
-    ${MASON_DIR:-~/.mason}/mason install jpeg v8d
-    MASON_JPEG=$(${MASON_DIR:-~/.mason}/mason prefix jpeg v8d)
+    ${MASON_DIR}/mason install jpeg v8d
+    MASON_JPEG=$(${MASON_DIR}/mason prefix jpeg v8d)
     SYSTEM_ZLIB="/usr"
 }
 

--- a/scripts/libuv/0.10.28/script.sh
+++ b/scripts/libuv/0.10.28/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=libuv
 MASON_VERSION=0.10.28
 MASON_LIB_FILE=lib/libuv.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/libuv/0.10.33/script.sh
+++ b/scripts/libuv/0.10.33/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=libuv
 MASON_VERSION=0.10.33
 MASON_LIB_FILE=lib/libuv.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/libuv/0.10.36/script.sh
+++ b/scripts/libuv/0.10.36/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=libuv
 MASON_VERSION=0.10.36
 MASON_LIB_FILE=lib/libuv.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/libuv/0.11.29/script.sh
+++ b/scripts/libuv/0.11.29/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=0.11.29
 MASON_LIB_FILE=lib/libuv.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/libuv.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/libuv/1.4.0/script.sh
+++ b/scripts/libuv/1.4.0/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=1.4.0
 MASON_LIB_FILE=lib/libuv.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/libuv.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/libuv/1.6.1/script.sh
+++ b/scripts/libuv/1.6.1/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=1.6.1
 MASON_LIB_FILE=lib/libuv.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/libuv.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/libuv/1.7.5/script.sh
+++ b/scripts/libuv/1.7.5/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=1.7.5
 MASON_LIB_FILE=lib/libuv.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/libuv.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/libxml2/2.9.2/script.sh
+++ b/scripts/libxml2/2.9.2/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=2.9.2
 MASON_LIB_FILE=lib/libxml2.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/libxml-2.0.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/libxml2/2.9.3/script.sh
+++ b/scripts/libxml2/2.9.3/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=2.9.3
 MASON_LIB_FILE=lib/libxml2.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/libxml-2.0.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/libzip/0.11.2/script.sh
+++ b/scripts/libzip/0.11.2/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=0.11.2
 MASON_LIB_FILE=lib/libzip.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/libzip.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/libzip/1.0.1/script.sh
+++ b/scripts/libzip/1.0.1/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=1.0.1
 MASON_LIB_FILE=lib/libzip.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/libzip.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/lua/5.1.0/script.sh
+++ b/scripts/lua/5.1.0/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=lua
 MASON_VERSION=5.1.0
 MASON_LIB_FILE=lib/liblua.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/lua/5.2.4/script.sh
+++ b/scripts/lua/5.2.4/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=lua
 MASON_VERSION=5.2.4
 MASON_LIB_FILE=lib/liblua.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/lua/5.3.0/script.sh
+++ b/scripts/lua/5.3.0/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=lua
 MASON_VERSION=5.3.0
 MASON_LIB_FILE=lib/liblua.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/luabind/e414c57bcb687bb3091b7c55bbff6947f052e46b/.travis.yml
+++ b/scripts/luabind/e414c57bcb687bb3091b7c55bbff6947f052e46b/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/luabind/e414c57bcb687bb3091b7c55bbff6947f052e46b/script.sh
+++ b/scripts/luabind/e414c57bcb687bb3091b7c55bbff6947f052e46b/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=luabind
 MASON_VERSION=e414c57bcb687bb3091b7c55bbff6947f052e46b
 MASON_LIB_FILE=lib/libluabind.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -18,10 +18,10 @@ function mason_load_source {
 
 function mason_prepare_compile {
     cd $(dirname ${MASON_ROOT})
-    ${MASON_DIR:-~/.mason}/mason install lua 5.3.0
-    MASON_LUA=$(${MASON_DIR:-~/.mason}/mason prefix lua 5.3.0)
-    ${MASON_DIR:-~/.mason}/mason install boost 1.57.0
-    MASON_BOOST_HEADERS=$(${MASON_DIR:-~/.mason}/mason prefix boost 1.57.0)
+    ${MASON_DIR}/mason install lua 5.3.0
+    MASON_LUA=$(${MASON_DIR}/mason prefix lua 5.3.0)
+    ${MASON_DIR}/mason install boost 1.57.0
+    MASON_BOOST_HEADERS=$(${MASON_DIR}/mason prefix boost 1.57.0)
     SYSTEM_ZLIB="/usr"
 }
 

--- a/scripts/luabind_lua51/e414c57bcb687bb3091b7c55bbff6947f052e46b/.travis.yml
+++ b/scripts/luabind_lua51/e414c57bcb687bb3091b7c55bbff6947f052e46b/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/luabind_lua51/e414c57bcb687bb3091b7c55bbff6947f052e46b/script.sh
+++ b/scripts/luabind_lua51/e414c57bcb687bb3091b7c55bbff6947f052e46b/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=luabind_lua51
 MASON_VERSION=e414c57bcb687bb3091b7c55bbff6947f052e46b
 MASON_LIB_FILE=lib/libluabind.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -18,10 +18,10 @@ function mason_load_source {
 
 function mason_prepare_compile {
     cd $(dirname ${MASON_ROOT})
-    ${MASON_DIR:-~/.mason}/mason install lua 5.1.0
-    MASON_LUA=$(${MASON_DIR:-~/.mason}/mason prefix lua 5.1.0)
-    ${MASON_DIR:-~/.mason}/mason install boost 1.57.0
-    MASON_BOOST_HEADERS=$(${MASON_DIR:-~/.mason}/mason prefix boost 1.57.0)
+    ${MASON_DIR}/mason install lua 5.1.0
+    MASON_LUA=$(${MASON_DIR}/mason prefix lua 5.1.0)
+    ${MASON_DIR}/mason install boost 1.57.0
+    MASON_BOOST_HEADERS=$(${MASON_DIR}/mason prefix boost 1.57.0)
     SYSTEM_ZLIB="/usr"
 }
 

--- a/scripts/luabind_lua524/e414c57bcb687bb3091b7c55bbff6947f052e46b/.travis.yml
+++ b/scripts/luabind_lua524/e414c57bcb687bb3091b7c55bbff6947f052e46b/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/luabind_lua524/e414c57bcb687bb3091b7c55bbff6947f052e46b/script.sh
+++ b/scripts/luabind_lua524/e414c57bcb687bb3091b7c55bbff6947f052e46b/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=luabind_lua524
 MASON_VERSION=e414c57bcb687bb3091b7c55bbff6947f052e46b
 MASON_LIB_FILE=lib/libluabind.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -18,10 +18,10 @@ function mason_load_source {
 
 function mason_prepare_compile {
     cd $(dirname ${MASON_ROOT})
-    ${MASON_DIR:-~/.mason}/mason install lua 5.2.4
-    MASON_LUA=$(${MASON_DIR:-~/.mason}/mason prefix lua 5.2.4)
-    ${MASON_DIR:-~/.mason}/mason install boost 1.57.0
-    MASON_BOOST_HEADERS=$(${MASON_DIR:-~/.mason}/mason prefix boost 1.57.0)
+    ${MASON_DIR}/mason install lua 5.2.4
+    MASON_LUA=$(${MASON_DIR}/mason prefix lua 5.2.4)
+    ${MASON_DIR}/mason install boost 1.57.0
+    MASON_BOOST_HEADERS=$(${MASON_DIR}/mason prefix boost 1.57.0)
     SYSTEM_ZLIB="/usr"
 }
 

--- a/scripts/luabind_luajit2.0.3/e414c57bcb687bb3091b7c55bbff6947f052e46b/.travis.yml
+++ b/scripts/luabind_luajit2.0.3/e414c57bcb687bb3091b7c55bbff6947f052e46b/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/luabind_luajit2.0.3/e414c57bcb687bb3091b7c55bbff6947f052e46b/script.sh
+++ b/scripts/luabind_luajit2.0.3/e414c57bcb687bb3091b7c55bbff6947f052e46b/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=luabind_luajit2.0.3
 MASON_VERSION=e414c57bcb687bb3091b7c55bbff6947f052e46b
 MASON_LIB_FILE=lib/libluabind.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -18,10 +18,10 @@ function mason_load_source {
 
 function mason_prepare_compile {
     cd $(dirname ${MASON_ROOT})
-    ${MASON_DIR:-~/.mason}/mason install luajit 2.0.3
-    MASON_LUA=$(${MASON_DIR:-~/.mason}/mason prefix luajit 2.0.3)
-    ${MASON_DIR:-~/.mason}/mason install boost 1.57.0
-    MASON_BOOST_HEADERS=$(${MASON_DIR:-~/.mason}/mason prefix boost 1.57.0)
+    ${MASON_DIR}/mason install luajit 2.0.3
+    MASON_LUA=$(${MASON_DIR}/mason prefix luajit 2.0.3)
+    ${MASON_DIR}/mason install boost 1.57.0
+    MASON_BOOST_HEADERS=$(${MASON_DIR}/mason prefix boost 1.57.0)
     SYSTEM_ZLIB="/usr"
 }
 

--- a/scripts/luajit/2.0.3/script.sh
+++ b/scripts/luajit/2.0.3/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=luajit
 MASON_VERSION=2.0.3
 MASON_LIB_FILE=lib/libluajit-5.1.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/mapnik/3.0.0-rc2/.travis.yml
+++ b/scripts/mapnik/3.0.0-rc2/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/mapnik/3.0.0-rc2/script.sh
+++ b/scripts/mapnik/3.0.0-rc2/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=mapnik
 MASON_VERSION=3.0.0-rc2
 MASON_LIB_FILE=lib/libmapnik-wkt.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/mapnik/3.0.0-rc3/.travis.yml
+++ b/scripts/mapnik/3.0.0-rc3/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/mapnik/3.0.0-rc3/script.sh
+++ b/scripts/mapnik/3.0.0-rc3/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=mapnik
 MASON_VERSION=3.0.0-rc3
 MASON_LIB_FILE=lib/libmapnik-wkt.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/mapnik/3.0.0/.travis.yml
+++ b/scripts/mapnik/3.0.0/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/mapnik/3.0.0/script.sh
+++ b/scripts/mapnik/3.0.0/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=mapnik
 MASON_VERSION=3.0.0
 MASON_LIB_FILE=lib/libmapnik-wkt.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/mapnik/dev/.travis.yml
+++ b/scripts/mapnik/dev/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/mapnik/dev/script.sh
+++ b/scripts/mapnik/dev/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=mapnik
 MASON_VERSION=dev
 MASON_LIB_FILE=lib/libmapnik-wkt.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     export MASON_BUILD_PATH=${MASON_ROOT}/.build/mapnik-3.x

--- a/scripts/mapnik/geom/script.sh
+++ b/scripts/mapnik/geom/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=mapnik
 MASON_VERSION=geom
 MASON_LIB_FILE=lib/libmapnik-wkt.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     export MASON_BUILD_PATH=${MASON_ROOT}/.build/mapnik-3.x

--- a/scripts/mapnik/latest/.travis.yml
+++ b/scripts/mapnik/latest/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/mapnik/latest/script.sh
+++ b/scripts/mapnik/latest/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=mapnik
 MASON_VERSION=latest
 MASON_LIB_FILE=lib/libmapnik-wkt.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     export MASON_BUILD_PATH=${MASON_ROOT}/.build/mapnik-3.x

--- a/scripts/mesa/10.3.5/script.sh
+++ b/scripts/mesa/10.3.5/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=10.3.5
 MASON_LIB_FILE=lib/libGL.so
 MASON_PKGCONFIG_FILE=lib/pkgconfig/gl.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/mesa/10.4.3/script.sh
+++ b/scripts/mesa/10.4.3/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=10.4.3
 MASON_LIB_FILE=lib/libGL.so
 MASON_PKGCONFIG_FILE=lib/pkgconfig/gl.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/mesa/10.5.4-dbg/script.sh
+++ b/scripts/mesa/10.5.4-dbg/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=10.5.4-dbg
 MASON_LIB_FILE=lib/libGL.so
 MASON_PKGCONFIG_FILE=lib/pkgconfig/gl.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/mesa/10.5.4/script.sh
+++ b/scripts/mesa/10.5.4/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=10.5.4
 MASON_LIB_FILE=lib/libGL.so
 MASON_PKGCONFIG_FILE=lib/pkgconfig/gl.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/minjur/a2c9dc871369432c7978718834dac487c0591bd6/.travis.yml
+++ b/scripts/minjur/a2c9dc871369432c7978718834dac487c0591bd6/.travis.yml
@@ -19,7 +19,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - if [[ $(uname -s) == 'Darwin' ]]; then brew install cmake; fi

--- a/scripts/minjur/a2c9dc871369432c7978718834dac487c0591bd6/script.sh
+++ b/scripts/minjur/a2c9dc871369432c7978718834dac487c0591bd6/script.sh
@@ -3,7 +3,7 @@
 MASON_NAME=minjur
 MASON_VERSION=a2c9dc871369432c7978718834dac487c0591bd6
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -23,20 +23,20 @@ function mason_prepare_compile {
     tar -xzf osmium.tar.gz
 
     cd $(dirname ${MASON_ROOT})
-    ${MASON_DIR:-~/.mason}/mason install boost 1.57.0
-    ${MASON_DIR:-~/.mason}/mason link boost 1.57.0
-    ${MASON_DIR:-~/.mason}/mason install boost_libprogram_options 1.57.0
-    ${MASON_DIR:-~/.mason}/mason link boost_libprogram_options 1.57.0
-    ${MASON_DIR:-~/.mason}/mason install protobuf 2.6.1
-    ${MASON_DIR:-~/.mason}/mason link protobuf 2.6.1
-    ${MASON_DIR:-~/.mason}/mason install zlib 1.2.8
-    ${MASON_DIR:-~/.mason}/mason link zlib 1.2.8
-    ${MASON_DIR:-~/.mason}/mason install expat 2.1.0
-    ${MASON_DIR:-~/.mason}/mason link expat 2.1.0
-    ${MASON_DIR:-~/.mason}/mason install osmpbf 1.3.3
-    ${MASON_DIR:-~/.mason}/mason link osmpbf 1.3.3
-    ${MASON_DIR:-~/.mason}/mason install bzip 1.0.6
-    ${MASON_DIR:-~/.mason}/mason link bzip 1.0.6
+    ${MASON_DIR}/mason install boost 1.57.0
+    ${MASON_DIR}/mason link boost 1.57.0
+    ${MASON_DIR}/mason install boost_libprogram_options 1.57.0
+    ${MASON_DIR}/mason link boost_libprogram_options 1.57.0
+    ${MASON_DIR}/mason install protobuf 2.6.1
+    ${MASON_DIR}/mason link protobuf 2.6.1
+    ${MASON_DIR}/mason install zlib 1.2.8
+    ${MASON_DIR}/mason link zlib 1.2.8
+    ${MASON_DIR}/mason install expat 2.1.0
+    ${MASON_DIR}/mason link expat 2.1.0
+    ${MASON_DIR}/mason install osmpbf 1.3.3
+    ${MASON_DIR}/mason link osmpbf 1.3.3
+    ${MASON_DIR}/mason install bzip 1.0.6
+    ${MASON_DIR}/mason link bzip 1.0.6
 }
 
 function mason_compile {

--- a/scripts/minjur/feac70472f46c3145b6bdf7a02fdc37777828318/.travis.yml
+++ b/scripts/minjur/feac70472f46c3145b6bdf7a02fdc37777828318/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/minjur/feac70472f46c3145b6bdf7a02fdc37777828318/script.sh
+++ b/scripts/minjur/feac70472f46c3145b6bdf7a02fdc37777828318/script.sh
@@ -3,7 +3,7 @@
 MASON_NAME=minjur
 MASON_VERSION=feac70472f46c3145b6bdf7a02fdc37777828318
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -23,20 +23,20 @@ function mason_prepare_compile {
     tar -xzf osmium.tar.gz
 
     cd $(dirname ${MASON_ROOT})
-    ${MASON_DIR:-~/.mason}/mason install boost 1.57.0
-    ${MASON_DIR:-~/.mason}/mason link boost 1.57.0
-    ${MASON_DIR:-~/.mason}/mason install boost_libprogram_options 1.57.0
-    ${MASON_DIR:-~/.mason}/mason link boost_libprogram_options 1.57.0
-    ${MASON_DIR:-~/.mason}/mason install protobuf 2.6.1
-    ${MASON_DIR:-~/.mason}/mason link protobuf 2.6.1
-    ${MASON_DIR:-~/.mason}/mason install zlib 1.2.8
-    ${MASON_DIR:-~/.mason}/mason link zlib 1.2.8
-    ${MASON_DIR:-~/.mason}/mason install expat 2.1.0
-    ${MASON_DIR:-~/.mason}/mason link expat 2.1.0
-    ${MASON_DIR:-~/.mason}/mason install osmpbf 1.3.3
-    ${MASON_DIR:-~/.mason}/mason link osmpbf 1.3.3
-    ${MASON_DIR:-~/.mason}/mason install bzip 1.0.6
-    ${MASON_DIR:-~/.mason}/mason link bzip 1.0.6
+    ${MASON_DIR}/mason install boost 1.57.0
+    ${MASON_DIR}/mason link boost 1.57.0
+    ${MASON_DIR}/mason install boost_libprogram_options 1.57.0
+    ${MASON_DIR}/mason link boost_libprogram_options 1.57.0
+    ${MASON_DIR}/mason install protobuf 2.6.1
+    ${MASON_DIR}/mason link protobuf 2.6.1
+    ${MASON_DIR}/mason install zlib 1.2.8
+    ${MASON_DIR}/mason link zlib 1.2.8
+    ${MASON_DIR}/mason install expat 2.1.0
+    ${MASON_DIR}/mason link expat 2.1.0
+    ${MASON_DIR}/mason install osmpbf 1.3.3
+    ${MASON_DIR}/mason link osmpbf 1.3.3
+    ${MASON_DIR}/mason install bzip 1.0.6
+    ${MASON_DIR}/mason link bzip 1.0.6
 }
 
 function mason_compile {

--- a/scripts/minjur/latest/script.sh
+++ b/scripts/minjur/latest/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=minjur
 MASON_VERSION=latest
 MASON_LIB_FILE=bin/minjur
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     export MASON_BUILD_PATH=${MASON_ROOT}/.build/minjur-latest
@@ -25,18 +25,18 @@ function mason_prepare_compile {
     mv osmcode-libosmium-* osmcode-libosmium-latest
 
     cd $(dirname ${MASON_ROOT})
-    ${MASON_DIR:-~/.mason}/mason install cmake 3.2.2
-    ${MASON_DIR:-~/.mason}/mason link cmake 3.2.2
-    ${MASON_DIR:-~/.mason}/mason install boost 1.59.0
-    ${MASON_DIR:-~/.mason}/mason link boost 1.59.0
-    ${MASON_DIR:-~/.mason}/mason install boost_liball 1.59.0
-    ${MASON_DIR:-~/.mason}/mason link boost_liball 1.59.0
-    ${MASON_DIR:-~/.mason}/mason install zlib 1.2.8
-    ${MASON_DIR:-~/.mason}/mason link zlib 1.2.8
-    ${MASON_DIR:-~/.mason}/mason install expat 2.1.0
-    ${MASON_DIR:-~/.mason}/mason link expat 2.1.0
-    ${MASON_DIR:-~/.mason}/mason install bzip 1.0.6
-    ${MASON_DIR:-~/.mason}/mason link bzip 1.0.6
+    ${MASON_DIR}/mason install cmake 3.2.2
+    ${MASON_DIR}/mason link cmake 3.2.2
+    ${MASON_DIR}/mason install boost 1.59.0
+    ${MASON_DIR}/mason link boost 1.59.0
+    ${MASON_DIR}/mason install boost_liball 1.59.0
+    ${MASON_DIR}/mason link boost_liball 1.59.0
+    ${MASON_DIR}/mason install zlib 1.2.8
+    ${MASON_DIR}/mason link zlib 1.2.8
+    ${MASON_DIR}/mason install expat 2.1.0
+    ${MASON_DIR}/mason link expat 2.1.0
+    ${MASON_DIR}/mason install bzip 1.0.6
+    ${MASON_DIR}/mason link bzip 1.0.6
 }
 
 function mason_compile {

--- a/scripts/nasm/2.11.06/script.sh
+++ b/scripts/nasm/2.11.06/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=nasm
 MASON_VERSION=2.11.06
 MASON_LIB_FILE=bin/nasm
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/node/0.10.35/script.sh
+++ b/scripts/node/0.10.35/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=node
 MASON_VERSION=0.10.35
 MASON_LIB_FILE=bin/node
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then

--- a/scripts/node/0.10.36/script.sh
+++ b/scripts/node/0.10.36/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=node
 MASON_VERSION=0.10.36
 MASON_LIB_FILE=bin/node
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then

--- a/scripts/node/0.12.0/script.sh
+++ b/scripts/node/0.12.0/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=node
 MASON_VERSION=0.12.0
 MASON_LIB_FILE=bin/node
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then

--- a/scripts/nunicode/1.5.1/.travis.yml
+++ b/scripts/nunicode/1.5.1/.travis.yml
@@ -27,7 +27,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - if [[ $(uname -s) == 'Darwin' ]]; then brew install cmake; fi

--- a/scripts/nunicode/1.5.1/script.sh
+++ b/scripts/nunicode/1.5.1/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=1.5.1
 MASON_LIB_FILE=lib/libnu.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/nu.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/nunicode/1.6/.travis.yml
+++ b/scripts/nunicode/1.6/.travis.yml
@@ -29,7 +29,7 @@ before_install:
 - "if [[ `lsb_release -r` =~ '12.04' ]]; then sudo add-apt-repository --yes ppa:kubuntu-ppa/backports ; fi"
 - "if [[ ${TRAVIS_OS_NAME:-linux} = 'linux' ]]; then sudo apt-get update -y ; fi"
 - "if [[ ${TRAVIS_OS_NAME:-linux} = 'linux' ]]; then sudo apt-get -y install cmake ; fi"
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - if [[ $(uname -s) == 'Darwin' ]]; then brew install cmake; fi

--- a/scripts/nunicode/1.6/script.sh
+++ b/scripts/nunicode/1.6/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=1.6
 MASON_LIB_FILE=lib/libnu.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/nu.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download https://bitbucket.org/alekseyt/nunicode/get/1.6.tar.bz2 \

--- a/scripts/openssl/1.0.1l/script.sh
+++ b/scripts/openssl/1.0.1l/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=1.0.1l
 MASON_LIB_FILE=lib/libssl.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/openssl.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/openssl/1.0.1p/script.sh
+++ b/scripts/openssl/1.0.1p/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=1.0.1p
 MASON_LIB_FILE=lib/libssl.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/openssl.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/openssl/1.0.2/script.sh
+++ b/scripts/openssl/1.0.2/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=1.0.2
 MASON_LIB_FILE=lib/libssl.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/openssl.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/openssl/1.0.2d/script.sh
+++ b/scripts/openssl/1.0.2d/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=1.0.2d
 MASON_LIB_FILE=lib/libssl.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/openssl.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/openswr-mesa/11.0-openswr/script.sh
+++ b/scripts/openswr-mesa/11.0-openswr/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=11.0-openswr
 MASON_LIB_FILE=lib/libGL.so
 MASON_PKGCONFIG_FILE=lib/pkgconfig/gl.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/osm2pgsql/0.87.2/.travis.yml
+++ b/scripts/osm2pgsql/0.87.2/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/osm2pgsql/0.87.2/script.sh
+++ b/scripts/osm2pgsql/0.87.2/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=osm2pgsql
 MASON_VERSION=0.87.2
 MASON_LIB_FILE=bin/osm2pgsql
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -27,35 +27,35 @@ function mason_prepare_compile {
     fi
     REPLACE="$(pwd)"
     REPLACE=${REPLACE////\\/}
-    ${MASON_DIR:-~/.mason}/mason install boost 1.57.0
-    MASON_BOOST=$(${MASON_DIR:-~/.mason}/mason prefix boost 1.57.0)
+    ${MASON_DIR}/mason install boost 1.57.0
+    MASON_BOOST=$(${MASON_DIR}/mason prefix boost 1.57.0)
     MASON_BOOST_LIBS=$(pwd)/mason_packages/.link/lib
-    ${MASON_DIR:-~/.mason}/mason install boost_libsystem 1.57.0
-    ${MASON_DIR:-~/.mason}/mason link boost_libsystem 1.57.0
-    ${MASON_DIR:-~/.mason}/mason install boost_libthread 1.57.0
-    ${MASON_DIR:-~/.mason}/mason link boost_libthread 1.57.0
-    MASON_BOOST_SYSTEM=$(${MASON_DIR:-~/.mason}/mason prefix boost_libsystem 1.57.0)
-    ${MASON_DIR:-~/.mason}/mason install boost_libfilesystem 1.57.0
-    ${MASON_DIR:-~/.mason}/mason link boost_libfilesystem 1.57.0
-    ${MASON_DIR:-~/.mason}/mason install libxml2 2.9.2
-    MASON_XML2=$(${MASON_DIR:-~/.mason}/mason prefix libxml2 2.9.2)
+    ${MASON_DIR}/mason install boost_libsystem 1.57.0
+    ${MASON_DIR}/mason link boost_libsystem 1.57.0
+    ${MASON_DIR}/mason install boost_libthread 1.57.0
+    ${MASON_DIR}/mason link boost_libthread 1.57.0
+    MASON_BOOST_SYSTEM=$(${MASON_DIR}/mason prefix boost_libsystem 1.57.0)
+    ${MASON_DIR}/mason install boost_libfilesystem 1.57.0
+    ${MASON_DIR}/mason link boost_libfilesystem 1.57.0
+    ${MASON_DIR}/mason install libxml2 2.9.2
+    MASON_XML2=$(${MASON_DIR}/mason prefix libxml2 2.9.2)
     perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_XML2}/bin/xml2-config
-    ${MASON_DIR:-~/.mason}/mason install geos 3.4.2
-    MASON_GEOS=$(${MASON_DIR:-~/.mason}/mason prefix geos 3.4.2)
+    ${MASON_DIR}/mason install geos 3.4.2
+    MASON_GEOS=$(${MASON_DIR}/mason prefix geos 3.4.2)
     perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_GEOS}/bin/geos-config
-    ${MASON_DIR:-~/.mason}/mason install proj 4.8.0
-    MASON_PROJ=$(${MASON_DIR:-~/.mason}/mason prefix proj 4.8.0)
-    ${MASON_DIR:-~/.mason}/mason install bzip 1.0.6
-    MASON_BZIP=$(${MASON_DIR:-~/.mason}/mason prefix bzip 1.0.6)
+    ${MASON_DIR}/mason install proj 4.8.0
+    MASON_PROJ=$(${MASON_DIR}/mason prefix proj 4.8.0)
+    ${MASON_DIR}/mason install bzip 1.0.6
+    MASON_BZIP=$(${MASON_DIR}/mason prefix bzip 1.0.6)
     # depends on sudo apt-get install zlib1g-dev
-    ${MASON_DIR:-~/.mason}/mason install zlib system
-    MASON_ZLIB=$(${MASON_DIR:-~/.mason}/mason prefix zlib system)
-    ${MASON_DIR:-~/.mason}/mason install protobuf 2.6.1
-    MASON_PROTOBUF=$(${MASON_DIR:-~/.mason}/mason prefix protobuf 2.6.1)
-    ${MASON_DIR:-~/.mason}/mason install protobuf_c 1.1.0
-    MASON_PROTOBUF_C=$(${MASON_DIR:-~/.mason}/mason prefix protobuf_c 1.1.0)
-    ${MASON_DIR:-~/.mason}/mason install libpq 9.4.1
-    MASON_LIBPQ=$(${MASON_DIR:-~/.mason}/mason prefix libpq 9.4.1)
+    ${MASON_DIR}/mason install zlib system
+    MASON_ZLIB=$(${MASON_DIR}/mason prefix zlib system)
+    ${MASON_DIR}/mason install protobuf 2.6.1
+    MASON_PROTOBUF=$(${MASON_DIR}/mason prefix protobuf 2.6.1)
+    ${MASON_DIR}/mason install protobuf_c 1.1.0
+    MASON_PROTOBUF_C=$(${MASON_DIR}/mason prefix protobuf_c 1.1.0)
+    ${MASON_DIR}/mason install libpq 9.4.1
+    MASON_LIBPQ=$(${MASON_DIR}/mason prefix libpq 9.4.1)
 }
 
 function mason_compile {

--- a/scripts/osm2pgsql/0.88.1/.travis.yml
+++ b/scripts/osm2pgsql/0.88.1/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/osm2pgsql/0.88.1/script.sh
+++ b/scripts/osm2pgsql/0.88.1/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=osm2pgsql
 MASON_VERSION=0.88.1
 MASON_LIB_FILE=bin/osm2pgsql
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -27,38 +27,38 @@ function mason_prepare_compile {
     fi
     REPLACE="$(pwd)"
     REPLACE=${REPLACE////\\/}
-    ${MASON_DIR:-~/.mason}/mason install boost 1.57.0
-    MASON_BOOST=$(${MASON_DIR:-~/.mason}/mason prefix boost 1.57.0)
+    ${MASON_DIR}/mason install boost 1.57.0
+    MASON_BOOST=$(${MASON_DIR}/mason prefix boost 1.57.0)
     MASON_BOOST_LIBS=$(pwd)/mason_packages/.link/lib
-    ${MASON_DIR:-~/.mason}/mason install boost_libsystem 1.57.0
-    ${MASON_DIR:-~/.mason}/mason link boost_libsystem 1.57.0
-    ${MASON_DIR:-~/.mason}/mason install boost_libthread 1.57.0
-    ${MASON_DIR:-~/.mason}/mason link boost_libthread 1.57.0
-    MASON_BOOST_SYSTEM=$(${MASON_DIR:-~/.mason}/mason prefix boost_libsystem 1.57.0)
-    ${MASON_DIR:-~/.mason}/mason install boost_libfilesystem 1.57.0
-    ${MASON_DIR:-~/.mason}/mason link boost_libfilesystem 1.57.0
-    ${MASON_DIR:-~/.mason}/mason install libxml2 2.9.2
-    ${MASON_DIR:-~/.mason}/mason link libxml2 2.9.2
-    MASON_XML2=$(${MASON_DIR:-~/.mason}/mason prefix libxml2 2.9.2)
+    ${MASON_DIR}/mason install boost_libsystem 1.57.0
+    ${MASON_DIR}/mason link boost_libsystem 1.57.0
+    ${MASON_DIR}/mason install boost_libthread 1.57.0
+    ${MASON_DIR}/mason link boost_libthread 1.57.0
+    MASON_BOOST_SYSTEM=$(${MASON_DIR}/mason prefix boost_libsystem 1.57.0)
+    ${MASON_DIR}/mason install boost_libfilesystem 1.57.0
+    ${MASON_DIR}/mason link boost_libfilesystem 1.57.0
+    ${MASON_DIR}/mason install libxml2 2.9.2
+    ${MASON_DIR}/mason link libxml2 2.9.2
+    MASON_XML2=$(${MASON_DIR}/mason prefix libxml2 2.9.2)
     perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_XML2}/bin/xml2-config
-    ${MASON_DIR:-~/.mason}/mason install geos 3.4.2
-    ${MASON_DIR:-~/.mason}/mason link geos 3.4.2
+    ${MASON_DIR}/mason install geos 3.4.2
+    ${MASON_DIR}/mason link geos 3.4.2
     MASON_LINKED_HEADERS=$(pwd)/mason_packages/.link/include
-    MASON_GEOS=$(${MASON_DIR:-~/.mason}/mason prefix geos 3.4.2)
+    MASON_GEOS=$(${MASON_DIR}/mason prefix geos 3.4.2)
     perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_GEOS}/bin/geos-config
-    ${MASON_DIR:-~/.mason}/mason install proj 4.8.0
-    MASON_PROJ=$(${MASON_DIR:-~/.mason}/mason prefix proj 4.8.0)
-    ${MASON_DIR:-~/.mason}/mason install bzip 1.0.6
-    MASON_BZIP=$(${MASON_DIR:-~/.mason}/mason prefix bzip 1.0.6)
+    ${MASON_DIR}/mason install proj 4.8.0
+    MASON_PROJ=$(${MASON_DIR}/mason prefix proj 4.8.0)
+    ${MASON_DIR}/mason install bzip 1.0.6
+    MASON_BZIP=$(${MASON_DIR}/mason prefix bzip 1.0.6)
     # depends on sudo apt-get install zlib1g-dev
-    ${MASON_DIR:-~/.mason}/mason install zlib system
-    MASON_ZLIB=$(${MASON_DIR:-~/.mason}/mason prefix zlib system)
-    ${MASON_DIR:-~/.mason}/mason install protobuf 2.6.1
-    MASON_PROTOBUF=$(${MASON_DIR:-~/.mason}/mason prefix protobuf 2.6.1)
-    ${MASON_DIR:-~/.mason}/mason install protobuf_c 1.1.0
-    MASON_PROTOBUF_C=$(${MASON_DIR:-~/.mason}/mason prefix protobuf_c 1.1.0)
-    ${MASON_DIR:-~/.mason}/mason install libpq 9.4.1
-    MASON_LIBPQ=$(${MASON_DIR:-~/.mason}/mason prefix libpq 9.4.1)
+    ${MASON_DIR}/mason install zlib system
+    MASON_ZLIB=$(${MASON_DIR}/mason prefix zlib system)
+    ${MASON_DIR}/mason install protobuf 2.6.1
+    MASON_PROTOBUF=$(${MASON_DIR}/mason prefix protobuf 2.6.1)
+    ${MASON_DIR}/mason install protobuf_c 1.1.0
+    MASON_PROTOBUF_C=$(${MASON_DIR}/mason prefix protobuf_c 1.1.0)
+    ${MASON_DIR}/mason install libpq 9.4.1
+    MASON_LIBPQ=$(${MASON_DIR}/mason prefix libpq 9.4.1)
 }
 
 function mason_compile {

--- a/scripts/osmium-tool/1.0.0/.travis.yml
+++ b/scripts/osmium-tool/1.0.0/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/osmium-tool/1.0.0/script.sh
+++ b/scripts/osmium-tool/1.0.0/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=osmium-tool
 MASON_VERSION=1.0.0
 MASON_LIB_FILE=bin/osmium
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -24,20 +24,20 @@ function mason_prepare_compile {
     tar -xzf osmium.tar.gz
 
     cd $(dirname ${MASON_ROOT})
-    ${MASON_DIR:-~/.mason}/mason install boost 1.57.0
-    ${MASON_DIR:-~/.mason}/mason link boost 1.57.0
-    ${MASON_DIR:-~/.mason}/mason install boost_libprogram_options 1.57.0
-    ${MASON_DIR:-~/.mason}/mason link boost_libprogram_options 1.57.0
-    ${MASON_DIR:-~/.mason}/mason install protobuf 2.6.1
-    ${MASON_DIR:-~/.mason}/mason link protobuf 2.6.1
-    ${MASON_DIR:-~/.mason}/mason install zlib 1.2.8
-    ${MASON_DIR:-~/.mason}/mason link zlib 1.2.8
-    ${MASON_DIR:-~/.mason}/mason install expat 2.1.0
-    ${MASON_DIR:-~/.mason}/mason link expat 2.1.0
-    ${MASON_DIR:-~/.mason}/mason install osmpbf 1.3.3
-    ${MASON_DIR:-~/.mason}/mason link osmpbf 1.3.3
-    ${MASON_DIR:-~/.mason}/mason install bzip 1.0.6
-    ${MASON_DIR:-~/.mason}/mason link bzip 1.0.6
+    ${MASON_DIR}/mason install boost 1.57.0
+    ${MASON_DIR}/mason link boost 1.57.0
+    ${MASON_DIR}/mason install boost_libprogram_options 1.57.0
+    ${MASON_DIR}/mason link boost_libprogram_options 1.57.0
+    ${MASON_DIR}/mason install protobuf 2.6.1
+    ${MASON_DIR}/mason link protobuf 2.6.1
+    ${MASON_DIR}/mason install zlib 1.2.8
+    ${MASON_DIR}/mason link zlib 1.2.8
+    ${MASON_DIR}/mason install expat 2.1.0
+    ${MASON_DIR}/mason link expat 2.1.0
+    ${MASON_DIR}/mason install osmpbf 1.3.3
+    ${MASON_DIR}/mason link osmpbf 1.3.3
+    ${MASON_DIR}/mason install bzip 1.0.6
+    ${MASON_DIR}/mason link bzip 1.0.6
 }
 
 function mason_compile {

--- a/scripts/osmium-tool/1.3.0/.travis.yml
+++ b/scripts/osmium-tool/1.3.0/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/osmium-tool/1.3.0/script.sh
+++ b/scripts/osmium-tool/1.3.0/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=osmium-tool
 MASON_VERSION=1.3.0
 MASON_LIB_FILE=bin/osmium
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -24,20 +24,20 @@ function mason_prepare_compile {
     tar -xzf osmium.tar.gz
 
     cd $(dirname ${MASON_ROOT})
-    ${MASON_DIR:-~/.mason}/mason install boost 1.57.0
-    ${MASON_DIR:-~/.mason}/mason link boost 1.57.0
-    ${MASON_DIR:-~/.mason}/mason install boost_libprogram_options 1.57.0
-    ${MASON_DIR:-~/.mason}/mason link boost_libprogram_options 1.57.0
-    ${MASON_DIR:-~/.mason}/mason install protobuf 2.6.1
-    ${MASON_DIR:-~/.mason}/mason link protobuf 2.6.1
-    ${MASON_DIR:-~/.mason}/mason install zlib 1.2.8
-    ${MASON_DIR:-~/.mason}/mason link zlib 1.2.8
-    ${MASON_DIR:-~/.mason}/mason install expat 2.1.0
-    ${MASON_DIR:-~/.mason}/mason link expat 2.1.0
-    ${MASON_DIR:-~/.mason}/mason install osmpbf 1.3.3
-    ${MASON_DIR:-~/.mason}/mason link osmpbf 1.3.3
-    ${MASON_DIR:-~/.mason}/mason install bzip 1.0.6
-    ${MASON_DIR:-~/.mason}/mason link bzip 1.0.6
+    ${MASON_DIR}/mason install boost 1.57.0
+    ${MASON_DIR}/mason link boost 1.57.0
+    ${MASON_DIR}/mason install boost_libprogram_options 1.57.0
+    ${MASON_DIR}/mason link boost_libprogram_options 1.57.0
+    ${MASON_DIR}/mason install protobuf 2.6.1
+    ${MASON_DIR}/mason link protobuf 2.6.1
+    ${MASON_DIR}/mason install zlib 1.2.8
+    ${MASON_DIR}/mason link zlib 1.2.8
+    ${MASON_DIR}/mason install expat 2.1.0
+    ${MASON_DIR}/mason link expat 2.1.0
+    ${MASON_DIR}/mason install osmpbf 1.3.3
+    ${MASON_DIR}/mason link osmpbf 1.3.3
+    ${MASON_DIR}/mason install bzip 1.0.6
+    ${MASON_DIR}/mason link bzip 1.0.6
 }
 
 function mason_compile {

--- a/scripts/osmium-tool/latest/script.sh
+++ b/scripts/osmium-tool/latest/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=osmium-tool
 MASON_VERSION=latest
 MASON_LIB_FILE=bin/osmium
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     export MASON_BUILD_PATH=${MASON_ROOT}/.build/osmium-tool-latest
@@ -25,22 +25,22 @@ function mason_prepare_compile {
     mv osmcode-libosmium-* osmcode-libosmium-latest
 
     cd $(dirname ${MASON_ROOT})
-    ${MASON_DIR:-~/.mason}/mason install boost 1.57.0
-    ${MASON_DIR:-~/.mason}/mason link boost 1.57.0
-    ${MASON_DIR:-~/.mason}/mason install boost_libprogram_options 1.57.0
-    ${MASON_DIR:-~/.mason}/mason link boost_libprogram_options 1.57.0
-    ${MASON_DIR:-~/.mason}/mason install protobuf 2.6.1
-    ${MASON_DIR:-~/.mason}/mason link protobuf 2.6.1
-    ${MASON_DIR:-~/.mason}/mason install zlib 1.2.8
-    ${MASON_DIR:-~/.mason}/mason link zlib 1.2.8
-    ${MASON_DIR:-~/.mason}/mason install expat 2.1.0
-    ${MASON_DIR:-~/.mason}/mason link expat 2.1.0
-    ${MASON_DIR:-~/.mason}/mason install osmpbf 1.3.3
-    ${MASON_DIR:-~/.mason}/mason link osmpbf 1.3.3
-    ${MASON_DIR:-~/.mason}/mason install bzip2 1.0.6
-    ${MASON_DIR:-~/.mason}/mason link bzip2 1.0.6
-    ${MASON_DIR:-~/.mason}/mason install geos 3.5.0
-    ${MASON_DIR:-~/.mason}/mason link geos 3.5.0
+    ${MASON_DIR}/mason install boost 1.57.0
+    ${MASON_DIR}/mason link boost 1.57.0
+    ${MASON_DIR}/mason install boost_libprogram_options 1.57.0
+    ${MASON_DIR}/mason link boost_libprogram_options 1.57.0
+    ${MASON_DIR}/mason install protobuf 2.6.1
+    ${MASON_DIR}/mason link protobuf 2.6.1
+    ${MASON_DIR}/mason install zlib 1.2.8
+    ${MASON_DIR}/mason link zlib 1.2.8
+    ${MASON_DIR}/mason install expat 2.1.0
+    ${MASON_DIR}/mason link expat 2.1.0
+    ${MASON_DIR}/mason install osmpbf 1.3.3
+    ${MASON_DIR}/mason link osmpbf 1.3.3
+    ${MASON_DIR}/mason install bzip2 1.0.6
+    ${MASON_DIR}/mason link bzip2 1.0.6
+    ${MASON_DIR}/mason install geos 3.5.0
+    ${MASON_DIR}/mason link geos 3.5.0
 }
 
 function mason_compile {

--- a/scripts/osmpbf/1.3.3/script.sh
+++ b/scripts/osmpbf/1.3.3/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=osmpbf
 MASON_VERSION=1.3.3
 MASON_LIB_FILE=lib/libosmpbf.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -18,8 +18,8 @@ function mason_load_source {
 
 function mason_prepare_compile {
     cd $(dirname ${MASON_ROOT})
-    ${MASON_DIR:-~/.mason}/mason install protobuf 2.6.1
-    ${MASON_DIR:-~/.mason}/mason link protobuf 2.6.1
+    ${MASON_DIR}/mason install protobuf 2.6.1
+    ${MASON_DIR}/mason link protobuf 2.6.1
 }
 
 function mason_compile {

--- a/scripts/osrm/0.4.1/.travis.yml
+++ b/scripts/osrm/0.4.1/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/osrm/0.4.1/script.sh
+++ b/scripts/osrm/0.4.1/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=osrm
 MASON_VERSION=0.4.1
 MASON_LIB_FILE=lib/libOSRM.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -17,8 +17,8 @@ function mason_load_source {
 }
 
 function dep() {
-    ${MASON_DIR:-~/.mason}/mason install $1 $2
-    ${MASON_DIR:-~/.mason}/mason link $1 $2
+    ${MASON_DIR}/mason install $1 $2
+    ${MASON_DIR}/mason link $1 $2
 }
 
 function all_deps() {

--- a/scripts/parallel/20160422/script.sh
+++ b/scripts/parallel/20160422/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=parallel
 MASON_VERSION=20160422
 MASON_LIB_FILE=bin/parallel
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/pixelmatch/0.9.0/script.sh
+++ b/scripts/pixelmatch/0.9.0/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=pixelmatch
 MASON_VERSION=0.9.0
 MASON_HEADER_ONLY=true
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/pixman/0.32.6/script.sh
+++ b/scripts/pixman/0.32.6/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=pixman
 MASON_VERSION=0.32.6
 MASON_LIB_FILE=lib/libpixman-1.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/postgis/2.2.2/script.sh
+++ b/scripts/postgis/2.2.2/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=postgis
 MASON_VERSION=2.2.2
 MASON_LIB_FILE=bin/shp2pgsql
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -17,14 +17,14 @@ function mason_load_source {
 
 function mason_prepare_compile {
     cd $(dirname ${MASON_ROOT})
-    ${MASON_DIR:-~/.mason}/mason install postgres 9.5.2
-    MASON_POSTGRES=$(${MASON_DIR:-~/.mason}/mason prefix postgres 9.5.2)
-    ${MASON_DIR:-~/.mason}/mason install proj 4.9.2
-    MASON_PROJ=$(${MASON_DIR:-~/.mason}/mason prefix proj 4.9.2)
-    ${MASON_DIR:-~/.mason}/mason install libxml2 2.9.3
-    MASON_XML2=$(${MASON_DIR:-~/.mason}/mason prefix libxml2 2.9.3)
-    ${MASON_DIR:-~/.mason}/mason install geos 3.5.0
-    MASON_GEOS=$(${MASON_DIR:-~/.mason}/mason prefix geos 3.5.0)
+    ${MASON_DIR}/mason install postgres 9.5.2
+    MASON_POSTGRES=$(${MASON_DIR}/mason prefix postgres 9.5.2)
+    ${MASON_DIR}/mason install proj 4.9.2
+    MASON_PROJ=$(${MASON_DIR}/mason prefix proj 4.9.2)
+    ${MASON_DIR}/mason install libxml2 2.9.3
+    MASON_XML2=$(${MASON_DIR}/mason prefix libxml2 2.9.3)
+    ${MASON_DIR}/mason install geos 3.5.0
+    MASON_GEOS=$(${MASON_DIR}/mason prefix geos 3.5.0)
     if [[ $(uname -s) == 'Darwin' ]]; then
         FIND="\/Users\/travis\/build\/mapbox\/mason"
     else
@@ -39,26 +39,26 @@ function mason_prepare_compile {
     perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_GEOS}/lib/libgeos_c.la
     perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_GEOS}/bin/geos-config
 
-    ${MASON_DIR:-~/.mason}/mason install gdal 2.0.2
-    MASON_GDAL=$(${MASON_DIR:-~/.mason}/mason prefix gdal 2.0.2)
+    ${MASON_DIR}/mason install gdal 2.0.2
+    MASON_GDAL=$(${MASON_DIR}/mason prefix gdal 2.0.2)
     ln -sf ${MASON_GDAL}/include ${MASON_GDAL}/include/gdal
     perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_GDAL}/lib/libgdal.la
-    ${MASON_DIR:-~/.mason}/mason install libtiff 4.0.6
-    MASON_TIFF=$(${MASON_DIR:-~/.mason}/mason prefix libtiff 4.0.6)
+    ${MASON_DIR}/mason install libtiff 4.0.6
+    MASON_TIFF=$(${MASON_DIR}/mason prefix libtiff 4.0.6)
     perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_TIFF}/lib/libtiff.la
-    ${MASON_DIR:-~/.mason}/mason install jpeg_turbo 1.4.2
-    MASON_JPEG=$(${MASON_DIR:-~/.mason}/mason prefix jpeg_turbo 1.4.2)
+    ${MASON_DIR}/mason install jpeg_turbo 1.4.2
+    MASON_JPEG=$(${MASON_DIR}/mason prefix jpeg_turbo 1.4.2)
     perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_JPEG}/lib/libjpeg.la
-    ${MASON_DIR:-~/.mason}/mason install libpng 1.6.21
-    MASON_PNG=$(${MASON_DIR:-~/.mason}/mason prefix libpng 1.6.21)
+    ${MASON_DIR}/mason install libpng 1.6.21
+    MASON_PNG=$(${MASON_DIR}/mason prefix libpng 1.6.21)
     perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_PNG}/lib/libpng.la
-    ${MASON_DIR:-~/.mason}/mason install expat 2.1.1
-    MASON_EXPAT=$(${MASON_DIR:-~/.mason}/mason prefix expat 2.1.1)
+    ${MASON_DIR}/mason install expat 2.1.1
+    MASON_EXPAT=$(${MASON_DIR}/mason prefix expat 2.1.1)
     perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_EXPAT}/lib/libexpat.la
-    ${MASON_DIR:-~/.mason}/mason install zlib system
-    MASON_ZLIB=$(${MASON_DIR:-~/.mason}/mason prefix zlib system)
-    #${MASON_DIR:-~/.mason}/mason install iconv system
-    #MASON_ICONV=$(${MASON_DIR:-~/.mason}/mason prefix iconv system)
+    ${MASON_DIR}/mason install zlib system
+    MASON_ZLIB=$(${MASON_DIR}/mason prefix zlib system)
+    #${MASON_DIR}/mason install iconv system
+    #MASON_ICONV=$(${MASON_DIR}/mason prefix iconv system)
 }
 
 function mason_compile {

--- a/scripts/postgres/9.5.2/script.sh
+++ b/scripts/postgres/9.5.2/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=postgres
 MASON_VERSION=9.5.2
 MASON_LIB_FILE=bin/psql
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/proj/4.8.0/script.sh
+++ b/scripts/proj/4.8.0/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=4.8.0
 MASON_LIB_FILE=lib/libproj.a
 #MASON_PKGCONFIG_FILE=lib/pkgconfig/proj.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/proj/4.9.2/script.sh
+++ b/scripts/proj/4.9.2/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=proj
 MASON_VERSION=4.9.2
 MASON_LIB_FILE=lib/libproj.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/protobuf/2.6.1/script.sh
+++ b/scripts/protobuf/2.6.1/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=2.6.1
 MASON_LIB_FILE=lib/libprotobuf-lite.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/protobuf-lite.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/protobuf_c/1.1.0/script.sh
+++ b/scripts/protobuf_c/1.1.0/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=1.1.0
 MASON_LIB_FILE=lib/libprotobuf-c.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/protobuf-c.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -19,8 +19,8 @@ function mason_load_source {
 
 function mason_prepare_compile {
     cd $(dirname ${MASON_ROOT})
-    ${MASON_DIR:-~/.mason}/mason install protobuf 2.6.1
-    MASON_PROTOBUF=$(${MASON_DIR:-~/.mason}/mason prefix protobuf 2.6.1)
+    ${MASON_DIR}/mason install protobuf 2.6.1
+    MASON_PROTOBUF=$(${MASON_DIR}/mason prefix protobuf 2.6.1)
     export PKG_CONFIG_PATH=${MASON_PROTOBUF}/lib/pkgconfig:${PKG_CONFIG_PATH}
 }
 

--- a/scripts/protozero/1.3.0/script.sh
+++ b/scripts/protozero/1.3.0/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=protozero
 MASON_VERSION=1.3.0
 MASON_HEADER_ONLY=true
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/ragel/6.9/script.sh
+++ b/scripts/ragel/6.9/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=ragel
 MASON_VERSION=6.9
 MASON_LIB_FILE=bin/ragel
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/rapidjson/1.0.2/script.sh
+++ b/scripts/rapidjson/1.0.2/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=rapidjson
 MASON_VERSION=1.0.2
 MASON_HEADER_ONLY=true
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/shelf-pack/1.0.0/script.sh
+++ b/scripts/shelf-pack/1.0.0/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=shelf-pack
 MASON_VERSION=1.0.0
 MASON_HEADER_ONLY=true
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/sparsehash/2.0.2/.travis.yml
+++ b/scripts/sparsehash/2.0.2/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/sparsehash/2.0.2/script.sh
+++ b/scripts/sparsehash/2.0.2/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=sparsehash
 MASON_VERSION=2.0.2
 MASON_HEADER_ONLY=true
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/sqlite/3.8.10.2/script.sh
+++ b/scripts/sqlite/3.8.10.2/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=3.8.10.2
 MASON_LIB_FILE=lib/libsqlite3.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/sqlite3.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/sqlite/3.8.8.1/script.sh
+++ b/scripts/sqlite/3.8.8.1/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=3.8.8.1
 MASON_LIB_FILE=lib/libsqlite3.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/sqlite3.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/sqlite/3.8.8.3/script.sh
+++ b/scripts/sqlite/3.8.8.3/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=3.8.8.3
 MASON_LIB_FILE=lib/libsqlite3.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/sqlite3.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/sqlite/3.9.1/script.sh
+++ b/scripts/sqlite/3.9.1/script.sh
@@ -7,7 +7,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/sqlite3.pc
 
 SQLITE_FILE_VERSION=3090100
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/sqlite/system/script.sh
+++ b/scripts/sqlite/system/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=sqlite
 MASON_VERSION=system
 MASON_SYSTEM_PACKAGE=true
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 
 if [[ ${MASON_PLATFORM} = 'android' ]]; then

--- a/scripts/stxxl/1.4.1/.travis.yml
+++ b/scripts/stxxl/1.4.1/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/stxxl/1.4.1/script.sh
+++ b/scripts/stxxl/1.4.1/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=stxxl
 MASON_VERSION=1.4.1
 MASON_LIB_FILE=lib/libstxxl.a
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/stxxl_shared/1.4.1/.travis.yml
+++ b/scripts/stxxl_shared/1.4.1/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/stxxl_shared/1.4.1/script.sh
+++ b/scripts/stxxl_shared/1.4.1/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=stxxl_shared
 MASON_VERSION=1.4.1
 MASON_LIB_FILE=lib/libstxxl.${MASON_DYNLIB_SUFFIX}
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/tbb/43_20150316/.travis.yml
+++ b/scripts/tbb/43_20150316/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/tbb/43_20150316/script.sh
+++ b/scripts/tbb/43_20150316/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=tbb
 MASON_VERSION=43_20150316
 MASON_LIB_FILE=bin/tbb
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/tbb/44_20151115/.travis.yml
+++ b/scripts/tbb/44_20151115/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/tbb/44_20151115/script.sh
+++ b/scripts/tbb/44_20151115/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=tbb
 MASON_VERSION=44_20151115
 MASON_LIB_FILE=bin/tbb
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/tbb/44_20160128/.travis.yml
+++ b/scripts/tbb/44_20160128/.travis.yml
@@ -15,7 +15,7 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 before_install:
-- source ~/.mason/scripts/setup_cpp11_toolchain.sh
+- source ./scripts/setup_cpp11_toolchain.sh
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/tbb/44_20160128/script.sh
+++ b/scripts/tbb/44_20160128/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=tbb
 MASON_VERSION=44_20160128
 MASON_LIB_FILE=bin/tbb
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/tippecanoe/1.9.7/script.sh
+++ b/scripts/tippecanoe/1.9.7/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=tippecanoe
 MASON_VERSION=1.9.7
 MASON_LIB_FILE=bin/tippecanoe
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
@@ -18,10 +18,10 @@ function mason_load_source {
 
 function mason_prepare_compile {
     cd $(dirname ${MASON_ROOT})
-    ${MASON_DIR:-~/.mason}/mason install protobuf 2.6.1
-    ${MASON_DIR:-~/.mason}/mason link protobuf 2.6.1
-    ${MASON_DIR:-~/.mason}/mason install sqlite 3.9.1
-    ${MASON_DIR:-~/.mason}/mason link sqlite 3.9.1
+    ${MASON_DIR}/mason install protobuf 2.6.1
+    ${MASON_DIR}/mason link protobuf 2.6.1
+    ${MASON_DIR}/mason install sqlite 3.9.1
+    ${MASON_DIR}/mason link sqlite 3.9.1
 }
 
 function mason_compile {

--- a/scripts/tippecanoe/latest/script.sh
+++ b/scripts/tippecanoe/latest/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=tippecanoe
 MASON_VERSION=latest
 MASON_LIB_FILE=bin/tippecanoe
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     export MASON_BUILD_PATH=${MASON_ROOT}/.build/tippecanoe-latest
@@ -17,10 +17,10 @@ function mason_load_source {
 
 function mason_prepare_compile {
     cd $(dirname ${MASON_ROOT})
-    ${MASON_DIR:-~/.mason}/mason install protobuf 2.6.1
-    ${MASON_DIR:-~/.mason}/mason link protobuf 2.6.1
-    ${MASON_DIR:-~/.mason}/mason install sqlite 3.9.1
-    ${MASON_DIR:-~/.mason}/mason link sqlite 3.9.1
+    ${MASON_DIR}/mason install protobuf 2.6.1
+    ${MASON_DIR}/mason link protobuf 2.6.1
+    ${MASON_DIR}/mason install sqlite 3.9.1
+    ${MASON_DIR}/mason link sqlite 3.9.1
 }
 
 function mason_compile {

--- a/scripts/utfcpp/2.3.4/script.sh
+++ b/scripts/utfcpp/2.3.4/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=utfcpp
 MASON_VERSION=2.3.4
 MASON_HEADER_ONLY=true
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/variant/1.0/script.sh
+++ b/scripts/variant/1.0/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=variant
 MASON_VERSION=1.0
 MASON_HEADER_ONLY=true
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/variant/1.1.0/script.sh
+++ b/scripts/variant/1.1.0/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=variant
 MASON_VERSION=1.1.0
 MASON_HEADER_ONLY=true
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/webp/0.4.2/script.sh
+++ b/scripts/webp/0.4.2/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=0.4.2
 MASON_LIB_FILE=lib/libwebp.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/libwebp.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/webp/0.5.0/script.sh
+++ b/scripts/webp/0.5.0/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=0.5.0
 MASON_LIB_FILE=lib/libwebp.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/libwebp.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/zip/3.0.0/script.sh
+++ b/scripts/zip/3.0.0/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=zip
 MASON_VERSION=3.0.0
 MASON_LIB_FILE=bin/zip
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/zlib/1.2.8/script.sh
+++ b/scripts/zlib/1.2.8/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=1.2.8
 MASON_LIB_FILE=lib/libz.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/zlib.pc
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \

--- a/scripts/zlib/system/script.sh
+++ b/scripts/zlib/system/script.sh
@@ -4,7 +4,7 @@ MASON_NAME=zlib
 MASON_VERSION=system
 MASON_SYSTEM_PACKAGE=true
 
-. ${MASON_DIR:-~/.mason}/mason.sh
+. ${MASON_DIR}/mason.sh
 
 
 if [[ ${MASON_PLATFORM} = 'ios' ]]; then

--- a/scripts/zlib/system/test.sh
+++ b/scripts/zlib/system/test.sh
@@ -94,7 +94,7 @@ function check_shared_lib_info() {
             readelf -d $resolved
         elif [[ ${MASON_PLATFORM} == 'android' ]]; then
             FILE_DETAILS=$(file $resolved)
-            MASON_ANDROID_ARCH=$(~/.mason/mason env MASON_ANDROID_ARCH)
+            MASON_ANDROID_ARCH=$(${MASON_DIR}/mason env MASON_ANDROID_ARCH)
             if [[ ${MASON_ANDROID_ARCH} =~ "64" ]]; then
                 if [[ ${FILE_DETAILS} =~ "64-bit" ]]; then
                     echo "ok: ${MASON_ANDROID_ARCH} 64-bit arch (for ${MASON_ANDROID_ABI}) expected and detected in $FILE_DETAILS"
@@ -108,7 +108,7 @@ function check_shared_lib_info() {
                     CODE=1
                 fi
             fi
-            BIN_PATH=$(~/.mason/mason env MASON_SDK_ROOT)/bin
+            BIN_PATH=$(${MASON_DIR}/mason env MASON_SDK_ROOT)/bin
             MASON_ANDROID_TOOLCHAIN=$(${MASON_DIR}/mason env MASON_ANDROID_TOOLCHAIN)
             ${BIN_PATH}/${MASON_ANDROID_TOOLCHAIN}-readelf -d $resolved
         fi

--- a/scripts/zlib/system/test.sh
+++ b/scripts/zlib/system/test.sh
@@ -66,8 +66,8 @@ function check_file_links() {
                     expected_keyword="/usr/include/"
                 fi
             elif [[ ${MASON_PLATFORM} == 'android' ]]; then
-                MASON_ANDROID_ABI=$(${MASON_DIR:-~/.mason}/mason env MASON_ANDROID_ABI)
-                MASON_NDK_PACKAGE_VERSION=$(${MASON_DIR:-~/.mason}/mason env MASON_NDK_PACKAGE_VERSION)
+                MASON_ANDROID_ABI=$(${MASON_DIR}/mason env MASON_ANDROID_ABI)
+                MASON_NDK_PACKAGE_VERSION=$(${MASON_DIR}/mason env MASON_NDK_PACKAGE_VERSION)
                 expected_keyword="android-ndk/${MASON_NDK_PACKAGE_VERSION}"
             fi
             if [[ "$resolved" =~ "${expected_keyword}" ]]; then
@@ -109,7 +109,7 @@ function check_shared_lib_info() {
                 fi
             fi
             BIN_PATH=$(~/.mason/mason env MASON_SDK_ROOT)/bin
-            MASON_ANDROID_TOOLCHAIN=$(${MASON_DIR:-~/.mason}/mason env MASON_ANDROID_TOOLCHAIN)
+            MASON_ANDROID_TOOLCHAIN=$(${MASON_DIR}/mason env MASON_ANDROID_TOOLCHAIN)
             ${BIN_PATH}/${MASON_ANDROID_TOOLCHAIN}-readelf -d $resolved
         fi
 
@@ -124,9 +124,9 @@ if [[ $MASON_PLATFORM != 'ios' ]]; then
     check_ldflags
     check_file_links "include/zlib.h"
     check_file_links "include/zconf.h"
-    check_file_links "lib/libz.$(${MASON_DIR:-~/.mason}/mason env MASON_DYNLIB_SUFFIX)"
+    check_file_links "lib/libz.$(${MASON_DIR}/mason env MASON_DYNLIB_SUFFIX)"
     if [[ ${CODE} == 0 ]]; then
-        check_shared_lib_info "lib/libz.$(${MASON_DIR:-~/.mason}/mason env MASON_DYNLIB_SUFFIX)"
+        check_shared_lib_info "lib/libz.$(${MASON_DIR}/mason env MASON_DYNLIB_SUFFIX)"
     else
         echo "Error already occured so skipping shared library test"
     fi


### PR DESCRIPTION
Work toward #140 / #141.

This is mostly rote search and replace. See individual commits for details.

Remaining `~/.mason` stragglers:

* [x] README.md
* [x] [selfupdate](https://github.com/mapbox/mason/blob/30ce49507e0bfc6a7d52c2fc898692416436ac98/mason#L23-L23) -- should we remove this command?
* [x] postgis 2.1.5 and 2.1.7 test.sh. I see this has been fixed in 2.2.2. Prune the older versions?
* [x] postgres 9.4.0, 9.4.1, 9.5.2 test.sh.
* [x] zlib system test.sh.