### PR TITLE
Remove armv7s as an iOS target architecture

### DIFF
--- a/mason.sh
+++ b/mason.sh
@@ -417,7 +417,7 @@ function mason_build {
     if [ ${MASON_PLATFORM} = 'ios' ]; then
 
         SIMULATOR_TARGETS="i386 x86_64"
-        DEVICE_TARGETS="armv7 armv7s arm64"
+        DEVICE_TARGETS="armv7 arm64"
         LIB_FOLDERS=
 
         for ARCH in ${SIMULATOR_TARGETS} ; do


### PR DESCRIPTION
This pull request stops Mason from building libraries with `armv7s` slices for the iOS platform. This primarily affects geojson-vt.

The Mapbox iOS SDK removed support for the `armv7s` architecture in https://github.com/mapbox/mapbox-gl-native/issues/4704 after we determined it was unnecessary. Devices that rely on `armv7s` can safely fall back to `armv7` with, in our case, no measurable performance impact.

/cc @jfirebaugh @springmeyer @1ec5 