### PR TITLE
Build + testing improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,24 @@
-language: cpp
+language: generic
 
-sudo: false
-
-env:
-  matrix:
-    - MASON_TEST="unit"
-    - MASON_TEST="c_install"
-    - MASON_TEST="c_build"
-    - MASON_TEST="c_install_symlink_includes"
-    - MASON_TEST="cpp11_header_install"
-    - MASON_TEST="cpp11_install"
-    - MASON_TEST="cpp11_build"
-    - MASON_TEST="c_build_android"
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode7.3
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++6
+           - libstdc++-5-dev
 
 install:
-# NOTE: must be absolute path for predictable behavior
-# when packages call out to mason themselves in order to install deps
-- export MASON_DIR=$(pwd)
+- source utils/toolchain.sh
+- ${CC} --version
+- ${CXX} --version
 
 script:
-- ./test/${MASON_TEST}.sh
+- ./test/all.sh

--- a/test/all.sh
+++ b/test/all.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 
+set -eu
+set -o pipefail
+
 $(dirname $0)/unit.sh
 $(dirname $0)/c_install.sh
 $(dirname $0)/c_build.sh
+$(dirname $0)/c_build_android.sh
+$(dirname $0)/c_install_symlink_includes.sh
+$(dirname $0)/cpp11_header_install.sh
 $(dirname $0)/cpp11_install.sh
 $(dirname $0)/cpp11_build.sh

--- a/utils/toolchain.sh
+++ b/utils/toolchain.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+CLANG_VERSION="3.8.0"
+./mason install clang ${CLANG_VERSION}
+export PATH=$(./mason prefix clang ${CLANG_VERSION})/bin:${PATH}
+export CXX=clang++-3.8
+export CC=clang-3.8
+
+set +eu


### PR DESCRIPTION
This moves to:

  - Testing on both Linux and OS X
  - Avoids excessive usage of multiple jobs, collapses to running all tests in one job
  - Properly installs our target C and C++ compiler in a consistent method:
     - Clang 3.8.0
     - Via mason itself
  - ~~Adds a `package_template.yml` that will be used as the default `.travis.yml` for triggered builds if one does not exist for a given script~~

Fixes #184 

/cc @kkaefer @jfirebaugh 