### PR TITLE
Fixing error when mason is a symlink

### DIFF
--- a/mason
+++ b/mason
@@ -16,7 +16,9 @@ if [ -z "${MASON_COMMAND}" ]; then
     exit 1
 fi
 
-ROOTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+REAL_PATH=$(readlink -f ${BASH_SOURCE[0]} 2>/dev/null || echo ${BASH_SOURCE[0]} )
+
+ROOTDIR="$( cd "$( dirname "$REAL_PATH" )" > /dev/null && pwd )"
 MASON_DIR=${MASON_DIR:-$ROOTDIR}
 
 if [ "${MASON_COMMAND}" = "env" ]; then


### PR DESCRIPTION
At last on Fedora, ROOTDIR var ends up in /usr/local/bin when mason
is a symlink, and then it fails to call other sub-scripts.

In case readlink fails, it uses BASH_SOURCE[0] as fallback.

* It's tested on Linux, I don't own a OSX machine to test it there...