### PR TITLE
Don't subversion for different releases of iOS

### DIFF
--- a/mason.cmake
+++ b/mason.cmake
@@ -26,10 +26,7 @@ endif()
 
 # Determine platform version string
 if(MASON_PLATFORM STREQUAL "ios")
-    execute_process(
-        COMMAND xcrun --sdk iphoneos --show-sdk-version
-        OUTPUT_VARIABLE MASON_PLATFORM_VERSION
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
+    set(MASON_PLATFORM_VERSION "8.0") # Deployment target version
 elseif(MASON_PLATFORM STREQUAL "android")
     if (ANDROID_ABI STREQUAL "armeabi")
         set(MASON_PLATFORM_VERSION "arm-v5-9")

--- a/mason.sh
+++ b/mason.sh
@@ -67,26 +67,28 @@ if [ ${MASON_PLATFORM} = 'osx' ]; then
 
 elif [ ${MASON_PLATFORM} = 'ios' ]; then
     export MASON_HOST_ARG="--host=arm-apple-darwin"
-    export MASON_PLATFORM_VERSION=`xcrun --sdk iphoneos --show-sdk-version`
+    export MASON_PLATFORM_VERSION="8.0" # Deployment target version
 
+    MASON_SDK_VERSION=`xcrun --sdk iphoneos --show-sdk-version`
     MASON_SDK_ROOT=${MASON_XCODE_ROOT}/Platforms/iPhoneOS.platform/Developer
-    MASON_SDK_PATH="${MASON_SDK_ROOT}/SDKs/iPhoneOS${MASON_PLATFORM_VERSION}.sdk"
-    MIN_SDK_VERSION_FLAG="-miphoneos-version-min=7.0"
+    MASON_SDK_PATH="${MASON_SDK_ROOT}/SDKs/iPhoneOS${MASON_SDK_VERSION}.sdk"
+
+    MIN_SDK_VERSION_FLAG="-miphoneos-version-min=${MASON_PLATFORM_VERSION}"
     export MASON_IOS_CFLAGS="${MIN_SDK_VERSION_FLAG} -isysroot ${MASON_SDK_PATH}"
-    if [[ ${MASON_PLATFORM_VERSION%%.*} -ge 9 ]]; then
+    if [[ ${MASON_SDK_VERSION%%.*} -ge 9 ]]; then
         export MASON_IOS_CFLAGS="${MASON_IOS_CFLAGS} -fembed-bitcode"
         export MASON_DYNLIB_SUFFIX="tbd"
     else
         export MASON_DYNLIB_SUFFIX="dylib"
     fi
 
-    if [ `xcrun --sdk iphonesimulator --show-sdk-version` != ${MASON_PLATFORM_VERSION} ]; then
+    if [ `xcrun --sdk iphonesimulator --show-sdk-version` != ${MASON_SDK_VERSION} ]; then
         mason_error "iPhone Simulator SDK version doesn't match iPhone SDK version"
         exit 1
     fi
 
     MASON_SDK_ROOT=${MASON_XCODE_ROOT}/Platforms/iPhoneSimulator.platform/Developer
-    MASON_SDK_PATH="${MASON_SDK_ROOT}/SDKs/iPhoneSimulator${MASON_PLATFORM_VERSION}.sdk"
+    MASON_SDK_PATH="${MASON_SDK_ROOT}/SDKs/iPhoneSimulator${MASON_SDK_VERSION}.sdk"
     export MASON_ISIM_CFLAGS="${MIN_SDK_VERSION_FLAG} -isysroot ${MASON_SDK_PATH}"
 
 elif [ ${MASON_PLATFORM} = 'linux' ]; then


### PR DESCRIPTION
Is there a reason to require building separate binaries for ios-9.0, ios-9.1, ios-9.2, etc? Like in #118 / #131 for OS X, this seems to provide little benefit but means that our build matrix must explicitly build for multiple iOS versions (see e.g. https://github.com/mapbox/mapbox-gl-native/issues/4546 and https://github.com/mapbox/mason/commit/cbe97886ec604018ea8b0faf1cf28658125e162d).

cc @springmeyer @kkaefer @1ec5 