### PR TITLE
add protozero @ 1.4.0

### DIFF
--- a/scripts/libosmium/2.8.0/.travis.yml
+++ b/scripts/libosmium/2.8.0/.travis.yml
@@ -1,0 +1,26 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode7.3
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
+
+env:
+  global:
+   - secure: "clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFnWLtmF3stlft5YWyc2kI+FI="
+   - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+
+after_success:
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/libosmium/2.8.0/script.sh
+++ b/scripts/libosmium/2.8.0/script.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+MASON_NAME=libosmium
+MASON_VERSION=2.8.0
+MASON_HEADER_ONLY=true
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        https://github.com/osmcode/${MASON_NAME}/archive/v${MASON_VERSION}.tar.gz \
+        30c5b5b74bdda40bace1ea993f43a00874ac553f
+
+    mason_extract_tar_gz
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
+}
+
+function mason_compile {
+    mkdir -p ${MASON_PREFIX}/include/
+    cp -r include/osmium ${MASON_PREFIX}/include/osmium
+}
+
+mason_run "$@"

--- a/scripts/protozero/1.4.0/.travis.yml
+++ b/scripts/protozero/1.4.0/.travis.yml
@@ -1,0 +1,22 @@
+language: cpp
+
+sudo: false
+
+matrix:
+  include:
+    - os: osx
+      compiler: clang
+    - os: linux
+      compiler: clang
+
+env:
+  global:
+   - secure: "clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFnWLtmF3stlft5YWyc2kI+FI="
+   - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason link ${MASON_NAME} ${MASON_VERSION}
+
+after_success:
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/protozero/1.4.0/.travis.yml
+++ b/scripts/protozero/1.4.0/.travis.yml
@@ -8,6 +8,12 @@ matrix:
       compiler: clang
     - os: linux
       compiler: clang
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
 
 env:
   global:

--- a/scripts/protozero/1.4.0/script.sh
+++ b/scripts/protozero/1.4.0/script.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+MASON_NAME=protozero
+MASON_VERSION=1.4.0
+MASON_HEADER_ONLY=true
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        https://github.com/mapbox/protozero/tarball/v1.4.0 \
+        0f6eb6234ee5a258216b2f9a83e35a1f5e60ca03
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/mapbox-protozero-ca34d86
+}
+
+function mason_compile {
+    mkdir -p ${MASON_PREFIX}/include/
+    cp -r include/protozero ${MASON_PREFIX}/include/protozero
+}
+
+function mason_cflags {
+    echo "-I${MASON_PREFIX}/include"
+}
+
+function mason_ldflags {
+    :
+}
+
+mason_run "$@"


### PR DESCRIPTION
Looks like I need protozero 1.4.0 before the updated libosmium (https://github.com/mapbox/mason/pull/222/files) compiles for me in timtam.

cc @springmeyer 