### PR TITLE
New pkgs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,11 @@ matrix:
           packages:
            - libstdc++-5-dev
 
+env:
+  global:
+   - secure: "clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFnWLtmF3stlft5YWyc2kI+FI="
+   - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
+
 install:
 - |
   if [[ ${MASON_PLATFORM:-unset} == 'unset' ]] || [[ ${MASON_PLATFORM} == 'osx' ]] || [[ ${MASON_PLATFORM} == 'linux' ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ matrix:
   include:
     - os: osx
       osx_image: xcode7.3
-      compiler: clang
     - os: linux
       sudo: false
       addons:
@@ -13,11 +12,6 @@ matrix:
            - ubuntu-toolchain-r-test
           packages:
            - libstdc++-5-dev
-
-env:
-  global:
-   - secure: "clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFnWLtmF3stlft5YWyc2kI+FI="
-   - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 install:
 - |

--- a/mason
+++ b/mason
@@ -47,6 +47,8 @@ if [ "${MASON_COMMAND}" = "trigger" ]; then
     config = YAML.load_file("scripts/${MASON_NAME}/${MASON_VERSION}/.travis.yml")
     config["env"] ||= {}
     config["env"]["global"] ||= []
+    config["env"]["global"] << {"secure":"clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFnWLtmF3stlft5YWyc2kI+FI="}
+    config["env"]["global"] << {"secure":"jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="}
     config["env"]["global"] << "MASON_NAME=${MASON_NAME}" << "MASON_VERSION=${MASON_VERSION}"
     puts JSON.pretty_generate(config)
 RUBY

--- a/mason
+++ b/mason
@@ -45,11 +45,15 @@ if [ "${MASON_COMMAND}" = "trigger" ]; then
     require 'yaml'
     require 'json'
     config = YAML.load_file("scripts/${MASON_NAME}/${MASON_VERSION}/.travis.yml")
+    config["language"] = "generic"
+    config["script"] = [
+        "./mason build ${MASON_NAME} ${MASON_VERSION}",
+        "./mason publish ${MASON_NAME} ${MASON_VERSION}"
+    ]
     config["env"] ||= {}
     config["env"]["global"] ||= []
     config["env"]["global"] << {"secure":"clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFnWLtmF3stlft5YWyc2kI+FI="}
     config["env"]["global"] << {"secure":"jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="}
-    config["env"]["global"] << "MASON_NAME=${MASON_NAME}" << "MASON_VERSION=${MASON_VERSION}"
     puts JSON.pretty_generate(config)
 RUBY
     )
@@ -68,7 +72,7 @@ RUBY
         -H "Travis-API-Version: 3" \
         -H "Authorization: token ${TRAVIS_TOKEN}" \
         -d "$body"
-
+    
     echo "Now go to https://travis-ci.org/mapbox/mason/builds to view build status"
 
     exit

--- a/scripts/cairo/1.14.6/.travis.yml
+++ b/scripts/cairo/1.14.6/.travis.yml
@@ -1,0 +1,21 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode7.3
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+
+after_success:
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/cairo/1.14.6/.travis.yml
+++ b/scripts/cairo/1.14.6/.travis.yml
@@ -1,10 +1,7 @@
-language: generic
-
 matrix:
   include:
     - os: osx
       osx_image: xcode7.3
-      compiler: clang
     - os: linux
       sudo: false
       addons:
@@ -13,9 +10,3 @@ matrix:
            - ubuntu-toolchain-r-test
           packages:
            - libstdc++-5-dev
-
-script:
-- ./mason build ${MASON_NAME} ${MASON_VERSION}
-
-after_success:
-- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/cairo/1.14.6/patch.diff
+++ b/scripts/cairo/1.14.6/patch.diff
@@ -1,0 +1,96 @@
+diff --git a/build/configure.ac.tools b/build/configure.ac.tools
+index a24dbce..aaf0e5d 100644
+--- a/build/configure.ac.tools
++++ b/build/configure.ac.tools
+@@ -10,16 +10,3 @@ AC_C_INLINE
+ 
+ dnl ===========================================================================
+ 
+-PKG_PROG_PKG_CONFIG()
+-if test "x$PKG_CONFIG" = x; then
+-	AC_MSG_ERROR([pkg-config >= $PKGCONFIG_REQUIRED required but not found (http://pkgconfig.freedesktop.org/)])
+-fi
+-
+-dnl Check for recent pkg-config which supports Requires.private
+-case `$PKG_CONFIG --version` in
+-[0.?|0.?.?|0.1[0-7]|0.1[0-7].?]) PKGCONFIG_REQUIRES="Requires"; ;;
+-*) PKGCONFIG_REQUIRES="Requires.private"; ;;
+-esac
+-
+-AC_SUBST(PKGCONFIG_REQUIRES)
+-
+diff --git a/configure.ac b/configure.ac
+index 2ce1959..87c71ac 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -321,26 +321,7 @@ CAIRO_ENABLE_SURFACE_BACKEND(gallium, Gallium3D, no, [
+ dnl ===========================================================================
+ 
+ CAIRO_ENABLE_FUNCTIONS(png, PNG, yes, [
+-  use_png=no
+-  AC_ARG_VAR([png_REQUIRES], [module name for libpng to search for using pkg-config])
+-  if test "x$png_REQUIRES" = x; then
+-    # libpng13 is GnuWin32's libpng-1.2.8 :-(
+-    for l in libpng libpng14 libpng12 libpng13 libpng10; do
+-      if $PKG_CONFIG --exists $l ; then
+-        png_REQUIRES=$l
+-        use_png=yes
+-        break
+-      fi
+-    done
+-  else
+-    use_png=yes
+-  fi
+-
+-  if test "x$use_png" = "xyes" ; then 
+-    PKG_CHECK_MODULES(png, $png_REQUIRES, , : )
+-  else
+-    AC_MSG_WARN([Could not find libpng in the pkg-config search path])
+-  fi    
++  use_png=yes
+ ])
+ 
+ dnl ===========================================================================
+@@ -495,10 +476,6 @@ FREETYPE_MIN_RELEASE=2.1.9
+ FREETYPE_MIN_VERSION=9.7.3
+ 
+ CAIRO_ENABLE_FONT_BACKEND(ft, FreeType, auto, [
+-
+-    PKG_CHECK_MODULES(FREETYPE, freetype2 >= $FREETYPE_MIN_VERSION,
+-                      [freetype_pkgconfig=yes],
+-		      [freetype_pkgconfig=no])
+   
+     if test "x$freetype_pkgconfig" = "xyes"; then
+       ft_REQUIRES="freetype2 >= $FREETYPE_MIN_VERSION $ft_REQUIRES"
+@@ -662,18 +639,12 @@ CAIRO_ENABLE(test_surfaces, test surfaces, no)
+ dnl ===========================================================================
+ 
+ CAIRO_ENABLE_SURFACE_BACKEND(image, image, always, [
+-  pixman_REQUIRES="pixman-1 >= 0.30.0"
+-  PKG_CHECK_MODULES(pixman, $pixman_REQUIRES, ,
+-    [use_image="no (requires $pixman_REQUIRES http://cairographics.org/releases/)"])
++  use_image=yes
+   image_REQUIRES=$pixman_REQUIRES
+   image_CFLAGS=$pixman_CFLAGS
+   image_LIBS=$pixman_LIBS
+ ])
+ 
+-if pkg-config --exists 'pixman-1 >= 0.27.1'; then
+-    AC_DEFINE([HAS_PIXMAN_GLYPHS], 1, [Enable pixman glyph cache])
+-fi
+-
+ 
+ dnl ===========================================================================
+ 
+diff --git a/test/Makefile.am b/test/Makefile.am
+index 950629b..f733dd9 100644
+--- a/test/Makefile.am
++++ b/test/Makefile.am
+@@ -75,7 +75,6 @@ endif
+ endif
+ test_sources += $(test)
+ 
+-noinst_PROGRAMS = cairo-test-suite$(EXEEXT) # always build
+ noinst_SCRIPTS = check-refs.sh
+ 
+ TESTS += cairo-test-suite$(EXEEXT)

--- a/scripts/cairo/1.14.6/script.sh
+++ b/scripts/cairo/1.14.6/script.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+MASON_NAME=cairo
+MASON_VERSION=1.14.6
+MASON_LIB_FILE=lib/libcairo.a
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        http://cairographics.org/releases/${MASON_NAME}-${MASON_VERSION}.tar.gz \
+        ecf18db1e89d99799783757d9026a74012dfafcb
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
+}
+
+function mason_prepare_compile {
+    cd $(dirname ${MASON_ROOT})
+    ${MASON_DIR}/mason install libpng 1.6.24
+    MASON_PNG=$(${MASON_DIR}/mason prefix libpng 1.6.24)
+    ${MASON_DIR}/mason install freetype 2.6
+    MASON_FREETYPE=$(${MASON_DIR}/mason prefix freetype 2.6)
+    ${MASON_DIR}/mason install pixman 0.32.6
+    MASON_PIXMAN=$(${MASON_DIR}/mason prefix pixman 0.32.6)
+}
+
+function mason_compile {
+    mason_step "Loading patch 'https://github.com/mapbox/mason/blob/${MASON_SLUG}/patch.diff'..."
+    curl --retry 3 -s -f -# -L \
+      https://raw.githubusercontent.com/mapbox/mason/${MASON_SLUG}/patch.diff \
+      -O || (mason_error "Could not find patch for ${MASON_SLUG}" && exit 1)
+    # patch cairo to avoid needing pkg-config as a build dep
+    patch -N -p1 < ./patch.diff
+    CFLAGS="${CFLAGS} -Wno-enum-conversion -I${MASON_PIXMAN}/include/pixman-1 -I${MASON_FREETYPE}/include/freetype2 -I${MASON_PNG}/include/"
+    LDFLAGS="-L${MASON_PIXMAN}/lib -lpixman-1 -L${MASON_FREETYPE}/lib -lfreetype -L${MASON_PNG}/lib -lpng"
+    CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} ./autogen.sh \
+        --prefix=${MASON_PREFIX} \
+        ${MASON_HOST_ARG} \
+        --enable-static --disable-shared \
+        --enable-pdf=yes \
+        --enable-ft=yes \
+        --enable-png=yes \
+        --enable-svg=yes \
+        --enable-ps=yes \
+        --enable-fc=no \
+        --enable-script=no \
+        --enable-interpreter=no \
+        --enable-quartz=no \
+        --enable-quartz-image=no \
+        --enable-quartz-font=no \
+        --enable-trace=no \
+        --enable-gtk-doc=no \
+        --enable-qt=no \
+        --enable-win32=no \
+        --enable-win32-font=no \
+        --enable-skia=no \
+        --enable-os2=no \
+        --enable-beos=no \
+        --enable-drm=no \
+        --enable-gallium=no \
+        --enable-gl=no \
+        --enable-glesv2=no \
+        --enable-directfb=no \
+        --enable-vg=no \
+        --enable-egl=no \
+        --enable-glx=no \
+        --enable-wgl=no \
+        --enable-test-surfaces=no \
+        --enable-tee=no \
+        --enable-xml=no \
+        --disable-valgrind \
+        --enable-gobject=no \
+        --enable-xlib=no \
+        --enable-xlib-xrender=no \
+        --enable-xcb=no \
+        --enable-xlib-xcb=no \
+        --enable-xcb-shm=no \
+        --enable-full-testing=no \
+        --enable-symbol-lookup=no \
+        --disable-dependency-tracking
+    # The -i and -k flags are to workaround make[6]: [install-data-local] Error 1 (ignored)
+    make V=1 -j${MASON_CONCURRENCY} -i -k
+    make install -i -k
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"

--- a/scripts/cairo/1.14.6/script.sh
+++ b/scripts/cairo/1.14.6/script.sh
@@ -20,10 +20,10 @@ function mason_prepare_compile {
     cd $(dirname ${MASON_ROOT})
     ${MASON_DIR}/mason install libpng 1.6.24
     MASON_PNG=$(${MASON_DIR}/mason prefix libpng 1.6.24)
-    ${MASON_DIR}/mason install freetype 2.6
-    MASON_FREETYPE=$(${MASON_DIR}/mason prefix freetype 2.6)
-    ${MASON_DIR}/mason install pixman 0.32.6
-    MASON_PIXMAN=$(${MASON_DIR}/mason prefix pixman 0.32.6)
+    ${MASON_DIR}/mason install freetype 2.6.5
+    MASON_FREETYPE=$(${MASON_DIR}/mason prefix freetype 2.6.5)
+    ${MASON_DIR}/mason install pixman 0.34.0
+    MASON_PIXMAN=$(${MASON_DIR}/mason prefix pixman 0.34.0)
 }
 
 function mason_compile {

--- a/scripts/cairo/1.14.6/script.sh
+++ b/scripts/cairo/1.14.6/script.sh
@@ -8,10 +8,10 @@ MASON_LIB_FILE=lib/libcairo.a
 
 function mason_load_source {
     mason_download \
-        http://cairographics.org/releases/${MASON_NAME}-${MASON_VERSION}.tar.gz \
-        ecf18db1e89d99799783757d9026a74012dfafcb
+        http://cairographics.org/releases/${MASON_NAME}-${MASON_VERSION}.tar.xz \
+        b19d7d7b4e290eb6377ddc3688984cb66da036cb
 
-    mason_extract_tar_gz
+    mason_extract_tar_xz
 
     export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
 }
@@ -27,12 +27,8 @@ function mason_prepare_compile {
 }
 
 function mason_compile {
-    mason_step "Loading patch 'https://github.com/mapbox/mason/blob/${MASON_SLUG}/patch.diff'..."
-    curl --retry 3 -s -f -# -L \
-      https://raw.githubusercontent.com/mapbox/mason/${MASON_SLUG}/patch.diff \
-      -O || (mason_error "Could not find patch for ${MASON_SLUG}" && exit 1)
-    # patch cairo to avoid needing pkg-config as a build dep
-    patch -N -p1 < ./patch.diff
+    mason_step "Loading patch"
+    patch -N -p1 < ${MASON_DIR}/scripts/${MASON_NAME}/${MASON_VERSION}/patch.diff
     CFLAGS="${CFLAGS} -Wno-enum-conversion -I${MASON_PIXMAN}/include/pixman-1 -I${MASON_FREETYPE}/include/freetype2 -I${MASON_PNG}/include/"
     LDFLAGS="-L${MASON_PIXMAN}/lib -lpixman-1 -L${MASON_FREETYPE}/lib -lfreetype -L${MASON_PNG}/lib -lpng"
     CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} ./autogen.sh \

--- a/scripts/expat/2.2.0/.travis.yml
+++ b/scripts/expat/2.2.0/.travis.yml
@@ -1,0 +1,20 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode7.3
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+
+after_success:
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/expat/2.2.0/.travis.yml
+++ b/scripts/expat/2.2.0/.travis.yml
@@ -1,5 +1,3 @@
-language: generic
-
 matrix:
   include:
     - os: osx
@@ -12,9 +10,3 @@ matrix:
            - ubuntu-toolchain-r-test
           packages:
            - libstdc++-5-dev
-
-script:
-- ./mason build ${MASON_NAME} ${MASON_VERSION}
-
-after_success:
-- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/expat/2.2.0/script.sh
+++ b/scripts/expat/2.2.0/script.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+MASON_NAME=expat
+MASON_VERSION=2.2.0
+MASON_LIB_FILE=lib/libexpat.a
+MASON_PKGCONFIG_FILE=lib/pkgconfig/expat.pc
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        http://downloads.sourceforge.net/project/${MASON_NAME}/${MASON_NAME}/${MASON_VERSION}/${MASON_NAME}-${MASON_VERSION}.tar.bz2 \
+        de632147cebfb22e51c8ef35fe0f8badcd424a47
+
+    mason_extract_tar_bz2
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
+}
+
+function mason_compile {
+    ./configure \
+        --prefix=${MASON_PREFIX} \
+        ${MASON_HOST_ARG} \
+        --enable-static \
+        --disable-shared \
+        --disable-dependency-tracking
+
+    make install -j${MASON_CONCURRENCY}
+}
+
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"

--- a/scripts/freetype/2.6.5/.travis.yml
+++ b/scripts/freetype/2.6.5/.travis.yml
@@ -1,0 +1,20 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode7.3
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+
+after_success:
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/freetype/2.6.5/.travis.yml
+++ b/scripts/freetype/2.6.5/.travis.yml
@@ -1,5 +1,3 @@
-language: generic
-
 matrix:
   include:
     - os: osx
@@ -12,9 +10,3 @@ matrix:
            - ubuntu-toolchain-r-test
           packages:
            - libstdc++-5-dev
-
-script:
-- ./mason build ${MASON_NAME} ${MASON_VERSION}
-
-after_success:
-- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/freetype/2.6.5/script.sh
+++ b/scripts/freetype/2.6.5/script.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+MASON_NAME=freetype
+MASON_VERSION=2.6.5
+MASON_LIB_FILE=lib/libfreetype.a
+MASON_PKGCONFIG_FILE=lib/pkgconfig/freetype2.pc
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        http://nongnu.askapache.com/freetype/freetype-${MASON_VERSION}.tar.bz2 \
+        24dd30c95d3795cb3d82a760b9858992de262630
+
+    mason_extract_tar_bz2
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/freetype-${MASON_VERSION}
+}
+
+function mason_compile {
+    ./configure --prefix=${MASON_PREFIX} \
+     --enable-static \
+     --disable-shared ${MASON_HOST_ARG} \
+     --with-zlib=yes \
+     --with-bzip2=no \
+     --with-harfbuzz=no \
+     --with-png=no \
+     --with-quickdraw-toolbox=no \
+     --with-quickdraw-carbon=no \
+     --with-ats=no \
+     --with-fsref=no \
+     --with-fsspec=no \
+
+    make -j${MASON_CONCURRENCY}
+    make install
+}
+
+function mason_ldflags {
+    : # We're only using the full path to the archive, which is output in static_libs
+}
+
+function mason_cflags {
+    echo "-I${MASON_PREFIX}/include/freetype2"
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"

--- a/scripts/gdal/2.1.1/.travis.yml
+++ b/scripts/gdal/2.1.1/.travis.yml
@@ -1,0 +1,27 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode7.3
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason link ${MASON_NAME} ${MASON_VERSION}
+- export GDAL_DATA=$(pwd)/mason_packages/.link/share/gdal
+- ./mason_packages/.link/bin/ogr2ogr --formats
+- if [[ $(uname -s) == 'Darwin' ]]; then otool -L ./mason_packages/.link/bin/ogr2ogr; else ldd ./mason_packages/.link/bin/ogr2ogr; fi;
+- ./mason_packages/.link/bin/gdalinfo --formats
+- if [[ $(uname -s) == 'Darwin' ]]; then otool -L ./mason_packages/.link/bin/gdalinfo; else ldd ./mason_packages/.link/bin/gdalinfo; fi;
+
+after_success:
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/gdal/2.1.1/.travis.yml
+++ b/scripts/gdal/2.1.1/.travis.yml
@@ -1,10 +1,7 @@
-language: generic
-
 matrix:
   include:
     - os: osx
       osx_image: xcode7.3
-      compiler: clang
     - os: linux
       sudo: false
       addons:
@@ -13,15 +10,3 @@ matrix:
            - ubuntu-toolchain-r-test
           packages:
            - libstdc++-5-dev
-
-script:
-- ./mason build ${MASON_NAME} ${MASON_VERSION}
-- ./mason link ${MASON_NAME} ${MASON_VERSION}
-- export GDAL_DATA=$(pwd)/mason_packages/.link/share/gdal
-- ./mason_packages/.link/bin/ogr2ogr --formats
-- if [[ $(uname -s) == 'Darwin' ]]; then otool -L ./mason_packages/.link/bin/ogr2ogr; else ldd ./mason_packages/.link/bin/ogr2ogr; fi;
-- ./mason_packages/.link/bin/gdalinfo --formats
-- if [[ $(uname -s) == 'Darwin' ]]; then otool -L ./mason_packages/.link/bin/gdalinfo; else ldd ./mason_packages/.link/bin/gdalinfo; fi;
-
-after_success:
-- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/gdal/2.1.1/patch.diff
+++ b/scripts/gdal/2.1.1/patch.diff
@@ -1,0 +1,133 @@
+diff --git a/apps/GNUmakefile b/apps/GNUmakefile
+index 2f6b749..7d8059c 100644
+--- a/apps/GNUmakefile
++++ b/apps/GNUmakefile
+@@ -44,97 +44,97 @@ lib-depend:
+ 	(cd ../port ; $(MAKE) )
+ 
+ gdalinfo$(EXE):	gdalinfo.$(OBJ_EXT) commonutils.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdalserver$(EXE):	gdalserver.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdal_translate$(EXE):	gdal_translate.$(OBJ_EXT) commonutils.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdaladdo$(EXE):	gdaladdo.$(OBJ_EXT)  $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdalwarp$(EXE): gdalwarp.$(OBJ_EXT) commonutils.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdal_contour$(EXE):	gdal_contour.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ nearblack$(EXE):	nearblack.$(OBJ_EXT) commonutils.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdalmanage$(EXE):	gdalmanage.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdal_rasterize$(EXE):	gdal_rasterize.$(OBJ_EXT) commonutils.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdaltindex$(EXE):	gdaltindex.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdalbuildvrt$(EXE):	gdalbuildvrt.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ multireadtest$(EXE):	multireadtest.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ dumpoverviews$(EXE):	dumpoverviews.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdalenhance$(EXE):	gdalenhance.$(OBJ_EXT) commonutils.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdaldem$(EXE): gdaldem.$(OBJ_EXT) commonutils.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdal_grid$(EXE):	gdal_grid.$(OBJ_EXT) commonutils.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdalwarpsimple$(EXE): gdalwarpsimple.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdaltransform$(EXE): gdaltransform.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdallocationinfo$(EXE): gdallocationinfo.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdalsrsinfo$(EXE):	gdalsrsinfo.$(OBJ_EXT) commonutils.$(OBJ_EXT)  $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdalflattenmask$(EXE): gdalflattenmask.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdaltorture$(EXE): gdaltorture.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdal2ogr$(EXE):	gdal2ogr.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ ogrinfo$(EXE):	ogrinfo.$(OBJ_EXT) commonutils.$(OBJ_EXT)  $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< commonutils.$(OBJ_EXT)  $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< commonutils.$(OBJ_EXT)  $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ ogrlineref$(EXE):	ogrlineref.$(OBJ_EXT) commonutils.$(OBJ_EXT)  $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< commonutils.$(OBJ_EXT)  $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< commonutils.$(OBJ_EXT)  $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ ogr2ogr$(EXE):	ogr2ogr.$(OBJ_EXT) commonutils.$(OBJ_EXT)  $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ testepsg$(EXE):	testepsg.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ ogrtindex$(EXE):	ogrtindex.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ test_ogrsf$(EXE):	test_ogrsf.$(OBJ_EXT) commonutils.$(OBJ_EXT)  $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdalasyncread$(EXE):	gdalasyncread.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ testreprojmulti$(EXE):	testreprojmulti.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ clean:
+ 	$(RM) *.o $(BIN_LIST) core gdal-config gdal-config-inst

--- a/scripts/gdal/2.1.1/patch.diff
+++ b/scripts/gdal/2.1.1/patch.diff
@@ -1,51 +1,51 @@
 diff --git a/apps/GNUmakefile b/apps/GNUmakefile
-index 2f6b749..7d8059c 100644
+index a87cd0f..931a988 100644
 --- a/apps/GNUmakefile
 +++ b/apps/GNUmakefile
-@@ -44,97 +44,97 @@ lib-depend:
- 	(cd ../port ; $(MAKE) )
+@@ -79,103 +79,103 @@ gdalbuildvrt_lib.$(OBJ_EXT): gdalbuildvrt_lib.cpp
+ 	$(CXX) -c $(GDAL_INCLUDE) $(CPPFLAGS) $(CXXFLAGS) $< -o $@
  
- gdalinfo$(EXE):	gdalinfo.$(OBJ_EXT) commonutils.$(OBJ_EXT) $(DEP_LIBS)
--	$(LD) $(LNK_FLAGS) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@
-+	$(LD) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ gdalinfo$(EXE):	gdalinfo_bin.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) $(CONFIG_LIB_UTILS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) $(CONFIG_LIB_UTILS) -o $@ $(LNK_FLAGS)
  
  gdalserver$(EXE):	gdalserver.$(OBJ_EXT) $(DEP_LIBS)
 -	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
 +	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
  
- gdal_translate$(EXE):	gdal_translate.$(OBJ_EXT) commonutils.$(OBJ_EXT) $(DEP_LIBS)
--	$(LD) $(LNK_FLAGS) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@
-+	$(LD) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ gdal_translate$(EXE):	gdal_translate_bin.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
  
  gdaladdo$(EXE):	gdaladdo.$(OBJ_EXT)  $(DEP_LIBS)
 -	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
 +	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
  
- gdalwarp$(EXE): gdalwarp.$(OBJ_EXT) commonutils.$(OBJ_EXT) $(DEP_LIBS)
--	$(LD) $(LNK_FLAGS) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@
-+	$(LD) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ gdalwarp$(EXE): gdalwarp_bin.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
  
  gdal_contour$(EXE):	gdal_contour.$(OBJ_EXT) $(DEP_LIBS)
 -	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
 +	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
  
- nearblack$(EXE):	nearblack.$(OBJ_EXT) commonutils.$(OBJ_EXT) $(DEP_LIBS)
--	$(LD) $(LNK_FLAGS) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@
-+	$(LD) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ nearblack$(EXE):	nearblack_bin.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
  
  gdalmanage$(EXE):	gdalmanage.$(OBJ_EXT) $(DEP_LIBS)
 -	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
 +	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
  
- gdal_rasterize$(EXE):	gdal_rasterize.$(OBJ_EXT) commonutils.$(OBJ_EXT) $(DEP_LIBS)
--	$(LD) $(LNK_FLAGS) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@
-+	$(LD) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ gdal_rasterize$(EXE):	gdal_rasterize_bin.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
  
  gdaltindex$(EXE):	gdaltindex.$(OBJ_EXT) $(DEP_LIBS)
 -	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
 +	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
  
- gdalbuildvrt$(EXE):	gdalbuildvrt.$(OBJ_EXT) $(DEP_LIBS)
+ gdalbuildvrt$(EXE):	gdalbuildvrt_bin.$(OBJ_EXT) $(DEP_LIBS)
 -	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
 +	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
  
@@ -57,17 +57,17 @@ index 2f6b749..7d8059c 100644
 -	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
 +	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
  
- gdalenhance$(EXE):	gdalenhance.$(OBJ_EXT) commonutils.$(OBJ_EXT) $(DEP_LIBS)
--	$(LD) $(LNK_FLAGS) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@
-+	$(LD) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ gdalenhance$(EXE):	gdalenhance.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
  
- gdaldem$(EXE): gdaldem.$(OBJ_EXT) commonutils.$(OBJ_EXT) $(DEP_LIBS)
--	$(LD) $(LNK_FLAGS) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@
-+	$(LD) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ gdaldem$(EXE): gdaldem_bin.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
  
- gdal_grid$(EXE):	gdal_grid.$(OBJ_EXT) commonutils.$(OBJ_EXT) $(DEP_LIBS)
--	$(LD) $(LNK_FLAGS) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@
-+	$(LD) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ gdal_grid$(EXE):	gdal_grid_bin.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
  
  gdalwarpsimple$(EXE): gdalwarpsimple.$(OBJ_EXT) $(DEP_LIBS)
 -	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
@@ -81,9 +81,9 @@ index 2f6b749..7d8059c 100644
 -	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
 +	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
  
- gdalsrsinfo$(EXE):	gdalsrsinfo.$(OBJ_EXT) commonutils.$(OBJ_EXT)  $(DEP_LIBS)
--	$(LD) $(LNK_FLAGS) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@
-+	$(LD) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ gdalsrsinfo$(EXE):	gdalsrsinfo.$(OBJ_EXT)  $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
  
  gdalflattenmask$(EXE): gdalflattenmask.$(OBJ_EXT) $(DEP_LIBS)
 -	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
@@ -97,17 +97,17 @@ index 2f6b749..7d8059c 100644
 -	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
 +	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
  
- ogrinfo$(EXE):	ogrinfo.$(OBJ_EXT) commonutils.$(OBJ_EXT)  $(DEP_LIBS)
--	$(LD) $(LNK_FLAGS) $< commonutils.$(OBJ_EXT)  $(XTRAOBJ) $(CONFIG_LIBS) -o $@
-+	$(LD) $< commonutils.$(OBJ_EXT)  $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ ogrinfo$(EXE):	ogrinfo.$(OBJ_EXT)  $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $<  $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $<  $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
  
- ogrlineref$(EXE):	ogrlineref.$(OBJ_EXT) commonutils.$(OBJ_EXT)  $(DEP_LIBS)
--	$(LD) $(LNK_FLAGS) $< commonutils.$(OBJ_EXT)  $(XTRAOBJ) $(CONFIG_LIBS) -o $@
-+	$(LD) $< commonutils.$(OBJ_EXT)  $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ ogrlineref$(EXE):	ogrlineref.$(OBJ_EXT)  $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $<  $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $<  $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
  
- ogr2ogr$(EXE):	ogr2ogr.$(OBJ_EXT) commonutils.$(OBJ_EXT)  $(DEP_LIBS)
--	$(LD) $(LNK_FLAGS) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@
-+	$(LD) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ ogr2ogr$(EXE):	ogr2ogr_bin.$(OBJ_EXT)  $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
  
  testepsg$(EXE):	testepsg.$(OBJ_EXT) $(DEP_LIBS)
 -	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
@@ -117,15 +117,23 @@ index 2f6b749..7d8059c 100644
 -	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
 +	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
  
- test_ogrsf$(EXE):	test_ogrsf.$(OBJ_EXT) commonutils.$(OBJ_EXT)  $(DEP_LIBS)
--	$(LD) $(LNK_FLAGS) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@
-+	$(LD) $< commonutils.$(OBJ_EXT) $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ test_ogrsf$(EXE):	test_ogrsf.$(OBJ_EXT)  $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
  
  gdalasyncread$(EXE):	gdalasyncread.$(OBJ_EXT) $(DEP_LIBS)
 -	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
 +	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
  
  testreprojmulti$(EXE):	testreprojmulti.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gnmmanage$(EXE):	gnmmanage.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gnmanalyse$(EXE):	gnmanalyse.$(OBJ_EXT) $(DEP_LIBS)
 -	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
 +	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
  

--- a/scripts/gdal/2.1.1/script.sh
+++ b/scripts/gdal/2.1.1/script.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+
+MASON_NAME=gdal
+MASON_VERSION=2.1.1
+MASON_LIB_FILE=lib/libgdal.a
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        http://download.osgeo.org/gdal/${MASON_VERSION}/gdal-${MASON_VERSION}.tar.gz \
+        66aa2e083027cff36c000060f4e61ce5e1405307
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
+}
+
+function mason_prepare_compile {
+    cd $(dirname ${MASON_ROOT})
+    # set up to fix libtool .la files
+    # https://github.com/mapbox/mason/issues/61
+    if [[ $(uname -s) == 'Darwin' ]]; then
+        FIND="\/Users\/travis\/build\/mapbox\/mason"
+    else
+        FIND="\/home\/travis\/build\/mapbox\/mason"
+    fi
+    REPLACE="$(pwd)"
+    REPLACE=${REPLACE////\\/}
+    ${MASON_DIR}/mason install libtiff 4.0.6
+    MASON_TIFF=$(${MASON_DIR}/mason prefix libtiff 4.0.6)
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_TIFF}/lib/libtiff.la
+    ${MASON_DIR}/mason install proj 4.9.2
+    MASON_PROJ=$(${MASON_DIR}/mason prefix proj 4.9.2)
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_PROJ}/lib/libproj.la
+    ${MASON_DIR}/mason install jpeg_turbo 1.5.0
+    MASON_JPEG=$(${MASON_DIR}/mason prefix jpeg_turbo 1.5.0)
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_JPEG}/lib/libjpeg.la
+    ${MASON_DIR}/mason install libpng 1.6.24
+    MASON_PNG=$(${MASON_DIR}/mason prefix libpng 1.6.24)
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_PNG}/lib/libpng.la
+    ${MASON_DIR}/mason install expat 2.2.0
+    MASON_EXPAT=$(${MASON_DIR}/mason prefix expat 2.2.0)
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_EXPAT}/lib/libexpat.la
+    ${MASON_DIR}/mason install libpq 9.5.2
+    MASON_LIBPQ=$(${MASON_DIR}/mason prefix libpq 9.5.2)
+    # depends on sudo apt-get install zlib1g-dev
+    ${MASON_DIR}/mason install zlib system
+    MASON_ZLIB=$(${MASON_DIR}/mason prefix zlib system)
+    # depends on sudo apt-get install libc6-dev
+    #${MASON_DIR}/mason install iconv system
+    #MASON_ICONV=$(${MASON_DIR}/mason prefix iconv system)
+    export LIBRARY_PATH=${MASON_LIBPQ}/lib:$LIBRARY_PATH
+}
+
+function mason_compile {
+    if [[ ${MASON_PLATFORM} == 'linux' ]]; then
+        mason_step "Loading patch"
+        patch -N -p1 < ${MASON_DIR}/scripts/${MASON_NAME}/${MASON_VERSION}/patch.diff
+    fi
+    CUSTOM_LIBS="-L${MASON_TIFF}/lib -ltiff -L${MASON_JPEG}/lib -ljpeg -L${MASON_PROJ}/lib -lproj -L${MASON_PNG}/lib -lpng -L${MASON_EXPAT}/lib -lexpat"
+    CUSTOM_CFLAGS="${CFLAGS} -I${MASON_LIBPQ}/include -I${MASON_TIFF}/include -I${MASON_JPEG}/include -I${MASON_PROJ}/include -I${MASON_PNG}/include -I${MASON_EXPAT}/include"
+
+    # very custom handling for libpq/postgres support
+    # forcing our portable static library to be used
+    MASON_LIBPQ_PATH=${MASON_LIBPQ}/lib/libpq.a
+    if [[ $(uname -s) == 'Linux' ]]; then
+        # on Linux passing -Wl will lead to libtool re-positioning libpq.a in the wrong place (no longer after libgdal.a)
+        # which leads to unresolved symbols
+        CUSTOM_LDFLAGS="${LDFLAGS} ${MASON_LIBPQ_PATH}"
+    else
+        # on OSX not passing -Wl will break libtool archive creation leading to confusing arch errors
+        CUSTOM_LDFLAGS="${LDFLAGS} -Wl,${MASON_LIBPQ_PATH}"
+    fi
+    # we have to remove -lpq otherwise it will trigger linking to system /usr/lib/libpq
+    perl -i -p -e "s/\-lpq //g;" configure
+    # on linux -Wl,/path/to/libpq.a still does not work for the configure test
+    # so we have to force it into LIBS. But we don't do this on OS X since it breaks libtool archive logic
+    if [[ $(uname -s) == 'Linux' ]]; then
+        CUSTOM_LIBS="${MASON_LIBPQ}/lib/libpq.a -pthread ${CUSTOM_LIBS}"
+    fi
+
+    # note: we put ${STDLIB_CXXFLAGS} into CXX instead of LDFLAGS due to libtool oddity:
+    # http://stackoverflow.com/questions/16248360/autotools-libtool-link-library-with-libstdc-despite-stdlib-libc-option-pass
+    if [[ $(uname -s) == 'Darwin' ]]; then
+        CXX="${CXX} -stdlib=libc++ -std=c++11"
+    fi
+
+    # note: it might be tempting to build with --without-libtool
+    # but I find that will only lead to a shared libgdal.so and will
+    # not produce a static library even if --enable-static is passed
+    LIBS="${CUSTOM_LIBS}" LDFLAGS="${CUSTOM_LDFLAGS}" CFLAGS="${CUSTOM_CFLAGS}" ./configure \
+        --enable-static --disable-shared \
+        ${MASON_HOST_ARG} \
+        --prefix=${MASON_PREFIX} \
+        --with-libz=${MASON_ZLIB} \
+        --disable-rpath \
+        --with-libjson-c=internal \
+        --with-geotiff=internal \
+        --with-expat=${MASON_EXPAT} \
+        --with-threads=yes \
+        --with-fgdb=no \
+        --with-rename-internal-libtiff-symbols=no \
+        --with-rename-internal-libgeotiff-symbols=no \
+        --with-hide-internal-symbols=yes \
+        --with-libtiff=${MASON_TIFF} \
+        --with-jpeg=${MASON_JPEG} \
+        --with-png=${MASON_PNG} \
+        --with-pg=${MASON_LIBPQ}/bin/pg_config \
+        --with-static-proj4=${MASON_PROJ} \
+        --with-spatialite=no \
+        --with-geos=no \
+        --with-sqlite3=no \
+        --with-curl=no \
+        --with-xml2=no \
+        --with-pcraster=no \
+        --with-cfitsio=no \
+        --with-odbc=no \
+        --with-libkml=no \
+        --with-pcidsk=no \
+        --with-jasper=no \
+        --with-gif=no \
+        --with-grib=no \
+        --with-freexl=no \
+        --with-avx=no \
+        --with-sse=no \
+        --with-perl=no \
+        --with-ruby=no \
+        --with-python=no \
+        --with-java=no \
+        --with-podofo=no \
+        --with-pam \
+        --with-webp=no \
+        --with-pcre=no \
+        --with-liblzma=no \
+        --with-netcdf=no \
+        --with-poppler=no
+
+    make -j${MASON_CONCURRENCY}
+    make install
+
+    # attempt to make paths relative in gdal-config
+    python -c "data=open('$MASON_PREFIX/bin/gdal-config','r').read();open('$MASON_PREFIX/bin/gdal-config','w').write(data.replace('$MASON_PREFIX','\$( cd \"\$( dirname \$( dirname \"\$0\" ))\" && pwd )'))"
+    # hack to re-add -lpq since otherwise it will not end up in --dep-libs
+    python -c "data=open('$MASON_PREFIX/bin/gdal-config','r').read();open('$MASON_PREFIX/bin/gdal-config','w').write(data.replace('\$CONFIG_DEP_LIBS','\$CONFIG_DEP_LIBS -lpq'))"
+    cat $MASON_PREFIX/bin/gdal-config
+}
+
+function mason_cflags {
+    echo "-I${MASON_PREFIX}/include/gdal"
+}
+
+function mason_ldflags {
+    echo $(${MASON_PREFIX}/bin/gdal-config --static --libs)
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"

--- a/scripts/gdal/2.1.1/script.sh
+++ b/scripts/gdal/2.1.1/script.sh
@@ -142,9 +142,13 @@ function mason_compile {
     # attempt to make paths relative in gdal-config
     # TODO: remove libpg.a from CONFIG_DEP_LIBS on linux?
     # fix the path to -lgdal to be relative (CONFIG_LIBS,CONFIG_PREFIX,CONFIG_CFLAGS)
-    python -c "data=open('$MASON_PREFIX/bin/gdal-config','r').read();open('$MASON_PREFIX/bin/gdal-config','w').write(data.replace('$MASON_PREFIX','\$( cd \"\$( dirname \$( dirname \$( realpath \"\$0\" ) ))\" && pwd )'))"
+    RESOLVE_SYMLINK="readlink"
+    if [[ $(uname -s) == 'Linux' ]];then
+        RESOLVE_SYMLINK="readlink -f"
+    fi
+    python -c "data=open('$MASON_PREFIX/bin/gdal-config','r').read();open('$MASON_PREFIX/bin/gdal-config','w').write(data.replace('$MASON_PREFIX','\$( cd \"\$( dirname \$( dirname \$( $RESOLVE_SYMLINK \"\$0\" ) ))\" && pwd )'))"
     # fix the path to dep libs (CONFIG_DEP_LIBS)
-    python -c "data=open('$MASON_PREFIX/bin/gdal-config','r').read();open('$MASON_PREFIX/bin/gdal-config','w').write(data.replace('${MASON_ROOT}/${MASON_PLATFORM_ID}','\$( cd \"\$( dirname \$( dirname \$( dirname \$( dirname \$( realpath \"\$0\" ) ) ) ))\" && pwd )'))"
+    python -c "data=open('$MASON_PREFIX/bin/gdal-config','r').read();open('$MASON_PREFIX/bin/gdal-config','w').write(data.replace('${MASON_ROOT}/${MASON_PLATFORM_ID}','\$( cd \"\$( dirname \$( dirname \$( dirname \$( dirname \$( $RESOLVE_SYMLINK \"\$0\" ) ) ) ))\" && pwd )'))"
     # hack to re-add -lpq since otherwise it will not end up in --dep-libs
     python -c "data=open('$MASON_PREFIX/bin/gdal-config','r').read();open('$MASON_PREFIX/bin/gdal-config','w').write(data.replace('\$CONFIG_DEP_LIBS','\$CONFIG_DEP_LIBS -lpq'))"
     cat $MASON_PREFIX/bin/gdal-config

--- a/scripts/gdal/2.1.1/script.sh
+++ b/scripts/gdal/2.1.1/script.sh
@@ -140,7 +140,11 @@ function mason_compile {
     make install
 
     # attempt to make paths relative in gdal-config
-    python -c "data=open('$MASON_PREFIX/bin/gdal-config','r').read();open('$MASON_PREFIX/bin/gdal-config','w').write(data.replace('$MASON_PREFIX','\$( cd \"\$( dirname \$( dirname \"\$0\" ))\" && pwd )'))"
+    # TODO: remove libpg.a from CONFIG_DEP_LIBS on linux?
+    # fix the path to -lgdal to be relative (CONFIG_LIBS,CONFIG_PREFIX,CONFIG_CFLAGS)
+    python -c "data=open('$MASON_PREFIX/bin/gdal-config','r').read();open('$MASON_PREFIX/bin/gdal-config','w').write(data.replace('$MASON_PREFIX','\$( cd \"\$( dirname \$( dirname \$( realpath \"\$0\" ) ))\" && pwd )'))"
+    # fix the path to dep libs (CONFIG_DEP_LIBS)
+    python -c "data=open('$MASON_PREFIX/bin/gdal-config','r').read();open('$MASON_PREFIX/bin/gdal-config','w').write(data.replace('${MASON_ROOT}/${MASON_PLATFORM_ID}','\$( cd \"\$( dirname \$( dirname \$( dirname \$( dirname \$( realpath \"\$0\" ) ) ) ))\" && pwd )'))"
     # hack to re-add -lpq since otherwise it will not end up in --dep-libs
     python -c "data=open('$MASON_PREFIX/bin/gdal-config','r').read();open('$MASON_PREFIX/bin/gdal-config','w').write(data.replace('\$CONFIG_DEP_LIBS','\$CONFIG_DEP_LIBS -lpq'))"
     cat $MASON_PREFIX/bin/gdal-config

--- a/scripts/harfbuzz/1.3.0/.travis.yml
+++ b/scripts/harfbuzz/1.3.0/.travis.yml
@@ -1,0 +1,20 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode7.3
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+
+after_success:
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/harfbuzz/1.3.0/.travis.yml
+++ b/scripts/harfbuzz/1.3.0/.travis.yml
@@ -1,5 +1,3 @@
-language: generic
-
 matrix:
   include:
     - os: osx
@@ -12,9 +10,3 @@ matrix:
            - ubuntu-toolchain-r-test
           packages:
            - libstdc++-5-dev
-
-script:
-- ./mason build ${MASON_NAME} ${MASON_VERSION}
-
-after_success:
-- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/harfbuzz/1.3.0/script.sh
+++ b/scripts/harfbuzz/1.3.0/script.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+MASON_NAME=harfbuzz
+MASON_VERSION=1.3.0
+MASON_LIB_FILE=lib/libharfbuzz.a
+MASON_PKGCONFIG_FILE=lib/pkgconfig/harfbuzz.pc
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-${MASON_VERSION}.tar.bz2 \
+        f5674500c67484caa2c9936270d0a100e52f56f0
+
+    mason_extract_tar_bz2
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
+}
+
+function mason_prepare_compile {
+    FREETYPE_VERSION="2.6.5"
+    ${MASON_DIR}/mason install freetype ${FREETYPE_VERSION}
+    MASON_FREETYPE=$(${MASON_DIR}/mason prefix freetype ${FREETYPE_VERSION})
+    MASON_PLATFORM= ${MASON_DIR}/mason install ragel 6.9
+    export PATH=$(MASON_PLATFORM= ${MASON_DIR}/mason prefix ragel 6.9)/bin:$PATH
+    export PKG_CONFIG_PATH="$(${MASON_DIR}/mason prefix freetype ${FREETYPE_VERSION})/lib/pkgconfig":$PKG_CONFIG_PATH
+    export C_INCLUDE_PATH="${MASON_FREETYPE}/include/freetype2"
+    export CPLUS_INCLUDE_PATH="${MASON_FREETYPE}/include/freetype2"
+    export LIBRARY_PATH="${MASON_FREETYPE}/lib"
+    if [[ ! `which pkg-config` ]]; then
+        echo "harfbuzz configure needs pkg-config, please install pkg-config"
+        exit 1
+    fi
+}
+
+function mason_compile {
+    export FREETYPE_CFLAGS="-I${MASON_FREETYPE}/include/freetype2"
+    export FREETYPE_LIBS="-L${MASON_FREETYPE}/lib -lfreetype -lz"
+    export CXXFLAGS="${CXXFLAGS} ${FREETYPE_CFLAGS}"
+    export CFLAGS="${CFLAGS} ${FREETYPE_CFLAGS}"
+    export LDFLAGS="${LDFLAGS} ${FREETYPE_LIBS}"
+
+    ./configure --prefix=${MASON_PREFIX} ${MASON_HOST_ARG} \
+     --enable-static \
+     --disable-shared \
+     --disable-dependency-tracking \
+     --with-icu=no \
+     --with-cairo=no \
+     --with-glib=no \
+     --with-gobject=no \
+     --with-graphite2=no \
+     --with-freetype \
+     --with-uniscribe=no \
+     --with-coretext=no
+
+    make -j${MASON_CONCURRENCY} V=1
+    make install
+}
+
+function mason_ldflags {
+    : # We're only using the full path to the archive, which is output in static_libs
+}
+
+function mason_cflags {
+    echo "-I${MASON_PREFIX}/include"
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"

--- a/scripts/jpeg_turbo/1.5.0/.travis.yml
+++ b/scripts/jpeg_turbo/1.5.0/.travis.yml
@@ -1,0 +1,20 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode7.3
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+
+after_success:
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/jpeg_turbo/1.5.0/.travis.yml
+++ b/scripts/jpeg_turbo/1.5.0/.travis.yml
@@ -1,5 +1,3 @@
-language: generic
-
 matrix:
   include:
     - os: osx
@@ -12,9 +10,3 @@ matrix:
            - ubuntu-toolchain-r-test
           packages:
            - libstdc++-5-dev
-
-script:
-- ./mason build ${MASON_NAME} ${MASON_VERSION}
-
-after_success:
-- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/jpeg_turbo/1.5.0/script.sh
+++ b/scripts/jpeg_turbo/1.5.0/script.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+MASON_NAME=jpeg_turbo
+MASON_VERSION=1.5.0
+MASON_LIB_FILE=lib/libjpeg.a
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        http://downloads.sourceforge.net/project/libjpeg-turbo/${MASON_VERSION}/libjpeg-turbo-${MASON_VERSION}.tar.gz \
+        b90a76db4d0628bde8381150e355a858e3ced923
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/libjpeg-turbo-${MASON_VERSION}
+}
+
+function mason_prepare_compile {
+    MASON_PLATFORM= ${MASON_DIR}/mason install nasm 2.11.06
+    MASON_NASM=$(MASON_PLATFORM= ${MASON_DIR}/mason prefix nasm 2.11.06)
+}
+
+function mason_compile {
+    ./configure \
+        NASM="${MASON_NASM}/bin/nasm" \
+        --prefix=${MASON_PREFIX} \
+        ${MASON_HOST_ARG} \
+        --with-jpeg8 \
+        --enable-static \
+        --disable-shared \
+        --disable-dependency-tracking
+
+    make -j1 # -j1 since build breaks with concurrency
+    make install
+}
+
+function mason_cflags {
+    echo -I${MASON_PREFIX}/include
+}
+
+function mason_ldflags {
+    echo -L${MASON_PREFIX}/lib -ljpeg
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"

--- a/scripts/libpng/1.6.24/.travis.yml
+++ b/scripts/libpng/1.6.24/.travis.yml
@@ -1,0 +1,41 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode7.3
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
+    - os: linux
+      sudo: false
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v5
+    - os: linux
+      sudo: false
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v7
+    - os: linux
+      sudo: false
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v8
+    - os: linux
+      sudo: false
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=x86
+    - os: linux
+      sudo: false
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=x86-64
+    - os: linux
+      sudo: false
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=mips
+    - os: linux
+      sudo: false
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=mips-64
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+
+after_success:
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/libpng/1.6.24/script.sh
+++ b/scripts/libpng/1.6.24/script.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+MASON_NAME=libpng
+MASON_VERSION=1.6.24
+MASON_LIB_FILE=lib/libpng.a
+MASON_PKGCONFIG_FILE=lib/pkgconfig/libpng.pc
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        http://superb-sea2.dl.sourceforge.net/project/${MASON_NAME}/${MASON_NAME}16/${MASON_VERSION}/${MASON_NAME}-${MASON_VERSION}.tar.gz \
+        ea724d11c25753ebad23ca0f63518b7f17c46a6a
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/libpng-${MASON_VERSION}
+}
+
+function mason_compile {
+    export CFLAGS="${CFLAGS:-} -O3"
+    ./configure \
+        --prefix=${MASON_PREFIX} \
+        ${MASON_HOST_ARG} \
+        --enable-static \
+        --with-pic \
+        --disable-shared \
+        --disable-dependency-tracking
+
+    make install -j${MASON_CONCURRENCY}
+}
+
+function mason_strip_ldflags {
+    shift # -L...
+    shift # -lpng16
+    echo "$@"
+}
+
+function mason_ldflags {
+    mason_strip_ldflags $(`mason_pkgconfig` --static --libs)
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"

--- a/scripts/libpq/9.5.2/.travis.yml
+++ b/scripts/libpq/9.5.2/.travis.yml
@@ -1,24 +1,12 @@
-language: cpp
-
-sudo: false
-
 matrix:
   include:
-    - os: linux
-      compiler: clang
     - os: osx
       osx_image: xcode7.3
-      compiler: clang
-
-env:
-  global:
-   - secure: "clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFnWLtmF3stlft5YWyc2kI+FI="
-   - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
-
-before_install:
-
-script:
-- ./mason build ${MASON_NAME} ${MASON_VERSION}
-
-after_success:
-- ./mason publish ${MASON_NAME} ${MASON_VERSION}
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev

--- a/scripts/libtiff/4.0.6/.travis.yml
+++ b/scripts/libtiff/4.0.6/.travis.yml
@@ -1,21 +1,17 @@
 language: generic
 
-sudo: false
-
 matrix:
   include:
     - os: osx
       osx_image: xcode7.3
-      compiler: clang
     - os: linux
-      compiler: clang
-
-env:
-  global:
-   - secure: "clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFnWLtmF3stlft5YWyc2kI+FI="
-   - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
-
-before_install:
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/libtiff/4.0.6/.travis.yml
+++ b/scripts/libtiff/4.0.6/.travis.yml
@@ -1,5 +1,3 @@
-language: generic
-
 matrix:
   include:
     - os: osx
@@ -12,9 +10,3 @@ matrix:
            - ubuntu-toolchain-r-test
           packages:
            - libstdc++-5-dev
-
-script:
-- ./mason build ${MASON_NAME} ${MASON_VERSION}
-
-after_success:
-- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/libtiff/4.0.6/script.sh
+++ b/scripts/libtiff/4.0.6/script.sh
@@ -21,7 +21,9 @@ function mason_prepare_compile {
     cd $(dirname ${MASON_ROOT})
     ${MASON_DIR}/mason install jpeg_turbo 1.5.0
     MASON_JPEG=$(${MASON_DIR}/mason prefix jpeg_turbo 1.5.0)
-    SYSTEM_ZLIB="/usr"
+    # depends on sudo apt-get install zlib1g-dev
+    ${MASON_DIR}/mason install zlib system
+    MASON_ZLIB=$(${MASON_DIR}/mason prefix zlib system)
 }
 
 
@@ -35,8 +37,8 @@ function mason_compile {
     --enable-chunky-strip-read \
     --with-jpeg-include-dir=${MASON_JPEG}/include \
     --with-jpeg-lib-dir=${MASON_JPEG}/lib \
-    --with-zlib-include-dir=${SYSTEM_ZLIB}/include \
-    --with-zlib-lib-dir=${SYSTEM_ZLIB}/lib \
+    --with-zlib-include-dir=${MASON_ZLIB}/include \
+    --with-zlib-lib-dir=${MASON_ZLIB}/lib \
     --disable-lzma --disable-jbig --disable-mdi \
     --without-x
 

--- a/scripts/libtiff/4.0.6/script.sh
+++ b/scripts/libtiff/4.0.6/script.sh
@@ -19,8 +19,8 @@ function mason_load_source {
 
 function mason_prepare_compile {
     cd $(dirname ${MASON_ROOT})
-    ${MASON_DIR}/mason install jpeg_turbo 1.4.2
-    MASON_JPEG=$(${MASON_DIR}/mason prefix jpeg_turbo 1.4.2)
+    ${MASON_DIR}/mason install jpeg_turbo 1.5.0
+    MASON_JPEG=$(${MASON_DIR}/mason prefix jpeg_turbo 1.5.0)
     SYSTEM_ZLIB="/usr"
 }
 

--- a/scripts/pixman/0.34.0/.travis.yml
+++ b/scripts/pixman/0.34.0/.travis.yml
@@ -1,0 +1,21 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode7.3
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+
+after_success:
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/pixman/0.34.0/.travis.yml
+++ b/scripts/pixman/0.34.0/.travis.yml
@@ -1,10 +1,7 @@
-language: generic
-
 matrix:
   include:
     - os: osx
       osx_image: xcode7.3
-      compiler: clang
     - os: linux
       sudo: false
       addons:
@@ -13,9 +10,3 @@ matrix:
            - ubuntu-toolchain-r-test
           packages:
            - libstdc++-5-dev
-
-script:
-- ./mason build ${MASON_NAME} ${MASON_VERSION}
-
-after_success:
-- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/pixman/0.34.0/script.sh
+++ b/scripts/pixman/0.34.0/script.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+MASON_NAME=pixman
+MASON_VERSION=0.34.0
+MASON_LIB_FILE=lib/libpixman-1.a
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        http://cairographics.org/releases/pixman-${MASON_VERSION}.tar.gz \
+        022e9e5856f4c5a8c9bdea3996c6b199683fce78
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
+}
+
+function mason_compile {
+    ./configure \
+        --prefix=${MASON_PREFIX} \
+        ${MASON_HOST_ARG} \
+        --enable-static \
+        --disable-shared \
+        --disable-dependency-tracking \
+        --disable-mmx \
+        --disable-ssse3 \
+        --disable-libpng \
+        --disable-gtk
+
+    # The -i and -k flags are to workaround osx bug in pixman tests: Undefined symbols for architecture x86_64: "_prng_state
+    make -j${MASON_CONCURRENCY} -i -k
+    make install -i -k
+}
+
+function mason_cflags {
+    echo -I${MASON_PREFIX}/include
+}
+
+function mason_ldflags {
+    echo -L${MASON_PREFIX}/lib -ljpeg
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"

--- a/scripts/sqlite/3.14.1/.travis.yml
+++ b/scripts/sqlite/3.14.1/.travis.yml
@@ -1,0 +1,38 @@
+language: cpp
+
+sudo: false
+
+compiler: clang
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode7
+    - os: linux
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v5
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v7
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v8
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=x86
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=x86-64
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=mips
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=mips-64
+
+env:
+  global:
+   - secure: "clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFnWLtmF3stlft5YWyc2kI+FI="
+   - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
+
+before_install:
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+
+after_success:
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/sqlite/3.14.1/.travis.yml
+++ b/scripts/sqlite/3.14.1/.travis.yml
@@ -1,5 +1,3 @@
-language: generic
-
 matrix:
   include:
     - os: osx
@@ -26,9 +24,3 @@ matrix:
       env: MASON_PLATFORM=android MASON_ANDROID_ABI=mips
     - os: linux
       env: MASON_PLATFORM=android MASON_ANDROID_ABI=mips-64
-
-script:
-- ./mason build ${MASON_NAME} ${MASON_VERSION}
-
-after_success:
-- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/sqlite/3.14.1/.travis.yml
+++ b/scripts/sqlite/3.14.1/.travis.yml
@@ -1,14 +1,17 @@
-language: cpp
-
-sudo: false
-
-compiler: clang
+language: generic
 
 matrix:
   include:
     - os: osx
-      osx_image: xcode7
+      osx_image: xcode7.3
     - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
     - os: linux
       env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v5
     - os: linux
@@ -23,13 +26,6 @@ matrix:
       env: MASON_PLATFORM=android MASON_ANDROID_ABI=mips
     - os: linux
       env: MASON_PLATFORM=android MASON_ANDROID_ABI=mips-64
-
-env:
-  global:
-   - secure: "clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFnWLtmF3stlft5YWyc2kI+FI="
-   - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
-
-before_install:
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/sqlite/3.14.1/script.sh
+++ b/scripts/sqlite/3.14.1/script.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+MASON_NAME=sqlite
+MASON_VERSION=3.41.1
+MASON_LIB_FILE=lib/libsqlite3.a
+MASON_PKGCONFIG_FILE=lib/pkgconfig/sqlite3.pc
+
+SQLITE_FILE_VERSION=3140100
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        https://www.sqlite.org/2016/sqlite-autoconf-${SQLITE_FILE_VERSION}.tar.gz \
+        3cd6b9b45b3c8822d443e50587a242db7c05bbd4
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/sqlite-autoconf-${SQLITE_FILE_VERSION}
+}
+
+function mason_compile {
+    CFLAGS="-O3 ${CFLAGS}" ./configure \
+        --prefix=${MASON_PREFIX} \
+        ${MASON_HOST_ARG} \
+        --enable-static \
+        --with-pic \
+        --disable-shared \
+        --disable-dependency-tracking
+
+    make install -j${MASON_CONCURRENCY}
+}
+
+function mason_strip_ldflags {
+    shift # -L...
+    shift # -lsqlite3
+    echo "$@"
+}
+
+function mason_ldflags {
+    mason_strip_ldflags $(`mason_pkgconfig` --static --libs)
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"

--- a/scripts/webp/0.5.1/.travis.yml
+++ b/scripts/webp/0.5.1/.travis.yml
@@ -1,0 +1,20 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode7.3
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+
+after_success:
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/webp/0.5.1/.travis.yml
+++ b/scripts/webp/0.5.1/.travis.yml
@@ -1,5 +1,3 @@
-language: generic
-
 matrix:
   include:
     - os: osx
@@ -12,9 +10,3 @@ matrix:
            - ubuntu-toolchain-r-test
           packages:
            - libstdc++-5-dev
-
-script:
-- ./mason build ${MASON_NAME} ${MASON_VERSION}
-
-after_success:
-- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/webp/0.5.1/script.sh
+++ b/scripts/webp/0.5.1/script.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+MASON_NAME=webp
+MASON_VERSION=0.5.1
+MASON_LIB_FILE=lib/libwebp.a
+MASON_PKGCONFIG_FILE=lib/pkgconfig/libwebp.pc
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        http://downloads.webmproject.org/releases/webp/libwebp-$MASON_VERSION.tar.gz \
+        7c2350c6524e8419e6b541a9087607c91c957377
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/libwebp-${MASON_VERSION}
+}
+
+function mason_compile {
+    export CFLAGS="${CFLAGS:-} -Os"
+    ./configure \
+        --prefix=${MASON_PREFIX} \
+        ${MASON_HOST_ARG} \
+        --enable-static \
+        --disable-shared \
+        --with-pic \
+        --enable-libwebpdecoder \
+        --disable-cwebp \
+        --disable-dwebp \
+        --enable-swap-16bit-csp \
+        --disable-gl \
+        --disable-png \
+        --disable-jpeg \
+        --disable-tiff \
+        --disable-gif \
+        --disable-wic \
+        --disable-dependency-tracking
+
+    make install -j${MASON_CONCURRENCY}
+}
+
+function mason_strip_ldflags {
+    ldflags=()
+    while [[ $1 ]]
+    do
+        case "$1" in
+            -lwebp)
+                shift
+                ;;
+            -L*)
+                shift
+                ;;
+            *)
+                ldflags+=("$1")
+                shift
+                ;;
+        esac
+    done
+    echo "${ldflags[@]}"
+}
+
+function mason_ldflags {
+    mason_strip_ldflags $(`mason_pkgconfig` --static --libs)
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"


### PR DESCRIPTION
Adds new versions for:

  - freetype
  - harfbuzz
  - jpeg_turbo
  - gdal
  - libpng
  - sqlite
  - cairo
  - pixman
  - webp

Also:

 - Rebuilds libtiff against latest jpeg_turbo.
 - Builds cairo and gdal against latest jpeg, tiff, and libpng.
 - Fixes glitches in gdal-config to report correct paths to dependencies using relative paths
 - Enhances the trigger behavior so that packages do not need to repeat the `secure keys`, `language`, or `script` sections.

Before merging:

  - [ ] break out the trigger enhancement into a new PR
  - [ ] Point mapnik back to mason master rather than this PR: https://github.com/mapnik/mapnik/blob/abfd55c911b4dd9f6a4ecf9a875d168e3df14d88/bootstrap.sh#L14