### PR TITLE
geojson-vt-cpp@4.1.2-cxx11abi configure --with-pic

### DIFF
--- a/scripts/geojsonvt/4.1.2-cxx11abi/script.sh
+++ b/scripts/geojsonvt/4.1.2-cxx11abi/script.sh
@@ -24,7 +24,7 @@ function mason_compile {
     ln -s ${MASON_DIR} .mason
 
     # build
-    INSTALL_PREFIX=${MASON_PREFIX} ./configure
+    INSTALL_PREFIX=${MASON_PREFIX} ./configure --with-pic
     CXXFLAGS="-fPIC ${CFLAGS:-} ${CXXFLAGS:-}" make install
 }
 


### PR DESCRIPTION
`-fPIC` alone isn't sufficient?

I think this should fix the following linker error I'm seeing when building [mapbox-gl-native](https://github.com/mapbox/mapbox-gl-native/) with `make node`, but `--with-pic` doesn't look like it's actually getting passed through to the right place.

```
/usr/bin/ld: /home/mikemorris/mapbox-gl-native/mason_packages/linux-x86_64/geojsonvt/4.1.2-cxx11abi/lib/libgeojsonvt.a(geojsonvt.o): unrecognized relocation (0x2a) in section `.text'
/usr/bin/ld: final link failed: Bad value
```

Prior art in #26, #30 - it looks like setting `-fPIC` explicitly in the scripts may be redundant with https://github.com/mapbox/mason/commit/2a955a1650fe65bf31e5a198972244541693e897, but `--with-pic` may still be required.

/cc @springmeyer @kkaefer 