### PR TITLE
Add clang-tidy v3.8.0 as repackaged binary from parent clang build

### DIFF
--- a/scripts/clang-tidy/3.8.0/.travis.yml
+++ b/scripts/clang-tidy/3.8.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      compiler: clang
+    - os: linux
+      sudo: false
+
+env:
+  global:
+   - secure: "clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFnWLtmF3stlft5YWyc2kI+FI="
+   - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+
+after_success:
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/clang-tidy/3.8.0/.travis.yml
+++ b/scripts/clang-tidy/3.8.0/.travis.yml
@@ -3,9 +3,19 @@ language: generic
 matrix:
   include:
     - os: osx
+      osx_image: xcode7.3
       compiler: clang
     - os: linux
+      compiler: gcc
+      env: CXX=g++-5 CC=gcc-5
       sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++6
+           - g++-5
 
 env:
   global:

--- a/scripts/clang-tidy/3.8.0/script.sh
+++ b/scripts/clang-tidy/3.8.0/script.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# dynamically take name of package from directory
+MASON_NAME=$(basename $(dirname $HERE))
+# dynamically take the version of the package from directory
+MASON_VERSION=$(basename $HERE)
+MASON_LIB_FILE=bin/${MASON_NAME}
+
+. ${MASON_DIR}/mason.sh
+
+function mason_build {
+    mason install clang ${MASON_VERSION}
+    CLANG_PREFIX=$(mason prefix clang ${MASON_VERSION})
+    mkdir -p "${MASON_PREFIX}/bin"
+    cp ${CLANG_PREFIX}/bin/${MASON_NAME} "${MASON_PREFIX}/bin/"
+}
+
+mason_run "$@"

--- a/scripts/clang-tidy/3.8.0/script.sh
+++ b/scripts/clang-tidy/3.8.0/script.sh
@@ -12,7 +12,7 @@ MASON_LIB_FILE=bin/${MASON_NAME}
 . ${MASON_DIR}/mason.sh
 
 function mason_build {
-    mason install clang ${MASON_VERSION}
+    ${MASON_DIR}/mason install clang ${MASON_VERSION}
     CLANG_PREFIX=$(${MASON_DIR}/mason prefix clang ${MASON_VERSION})
     mkdir -p "${MASON_PREFIX}/bin"
     cp ${CLANG_PREFIX}/bin/${MASON_NAME} "${MASON_PREFIX}/bin/"

--- a/scripts/clang-tidy/3.8.0/script.sh
+++ b/scripts/clang-tidy/3.8.0/script.sh
@@ -13,7 +13,7 @@ MASON_LIB_FILE=bin/${MASON_NAME}
 
 function mason_build {
     mason install clang ${MASON_VERSION}
-    CLANG_PREFIX=$(mason prefix clang ${MASON_VERSION})
+    CLANG_PREFIX=$(${MASON_DIR}/mason prefix clang ${MASON_VERSION})
     mkdir -p "${MASON_PREFIX}/bin"
     cp ${CLANG_PREFIX}/bin/${MASON_NAME} "${MASON_PREFIX}/bin/"
 }


### PR DESCRIPTION
This creates a clang-tidy package that re-packages just the `clang-tidy` binary. You can use `clang-tidy` from the main `clang` v3.8.0 package, but when users need just the minimal `clang-tidy` binary this package is much smaller.

It dynamically determines its version and name from the directory. The idea here is to make it easy to copy and modify for re-packaging other clang binaries in the future.

Refs #188