### PR TITLE
clang-3.8

### DIFF
--- a/scripts/clang/3.8.0/.travis.yml
+++ b/scripts/clang/3.8.0/.travis.yml
@@ -15,7 +15,7 @@ matrix:
           packages:
            - libstdc++6
            - cmake
-           - ninja
+           - ninja-build
 
 env:
   global:

--- a/scripts/clang/3.8.0/.travis.yml
+++ b/scripts/clang/3.8.0/.travis.yml
@@ -14,6 +14,8 @@ matrix:
            - ubuntu-toolchain-r-test
           packages:
            - libstdc++6
+           - cmake
+           - ninja
 
 env:
   global:

--- a/scripts/clang/3.8.0/.travis.yml
+++ b/scripts/clang/3.8.0/.travis.yml
@@ -1,0 +1,27 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode7.3
+      compiler: clang
+    - os: linux
+      compiler: clang
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++6
+
+env:
+  global:
+   - secure: "clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFnWLtmF3stlft5YWyc2kI+FI="
+   - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+
+after_success:
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/clang/3.8.0/.travis.yml
+++ b/scripts/clang/3.8.0/.travis.yml
@@ -6,7 +6,8 @@ matrix:
       osx_image: xcode7.3
       compiler: clang
     - os: linux
-      compiler: clang
+      compiler: gcc
+      env: CXX=gcc++-5 CC=gcc-5
       sudo: false
       addons:
         apt:
@@ -15,6 +16,7 @@ matrix:
           packages:
            - libstdc++6
            - ninja-build
+           - g++-5
 
 env:
   global:

--- a/scripts/clang/3.8.0/.travis.yml
+++ b/scripts/clang/3.8.0/.travis.yml
@@ -14,7 +14,6 @@ matrix:
            - ubuntu-toolchain-r-test
           packages:
            - libstdc++6
-           - cmake
            - ninja-build
 
 env:
@@ -23,6 +22,8 @@ env:
    - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 script:
+- ./mason install cmake 3.5.2
+- export PATH=$(./mason prefix cmake 3.5.2)/bin:${PATH}
 - ./mason build ${MASON_NAME} ${MASON_VERSION}
 
 after_success:

--- a/scripts/clang/3.8.0/script.sh
+++ b/scripts/clang/3.8.0/script.sh
@@ -85,7 +85,7 @@ function mason_compile {
      -DCMAKE_CXX_FLAGS_RELEASE="${CXXFLAGS}" \
      -DLLVM_OPTIMIZED_TABLEGEN=ON \
      ${CMAKE_EXTRA_ARGS}
-    ninja -j${JOBS} -k5
+    ninja -j${MASON_CONCURRENCY} -k5
     ninja install -k5
 }
 

