### PR TITLE
Clang++ v3.8.0

### DIFF
--- a/scripts/clang++/3.8.0/.travis.yml
+++ b/scripts/clang++/3.8.0/.travis.yml
@@ -1,0 +1,29 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode7.3
+      compiler: clang
+    - os: linux
+      compiler: gcc
+      env: CXX=g++-5 CC=gcc-5
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++6
+           - g++-5
+
+env:
+  global:
+   - secure: "clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFnWLtmF3stlft5YWyc2kI+FI="
+   - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+
+after_success:
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/clang++/3.8.0/script.sh
+++ b/scripts/clang++/3.8.0/script.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# dynamically take name of package from directory
+MASON_NAME=$(basename $(dirname $HERE))
+# dynamically take the version of the package from directory
+MASON_VERSION=$(basename $HERE)
+MASON_LIB_FILE=bin/${MASON_NAME}
+
+. ${MASON_DIR}/mason.sh
+
+function mason_build {
+    ${MASON_DIR}/mason install clang ${MASON_VERSION}
+    CLANG_PREFIX=$(${MASON_DIR}/mason prefix clang ${MASON_VERSION})
+    mkdir -p "${MASON_PREFIX}/bin"
+    # we need to copy the standard C++ headers because clang-tidy doesn't know
+    # where to find them in the system and complains about missing information
+    mkdir -p "${MASON_PREFIX}/include"
+    mkdir -p "${MASON_PREFIX}/lib/clang/${MASON_VERSION}"
+    cp ${CLANG_PREFIX}/bin/${MASON_NAME} "${MASON_PREFIX}/bin/"
+    cp -R ${CLANG_PREFIX}/include/c++ "${MASON_PREFIX}/include/c++"
+    cp -R ${CLANG_PREFIX}/lib/clang/${MASON_VERSION}/include "${MASON_PREFIX}/lib/clang/${MASON_VERSION}/include"
+}
+
+mason_run "$@"

--- a/scripts/clang++/3.8.0/script.sh
+++ b/scripts/clang++/3.8.0/script.sh
@@ -21,7 +21,7 @@ function mason_build {
     mkdir -p "${MASON_PREFIX}/lib/clang/${MASON_VERSION}"
     cp ${CLANG_PREFIX}/bin/${MASON_NAME} "${MASON_PREFIX}/bin/"
     cp -R ${CLANG_PREFIX}/include/c++ "${MASON_PREFIX}/include/c++"
-    cp -R ${CLANG_PREFIX}/lib/clang/${MASON_VERSION}/include "${MASON_PREFIX}/lib/clang/${MASON_VERSION}/include"
+    cp -R ${CLANG_PREFIX}/lib/clang/${MASON_VERSION}/* "${MASON_PREFIX}/lib/clang/${MASON_VERSION}/"
 }
 
 mason_run "$@"


### PR DESCRIPTION
Metapackage that repackages just clang++ by pulling from the massive (760MB) clang 3.8.0 package.