### PR TITLE
export MASON_ROOT

### DIFF
--- a/mason.sh
+++ b/mason.sh
@@ -2,7 +2,7 @@ set -e
 set -o pipefail
 # set -x
 
-MASON_ROOT=${MASON_ROOT:-`pwd`/mason_packages}
+export MASON_ROOT=${MASON_ROOT:-`pwd`/mason_packages}
 MASON_BUCKET=${MASON_BUCKET:-mason-binaries}
 MASON_IGNORE_OSX_SDK=${MASON_IGNORE_OSX_SDK:-false}
 


### PR DESCRIPTION
Dependent invocations of `mason` are currently writing into their own `mason_packages` folder, which makes those builds very slow because they can't reuse the packages already in the master `mason_packages` folder.

This change `export`s the `MASON_ROOT` variable so that all dependent `mason` builds use the root folder.

/cc @springmeyer 