### PR TITLE
RapidJSON 1.1.0

### DIFF
--- a/scripts/rapidjson/1.1.0/.travis.yml
+++ b/scripts/rapidjson/1.1.0/.travis.yml
@@ -1,0 +1,15 @@
+language: cpp
+sudo: false
+
+env:
+  global:
+   - secure: "clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFnWLtmF3stlft5YWyc2kI+FI="
+   - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
+
+before_install:
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+
+after_success:
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/rapidjson/1.1.0/script.sh
+++ b/scripts/rapidjson/1.1.0/script.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+MASON_NAME=rapidjson
+MASON_VERSION=1.1.0
+MASON_HEADER_ONLY=true
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+    https://github.com/miloyip/rapidjson/archive/v1.1.0.tar.gz \
+    eb129f3e940d4bc220a16cfb1b6625e79a09b2d4
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/rapidjson-1.1.0
+}
+
+function mason_compile {
+    mkdir -p ${MASON_PREFIX}
+    cp -rv include ${MASON_PREFIX}
+}
+
+function mason_cflags {
+    echo -I${MASON_PREFIX}/include
+}
+
+function mason_ldflags {
+    : # We're only using the full path to the archive, which is output in static_libs
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"


### PR DESCRIPTION
RapidJSON 1.1.0 got [released yesterday](https://github.com/miloyip/rapidjson/releases/tag/v1.1.0) and includes roughly a year of fixes and improvements. We should add it to Mason and upgrade all libraries that use it.