--- a/scripts/clang/3.8.0/script.sh
+++ b/scripts/clang/3.8.0/script.sh
@@ -68,6 +68,7 @@ function mason_compile {
     mkdir -p ./build
     cd ./build
     CMAKE_EXTRA_ARGS=""
+    ## TODO: CLANG_DEFAULT_CXX_STDLIB and CLANG_APPEND_VC_REV not available in clang-3.8 cmake files
     if [[ $(uname -s) == 'Darwin' ]]; then
         CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DCLANG_DEFAULT_CXX_STDLIB=libc++"
         CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DC_INCLUDE_DIRS=:/usr/include:/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/"
@@ -86,9 +87,6 @@ function mason_compile {
      ${CMAKE_EXTRA_ARGS}
     ninja -j${JOBS} -k5
     ninja install -k5
-    # manual install of tools that don't get installed right
-    cp build/Release/bin/include-what-you-use ${MASON_PREFIX}/bin
-
 }
 
 function mason_cflags {

--- a/scripts/clang/3.8.0/script.sh
+++ b/scripts/clang/3.8.0/script.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+
+MASON_NAME=clang
+MASON_VERSION=3.8.0
+MASON_LIB_FILE=bin/clang
+
+. ${MASON_DIR}/mason.sh
+
+
+# options
+ENABLE_LLDB=false
+
+function curl_get() {
+    if [ ! -f $(basename ${1}) ] ; then
+        mason_step "Downloading $1 to $(pwd)/$(basename ${1})"
+        curl --retry 3 -f -L -O "$1"
+    else
+        echo "already downloaded $1 to $(pwd)/$(basename ${1})"
+    fi
+}
+
+function setup_release() {
+    LLVM_RELEASE=$1
+    BUILD_PATH=$2
+    curl_get "http://llvm.org/releases/${LLVM_RELEASE}/llvm-${LLVM_RELEASE}.src.tar.xz"
+    curl_get "http://llvm.org/releases/${LLVM_RELEASE}/cfe-${LLVM_RELEASE}.src.tar.xz"
+    curl_get "http://llvm.org/releases/${LLVM_RELEASE}/compiler-rt-${LLVM_RELEASE}.src.tar.xz"
+    curl_get "http://llvm.org/releases/${LLVM_RELEASE}/libcxx-${LLVM_RELEASE}.src.tar.xz"
+    curl_get "http://llvm.org/releases/${LLVM_RELEASE}/libcxxabi-${LLVM_RELEASE}.src.tar.xz"
+    curl_get "http://llvm.org/releases/${LLVM_RELEASE}/libunwind-${LLVM_RELEASE}.src.tar.xz"
+    curl_get "http://llvm.org/releases/${LLVM_RELEASE}/lld-${LLVM_RELEASE}.src.tar.xz"
+    if [[ ${ENABLE_LLDB} == true ]]; then
+        curl_get "http://llvm.org/releases/${LLVM_RELEASE}/lldb-${LLVM_RELEASE}.src.tar.xz"
+    fi
+    curl_get "http://llvm.org/releases/${LLVM_RELEASE}/openmp-${LLVM_RELEASE}.src.tar.xz"
+    curl_get "http://llvm.org/releases/${LLVM_RELEASE}/clang-tools-extra-${LLVM_RELEASE}.src.tar.xz"
+    for i in $(ls *.xz); do
+        echo "unpacking $i"
+        tar xf $i;
+    done
+    mv llvm-${LLVM_RELEASE}.src/* ${BUILD_PATH}/
+    ls ${BUILD_PATH}/
+    mv cfe-${LLVM_RELEASE}.src ${BUILD_PATH}/tools/clang
+    mv compiler-rt-${LLVM_RELEASE}.src ${BUILD_PATH}/projects/compiler-rt
+    mv libcxx-${LLVM_RELEASE}.src ${BUILD_PATH}/projects/libcxx
+    mv libcxxabi-${LLVM_RELEASE}.src ${BUILD_PATH}/projects/libcxxabi
+    mv libunwind-${LLVM_RELEASE}.src ${BUILD_PATH}/projects/libunwind
+    mv lld-${LLVM_RELEASE}.src ${BUILD_PATH}/tools/lld
+    if [[ ${ENABLE_LLDB} == true ]]; then
+        mv lldb-${LLVM_RELEASE}.src ${BUILD_PATH}/tools/lldb
+    fi
+    mv openmp-${LLVM_RELEASE}.src ${BUILD_PATH}/projects/openmp
+    mv clang-tools-extra-${LLVM_RELEASE}.src ${BUILD_PATH}/tools/clang/tools/extra
+    cd ../
+}
+
+
+function mason_load_source {
+    mkdir -p "${MASON_ROOT}/.cache"
+    cd "${MASON_ROOT}/.cache"
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/llvm-${MASON_VERSION}
+    mkdir -p ${MASON_BUILD_PATH}/
+    setup_release ${MASON_VERSION} ${MASON_BUILD_PATH}
+}
+
+function mason_compile {
+    CLANG_GIT_REV=$(git -C tools/clang/ rev-list --max-count=1 HEAD)
+    mkdir -p ./build
+    cd ./build
+    CMAKE_EXTRA_ARGS=""
+    if [[ $(uname -s) == 'Darwin' ]]; then
+        CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DCLANG_DEFAULT_CXX_STDLIB=libc++"
+        CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DC_INCLUDE_DIRS=:/usr/include:/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/"
+        CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DDEFAULT_SYSROOT=/"
+    fi
+    cmake ../ -G Ninja -DCMAKE_INSTALL_PREFIX=${MASON_PREFIX} \
+     -DCMAKE_BUILD_TYPE=Release \
+     -DLLVM_ENABLE_ASSERTIONS=OFF \
+     -DCLANG_VENDOR=mapbox/mason \
+     -DCLANG_REPOSITORY_STRING=https://github.com/mapbox/mason \
+     -DCLANG_APPEND_VC_REV=$CLANG_GIT_REV \
+     -DCLANG_VENDOR_UTI=org.mapbox.clang \
+     -DCMAKE_EXE_LINKER_FLAGS="${LDFLAGS}" \
+     -DCMAKE_CXX_FLAGS_RELEASE="${CXXFLAGS}" \
+     -DLLVM_OPTIMIZED_TABLEGEN=ON \
+     ${CMAKE_EXTRA_ARGS}
+    ninja -j${JOBS} -k5
+    ninja install -k5
+    # manual install of tools that don't get installed right
+    cp build/Release/bin/include-what-you-use ${MASON_PREFIX}/bin
+
+}
+
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
+mason_run "$@"

--- a/scripts/ninja/1.7.1/.travis.yml
+++ b/scripts/ninja/1.7.1/.travis.yml
@@ -7,7 +7,7 @@ matrix:
       compiler: clang
     - os: linux
       compiler: gcc
-      env: CXX=g++-5 CC=gcc-5
+      env: CXX=gcc++-5 CC=gcc-5
       sudo: false
       addons:
         apt:
@@ -15,6 +15,7 @@ matrix:
            - ubuntu-toolchain-r-test
           packages:
            - libstdc++6
+           - ninja-build
            - g++-5
 
 env:
@@ -25,8 +26,6 @@ env:
 script:
 - ./mason install cmake 3.5.2
 - export PATH=$(./mason prefix cmake 3.5.2)/bin:${PATH}
-- ./mason install ninja 1.7.1
-- export PATH=$(./mason prefix ninja 1.7.1)/bin:${PATH}
 - ./mason build ${MASON_NAME} ${MASON_VERSION}
 
 after_success:

--- a/scripts/ninja/1.7.1/script.sh
+++ b/scripts/ninja/1.7.1/script.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+MASON_NAME=ninja
+MASON_VERSION=1.7.1
+MASON_LIB_FILE=bin/ninja
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        https://github.com/ninja-build/ninja/archive/v${MASON_VERSION}.tar.gz \
+        2756449c3d68f965d3b6bd6e4989fcaa84caee5a
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
+}
+
+function mason_compile {
+    ./configure.py --bootstrap
+    mkdir -p ${MASON_PREFIX}/bin/
+    cp ./ninja ${MASON_PREFIX}/bin/
+}
+
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
+mason_run "$@"


### PR DESCRIPTION
Packaging clang++-3.8 in order to use it for travis builds (To get off unreliable llvm.org apt repos: http://lists.llvm.org/pipermail/llvm-dev/2016-May/100303.html).

 - Will package clang++-3.5 as well if this approach works.
 - Will likely need to manually build and publish since compile takes too long for travis.