### PR TITLE
Introduce [suffix] optional parameter

### DIFF
--- a/mason
+++ b/mason
@@ -3,12 +3,13 @@
 MASON_COMMAND=$1 ; shift
 MASON_NAME=$1 ; shift
 MASON_VERSION=$1 ; shift
+MASON_SUFFIX=$1 ; shift
 
 set -e
 set -o pipefail
 
 function usage {
-    echo "Usage: $0 <command> <lib> <version>"
+    echo "Usage: $0 <command> <lib> <version> [suffix]"
 }
 
 if [ -z "${MASON_COMMAND}" ]; then
@@ -37,6 +38,10 @@ elif [ -z "${MASON_VERSION}" ]; then
     usage
     echo "Missing <version>"
     exit 1
+fi
+
+if [ ! -z "${MASON_SUFFIX}" ]; then
+    export MASON_SUFFIX="-${MASON_SUFFIX}"
 fi
 
 if [ "${MASON_COMMAND}" = "trigger" ]; then

--- a/mason.sh
+++ b/mason.sh
@@ -246,8 +246,9 @@ if [[ ${MASON_HEADER_ONLY} == true ]]; then
 else
     MASON_PLATFORM_ID=${MASON_PLATFORM}-${MASON_PLATFORM_VERSION}
 fi
-MASON_PREFIX=${MASON_ROOT}/${MASON_PLATFORM_ID}/${MASON_NAME}/${MASON_VERSION}
-MASON_BINARIES=${MASON_PLATFORM_ID}/${MASON_NAME}/${MASON_VERSION}.tar.gz
+MASON_SUFFIX=${MASON_SUFFIX:-}
+MASON_PREFIX=${MASON_ROOT}/${MASON_PLATFORM_ID}/${MASON_NAME}/${MASON_VERSION}${MASON_SUFFIX}
+MASON_BINARIES=${MASON_PLATFORM_ID}/${MASON_NAME}/${MASON_VERSION}${MASON_SUFFIX}.tar.gz
 MASON_BINARIES_PATH=${MASON_ROOT}/.binaries/${MASON_BINARIES}
 
 
@@ -557,7 +558,7 @@ function mason_version {
 
 function mason_list_existing_package {
     local PREFIX=$1
-    local RESULT=$(aws s3api head-object --bucket mason-binaries --key $PREFIX/$MASON_NAME/$MASON_VERSION.tar.gz 2>/dev/null)
+    local RESULT=$(aws s3api head-object --bucket mason-binaries --key ${PREFIX}/${MASON_NAME}/${MASON_VERSION}${MASON_SUFFIX}.tar.gz 2>/dev/null)
     if [ ! -z "${RESULT}" ]; then
         printf "%-30s %6.1fM    %s\n" \
             "${PREFIX}" \


### PR DESCRIPTION
Append a suffix on any package, so you can build/install
different binaries of packages with the same version like:
```
foobar-1.0-cxx11abi
foobar-1.0-gcc4.9
foobar-1.0-patch1
foobar-1.0-whatever
```
Normal usage remains:
```
$ mason build foobar 1.0
$ mason publish foobar 1.0
```
Or:
```
$ mason build foobar 1.0 cxx11abi
$ mason publish foobar 1.0 cxx11abi
```
Fixes #157