### PR TITLE
add leveldb@1.18

### DIFF
--- a/scripts/leveldb/1.18/.travis.yml
+++ b/scripts/leveldb/1.18/.travis.yml
@@ -1,0 +1,22 @@
+language: cpp
+
+sudo: false
+
+matrix:
+  include:
+    - os: osx
+      compiler: clang
+    - os: linux
+      compiler: clang
+
+env:
+  global:
+   - secure: "clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFnWLtmF3stlft5YWyc2kI+FI="
+   - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason link ${MASON_NAME} ${MASON_VERSION}
+
+after_success:
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/leveldb/1.18/script.sh
+++ b/scripts/leveldb/1.18/script.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+MASON_NAME=leveldb
+MASON_VERSION=1.18
+MASON_HEADER_ONLY=true
+
+. ${MASON_DIR:-~/.mason}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        https://github.com/google/leveldb/tarball/v${MASON_VERSION} \
+        803d69203a62faf50f1b77897310a3a1fcae712b
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/leveldb-${MASON_VERSION} 
+}
+
+function mason_compile {
+    mkdir -p ${MASON_PREFIX}/include/
+    cp -r include/leveldb ${MASON_PREFIX}/include/leveldb
+}
+
+mason_run "$@"

--- a/scripts/leveldb/1.18/script.sh
+++ b/scripts/leveldb/1.18/script.sh
@@ -8,8 +8,8 @@ MASON_HEADER_ONLY=true
 
 function mason_load_source {
     mason_download \
-        https://github.com/google/leveldb/tarball/v${MASON_VERSION} \
-        803d69203a62faf50f1b77897310a3a1fcae712b
+        https://github.com/google/leveldb/archive/v${MASON_VERSION}.tar.gz \
+        d90b5cadb7a366a2ab27ec8b5ed1ea9445c9a2df
 
     mason_extract_tar_gz
 


### PR DESCRIPTION
This PR adds [leveldb](https://github.com/google/leveldb) as a header-only library. This is my first time publishing a mason lib, so I would love to get a review when you have a minute @springmeyer to make sure I am doing this correctly.

cc @rclark 