### PR TITLE
Better linking

### DIFF
--- a/mason.sh
+++ b/mason.sh
@@ -364,7 +364,7 @@ function run_lndir() {
     mason_step "Links will be inside ${TARGET_SUBDIR}"
     if hash lndir 2>/dev/null; then
         mason_substep "Using $(which lndir) for symlinking"
-        lndir -silent ${MASON_PREFIX}/ ${TARGET_SUBDIR}
+        lndir -silent ${MASON_PREFIX}/ ${TARGET_SUBDIR} 2>/dev/null
     else
         mason_substep "Using bash fallback for symlinking (install lndir for faster symlinking)"
         bash_lndir ${MASON_PREFIX}/ ${TARGET_SUBDIR}

--- a/mason.sh
+++ b/mason.sh
@@ -335,64 +335,41 @@ function mason_clean {
     :
 }
 
-function link_files_in_root {
-    if [[ -d "${MASON_PREFIX}/$1/" ]] ; then
-        for i in $(find -H ${MASON_PREFIX}/$1/ -maxdepth 1 -mindepth 1 -name "*" ! -type d -print); do
-            common_part=$(python -c "import os;print(os.path.relpath('$i','${MASON_PREFIX}'))")
-            if [[ $common_part != '.' ]] && [[ ! -e "${MASON_ROOT}/.link/$common_part" ]]; then
-                mason_step "linking ${MASON_ROOT}/.link/$common_part"
-                mkdir -p $(dirname ${MASON_ROOT}/.link/$common_part)
-                ln -sf ${MASON_PREFIX}/$common_part ${MASON_ROOT}/.link/$common_part
-            else
-                mason_success "Already linked file ${MASON_ROOT}/.link/$common_part"
+function bash_lndir() {
+    oldifs=$IFS
+    IFS='
+    '
+    src=$(cd "$1" ; pwd)
+    dst=$(cd "$2" ; pwd)
+    find "$src" -type d |
+    while read dir; do
+            mkdir -p "$dst${dir#$src}"
+    done
+
+    find "$src" -type f -o -type l |
+    while read src_f; do
+            dst_f="$dst${src_f#$src}"
+            if [[ ! -f $dst_f ]]; then
+                ln -s "$src_f" "$dst_f"
             fi
-        done
-    fi
+    done
+    IFS=$oldifs
 }
 
-function link_files_recursively {
-    if [[ -d "${MASON_PREFIX}/$1/" ]] ; then
-        for i in $(find -H ${MASON_PREFIX}/$1/ -name "*" ! -type d -print); do
-            common_part=$(python -c "import os;print(os.path.relpath('$i','${MASON_PREFIX}'))")
-            if [[ $common_part != '.' ]] && [[ ! -e "${MASON_ROOT}/.link/$common_part" ]]; then
-                mason_step "linking ${MASON_ROOT}/.link/$common_part"
-                mkdir -p $(dirname ${MASON_ROOT}/.link/$common_part)
-                ln -sf ${MASON_PREFIX}/$common_part ${MASON_ROOT}/.link/$common_part
-            else
-                mason_success "Already linked file ${MASON_ROOT}/.link/$common_part"
-            fi
-        done
-    fi
-}
 
-function link_dir {
-    if [[ -d ${MASON_PREFIX}/$1 ]]; then
-        FOUND_SUBDIR=$(find ${MASON_PREFIX}/$1 -maxdepth 1 -mindepth 1 -name "*" -type d -print)
-        # for headers like boost that use include/boost it is most efficient to symlink just the directory
-        # skip linking include/google due to https://github.com/mapbox/mason/issues/81
-        if [[ ${FOUND_SUBDIR} ]] && [[ ${FOUND_SUBDIR} == *"include/boost" ]]; then
-            for dir in ${FOUND_SUBDIR}; do
-                local SUBDIR_BASENAME=$(basename $dir)
-                # skip man entries to avoid conflicts
-                if [[ $SUBDIR_BASENAME == "man" || $SUBDIR_BASENAME == "aclocal" || $SUBDIR_BASENAME == "doc" ]]; then
-                    continue;
-                else
-                    local TARGET_SUBDIR="${MASON_ROOT}/.link/$1/${SUBDIR_BASENAME}"
-                    if [[ ! -d ${TARGET_SUBDIR} && ! -L ${TARGET_SUBDIR} ]]; then
-                        mason_step "linking directory ${TARGET_SUBDIR}"
-                        mkdir -p $(dirname ${TARGET_SUBDIR})
-                        ln -s ${MASON_PREFIX}/$1/${SUBDIR_BASENAME} ${TARGET_SUBDIR}
-                    else
-                        mason_success "Already linked directory ${TARGET_SUBDIR}"
-                    fi
-                fi
-            done
-            # still need to link files in the root directory for apps like postgres
-            link_files_in_root include
-        else
-            link_files_recursively include
-        fi
+function run_lndir() {
+    # TODO: cp is fast, but inconsistent across osx
+    #/bin/cp -R -n ${MASON_PREFIX}/* ${TARGET_SUBDIR}
+    mason_step "Linking ${MASON_PREFIX}"
+    mason_step "Links will be inside ${TARGET_SUBDIR}"
+    if hash lndir 2>/dev/null; then
+        mason_substep "Using $(which lndir) for symlinking"
+        lndir -silent ${MASON_PREFIX}/ ${TARGET_SUBDIR}
+    else
+        mason_substep "Using bash fallback for symlinking (install lndir for faster symlinking)"
+        bash_lndir ${MASON_PREFIX}/ ${TARGET_SUBDIR}
     fi
+    mason_step "Done linking ${MASON_PREFIX}"
 }
 
 function mason_link {
@@ -400,10 +377,9 @@ function mason_link {
         mason_error "${MASON_PREFIX} not found, please install first"
         exit 0
     fi
-    link_files_recursively lib
-    link_files_recursively bin
-    link_dir include
-    link_dir share
+    TARGET_SUBDIR="${MASON_ROOT}/.link/"
+    mkdir -p ${TARGET_SUBDIR}
+    run_lndir
 }
 
 

--- a/test/cpp11_header_install.sh
+++ b/test/cpp11_header_install.sh
@@ -14,36 +14,33 @@ if [[ ! -d mason_packages/.link/include/boost ]]; then
     failure=1
 fi
 
-if [[ ! -L mason_packages/.link/include/boost ]]; then
-    echo "include/boost is not a symlink like expected"
-    failure=1
-fi
+# install packages that share namespaces and directories
+# and insure they get placed okay (and don't prevent each other
+# from being symlinked)
 
 ./mason install sparsehash 2.0.2
 ./mason link sparsehash 2.0.2
+./mason install protobuf 2.6.1
+./mason link protobuf 2.6.1
 ./mason install geometry 0.7.0
 ./mason link geometry 0.7.0
+./mason install variant 1.1.0
+./mason link variant 1.1.0
 
-failure=0
-
-# google packages we symlink the files to avoid conflicts
-if [[ ! -d mason_packages/.link/include/google ]]; then
-    echo "could not find expected include/google"
+if [[ ! -d mason_packages/.link/include/google/sparsehash ]]; then
+    echo "could not find expected include/google/sparsehash"
     failure=1
 fi
 
-if [[ -L mason_packages/.link/include/google ]]; then
-    echo "include/google is not expected to be a symlink"
+
+if [[ ! -d mason_packages/.link/include/google/protobuf ]]; then
+    echo "could not find expected include/google/protobuf"
     failure=1
 fi
 
-if [[ ! -d mason_packages/.link/include/mapbox ]]; then
-    echo "could not find expected include/mapbox"
-    failure=1
-fi
 
-if [[ -L mason_packages/.link/include/mapbox ]]; then
-    echo "include/mapbox is not expected to be a symlink"
+if [[ ! -d mason_packages/.link/include/mapbox/geometry ]]; then
+    echo "could not find expected include/mapbox/geometry"
     failure=1
 fi
 


### PR DESCRIPTION
The `mason link` command is able to:

  - Create symlinks inside `./mason_packages/.link/` for a given package
  - It does this recursively and works to merge packages that share directories like `include/mapbox`

The usecase here is to make it easy to have multiple mason packages installed and be able to point to them with one path when building like:

`cc -I./mason_packages/.link/include -L./mason_packages/.link/lib`

This PR improves the logic by:

 - Dropping the python dependency
 - Using the `lndir` command, when available, which is much faster (it is part of X11)
 - Falls back to a push bash, but slow version.

Notes:

  - I wish there was a more widely known and used command instead of `lndir`, but I can't find one.
  - Using `cp -rs` could work and is also fast, but behaves very different on OS X and Linux (and between the osx built in /bin/cp and the homebrew coreutils/cp), so this feels bug prone.