### PR TITLE
Stop building armv7s for iOS

### DIFF
--- a/mason.sh
+++ b/mason.sh
@@ -414,7 +414,7 @@ function mason_build {
     if [ ${MASON_PLATFORM} = 'ios' ]; then
 
         SIMULATOR_TARGETS="i386 x86_64"
-        DEVICE_TARGETS="armv7 armv7s arm64"
+        DEVICE_TARGETS="armv7 arm64"
         LIB_FOLDERS=
 
         for ARCH in ${SIMULATOR_TARGETS} ; do


### PR DESCRIPTION
This change removes the `armv7s` slice from iOS build products.

We decided in mapbox/mapbox-gl-native#4704 to drop the armv7s slice from the Mapbox iOS SDK, because iPhone 5 and 5c fall back to `armv7` and the performance boost of `armv7s` over `armv7` is negligible. However, libgeojsonvt.a’s armv7s slice still gets lipo’d into the SDK’s static library.

/cc @friedbunny @jfirebaugh