### PR TITLE
Add llvm 3.8.1 and 3.9.0

### DIFF
--- a/scripts/clang++/3.8.1/.travis.yml
+++ b/scripts/clang++/3.8.1/.travis.yml
@@ -1,0 +1,16 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+    - os: linux
+      sudo: false
+
+env:
+  global:
+   - secure: "clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFnWLtmF3stlft5YWyc2kI+FI="
+   - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/clang++/3.8.1/script.sh
+++ b/scripts/clang++/3.8.1/script.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# dynamically take name of package from directory
+MASON_NAME=$(basename $(dirname $HERE))
+# dynamically take the version of the package from directory
+MASON_VERSION=$(basename $HERE)
+MASON_LIB_FILE=bin/${MASON_NAME}
+
+. ${MASON_DIR}/mason.sh
+
+# inherit all functions from base
+source ${HERE}/../../${MASON_NAME}/base/common.sh
+
+mason_run "$@"

--- a/scripts/clang++/3.9.0/.travis.yml
+++ b/scripts/clang++/3.9.0/.travis.yml
@@ -1,0 +1,16 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+    - os: linux
+      sudo: false
+
+env:
+  global:
+   - secure: "clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFnWLtmF3stlft5YWyc2kI+FI="
+   - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/clang++/3.9.0/script.sh
+++ b/scripts/clang++/3.9.0/script.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# dynamically take name of package from directory
+MASON_NAME=$(basename $(dirname $HERE))
+# dynamically take the version of the package from directory
+MASON_VERSION=$(basename $HERE)
+MASON_LIB_FILE=bin/${MASON_NAME}
+
+. ${MASON_DIR}/mason.sh
+
+# inherit all functions from base
+source ${HERE}/../../${MASON_NAME}/base/common.sh
+
+mason_run "$@"

--- a/scripts/clang++/base/common.sh
+++ b/scripts/clang++/base/common.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+function mason_build {
+    ${MASON_DIR}/mason install llvm ${MASON_VERSION}
+    CLANG_PREFIX=$(${MASON_DIR}/mason prefix llvm ${MASON_VERSION})
+
+    # copy bin
+    mkdir -p "${MASON_PREFIX}/bin"
+    cp "${CLANG_PREFIX}/bin/${MASON_NAME}" "${MASON_PREFIX}/bin/"
+    cp "${CLANG_PREFIX}/bin/clang" "${MASON_PREFIX}/bin/"
+    # copy share
+    mkdir -p "${MASON_PREFIX}/share"
+    cp -r "${CLANG_PREFIX}/share/clang" "${MASON_PREFIX}/share/"
+    # copy include/c++
+    mkdir -p "${MASON_PREFIX}/include"
+    cp -r "${CLANG_PREFIX}/include/c++" "${MASON_PREFIX}/include/"
+    # copy libs
+    mkdir -p "${MASON_PREFIX}/lib"
+    cp -r ${CLANG_PREFIX}/lib/libc++* "${MASON_PREFIX}/lib/"
+    cp -r ${CLANG_PREFIX}/lib/libLTO.* "${MASON_PREFIX}/lib/"
+    mkdir -p "${MASON_PREFIX}/lib/clang"
+    cp -R ${CLANG_PREFIX}/lib/clang/${MASON_VERSION} "${MASON_PREFIX}/lib/clang/"
+
+    # fixup symlinks
+    cd "${MASON_PREFIX}/bin/"
+    MAJOR_MINOR=$(echo $MASON_VERSION | cut -d '.' -f1-2)
+    rm -f "clang++-${MAJOR_MINOR}"
+    ln -s "clang++" "clang++-${MAJOR_MINOR}"
+    rm -f "clang-${MAJOR_MINOR}"
+    ln -s "clang" "clang-${MAJOR_MINOR}"
+}
+
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}

--- a/scripts/clang-format/3.8.1/.travis.yml
+++ b/scripts/clang-format/3.8.1/.travis.yml
@@ -1,0 +1,16 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+    - os: linux
+      sudo: false
+
+env:
+  global:
+   - secure: "clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFnWLtmF3stlft5YWyc2kI+FI="
+   - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/clang-format/3.8.1/script.sh
+++ b/scripts/clang-format/3.8.1/script.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# dynamically take name of package from directory
+MASON_NAME=$(basename $(dirname $HERE))
+# dynamically take the version of the package from directory
+MASON_VERSION=$(basename $HERE)
+MASON_LIB_FILE=bin/${MASON_NAME}
+
+. ${MASON_DIR}/mason.sh
+
+# inherit all functions from base
+source ${HERE}/../../${MASON_NAME}/base/common.sh
+
+mason_run "$@"

--- a/scripts/clang-format/3.9.0/.travis.yml
+++ b/scripts/clang-format/3.9.0/.travis.yml
@@ -1,0 +1,16 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+    - os: linux
+      sudo: false
+
+env:
+  global:
+   - secure: "clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFnWLtmF3stlft5YWyc2kI+FI="
+   - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/clang-format/3.9.0/script.sh
+++ b/scripts/clang-format/3.9.0/script.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# dynamically take name of package from directory
+MASON_NAME=$(basename $(dirname $HERE))
+# dynamically take the version of the package from directory
+MASON_VERSION=$(basename $HERE)
+MASON_LIB_FILE=bin/${MASON_NAME}
+
+. ${MASON_DIR}/mason.sh
+
+# inherit all functions from base
+source ${HERE}/../../${MASON_NAME}/base/common.sh
+
+mason_run "$@"

--- a/scripts/clang-format/base/common.sh
+++ b/scripts/clang-format/base/common.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+function mason_build {
+    ${MASON_DIR}/mason install llvm ${MASON_VERSION}
+    CLANG_PREFIX=$(${MASON_DIR}/mason prefix llvm ${MASON_VERSION})
+    # copy bin
+    mkdir -p "${MASON_PREFIX}/bin"
+    cp "${CLANG_PREFIX}/bin/${MASON_NAME}" "${MASON_PREFIX}/bin/"
+}
+
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}

--- a/scripts/clang-tidy/3.8.1/.travis.yml
+++ b/scripts/clang-tidy/3.8.1/.travis.yml
@@ -1,0 +1,16 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+    - os: linux
+      sudo: false
+
+env:
+  global:
+   - secure: "clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFnWLtmF3stlft5YWyc2kI+FI="
+   - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/clang-tidy/3.8.1/script.sh
+++ b/scripts/clang-tidy/3.8.1/script.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# dynamically take name of package from directory
+MASON_NAME=$(basename $(dirname $HERE))
+# dynamically take the version of the package from directory
+MASON_VERSION=$(basename $HERE)
+MASON_LIB_FILE=bin/${MASON_NAME}
+
+. ${MASON_DIR}/mason.sh
+
+# inherit all functions from base
+source ${HERE}/../../${MASON_NAME}/base/common.sh
+
+mason_run "$@"

--- a/scripts/clang-tidy/3.9.0/.travis.yml
+++ b/scripts/clang-tidy/3.9.0/.travis.yml
@@ -1,0 +1,16 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+    - os: linux
+      sudo: false
+
+env:
+  global:
+   - secure: "clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFnWLtmF3stlft5YWyc2kI+FI="
+   - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/clang-tidy/3.9.0/script.sh
+++ b/scripts/clang-tidy/3.9.0/script.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# dynamically take name of package from directory
+MASON_NAME=$(basename $(dirname $HERE))
+# dynamically take the version of the package from directory
+MASON_VERSION=$(basename $HERE)
+MASON_LIB_FILE=bin/${MASON_NAME}
+
+. ${MASON_DIR}/mason.sh
+
+# inherit all functions from base
+source ${HERE}/../../${MASON_NAME}/base/common.sh
+
+mason_run "$@"

--- a/scripts/clang-tidy/base/common.sh
+++ b/scripts/clang-tidy/base/common.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+function mason_build {
+    ${MASON_DIR}/mason install llvm ${MASON_VERSION}
+    CLANG_PREFIX=$(${MASON_DIR}/mason prefix llvm ${MASON_VERSION})
+
+    # copy bin
+    mkdir -p "${MASON_PREFIX}/bin"
+    cp "${CLANG_PREFIX}/bin/${MASON_NAME}" "${MASON_PREFIX}/bin/"
+
+    # copy include/c++
+    mkdir -p "${MASON_PREFIX}/include"
+    cp -r "${CLANG_PREFIX}/include/c++" "${MASON_PREFIX}/include/"
+    # copy libs
+    mkdir -p "${MASON_PREFIX}/lib"
+    mkdir -p "${MASON_PREFIX}/lib/clang"
+    cp -r ${CLANG_PREFIX}/lib/clang/${MASON_VERSION} "${MASON_PREFIX}/lib/clang/"
+}
+
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}

--- a/scripts/lldb/3.9.0/.travis.yml
+++ b/scripts/lldb/3.9.0/.travis.yml
@@ -1,0 +1,22 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
+
+env:
+  global:
+   - secure: "clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFnWLtmF3stlft5YWyc2kI+FI="
+   - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/lldb/3.9.0/script.sh
+++ b/scripts/lldb/3.9.0/script.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# dynamically take name of package from directory
+MASON_NAME=$(basename $(dirname $HERE))
+# dynamically take the version of the package from directory
+MASON_VERSION=$(basename $HERE)
+MASON_LIB_FILE=bin/${MASON_NAME}
+
+. ${MASON_DIR}/mason.sh
+
+# inherit all functions from base
+source ${HERE}/../../${MASON_NAME}/base/common.sh
+
+mason_run "$@"

--- a/scripts/lldb/base/common.sh
+++ b/scripts/lldb/base/common.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+function mason_build {
+    ${MASON_DIR}/mason install llvm ${MASON_VERSION}
+    CLANG_PREFIX=$(${MASON_DIR}/mason prefix llvm ${MASON_VERSION})
+    # copy bin
+    mkdir -p "${MASON_PREFIX}/bin"
+    cp "${CLANG_PREFIX}/bin/${MASON_NAME}" "${MASON_PREFIX}/bin/"
+    # copy lib
+    mkdir -p "${MASON_PREFIX}/lib"
+    if [[ $(uname -s) == 'Darwin' ]]; then
+        cp -r ${CLANG_PREFIX}/lib/liblldb*.dylib "${MASON_PREFIX}/lib/"
+    else
+        cp -r ${CLANG_PREFIX}/lib/liblldb*.so* "${MASON_PREFIX}/lib/"
+    fi
+}
+
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}

--- a/scripts/llvm-cov/3.9.0/.travis.yml
+++ b/scripts/llvm-cov/3.9.0/.travis.yml
@@ -5,6 +5,12 @@ matrix:
     - os: osx
     - os: linux
       sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
 
 env:
   global:

--- a/scripts/llvm-cov/3.9.0/.travis.yml
+++ b/scripts/llvm-cov/3.9.0/.travis.yml
@@ -1,0 +1,16 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+    - os: linux
+      sudo: false
+
+env:
+  global:
+   - secure: "clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFnWLtmF3stlft5YWyc2kI+FI="
+   - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/llvm-cov/3.9.0/script.sh
+++ b/scripts/llvm-cov/3.9.0/script.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# dynamically take name of package from directory
+MASON_NAME=$(basename $(dirname $HERE))
+# dynamically take the version of the package from directory
+MASON_VERSION=$(basename $HERE)
+MASON_LIB_FILE=bin/${MASON_NAME}
+
+. ${MASON_DIR}/mason.sh
+
+# inherit all functions from base
+source ${HERE}/../../${MASON_NAME}/base/common.sh
+
+mason_run "$@"

--- a/scripts/llvm-cov/base/common.sh
+++ b/scripts/llvm-cov/base/common.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+function mason_build {
+    ${MASON_DIR}/mason install llvm ${MASON_VERSION}
+    CLANG_PREFIX=$(${MASON_DIR}/mason prefix llvm ${MASON_VERSION})
+    # copy bin
+    mkdir -p "${MASON_PREFIX}/bin"
+    cp "${CLANG_PREFIX}/bin/${MASON_NAME}" "${MASON_PREFIX}/bin/"
+    cp "${CLANG_PREFIX}/bin/llvm-profdata" "${MASON_PREFIX}/bin/"
+}
+
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}

--- a/scripts/llvm/3.8.1/.travis.yml
+++ b/scripts/llvm/3.8.1/.travis.yml
@@ -1,0 +1,9 @@
+language: generic
+
+env:
+  global:
+   - secure: "clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFnWLtmF3stlft5YWyc2kI+FI="
+   - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
+
+script:
+- echo "nothing to do since travis cannot compile something as large as llvm"

--- a/scripts/llvm/3.8.1/README.md
+++ b/scripts/llvm/3.8.1/README.md
@@ -1,0 +1,7 @@
+### llvm v3.8.1
+
+This is a package of all llvm tools. Multiple packages are based on repackaging the binaries from this one including:
+
+  - clang++ 3.8.1
+  - clang-tidy 3.8.1
+  - clang-format 3.8.1

--- a/scripts/llvm/3.8.1/script.sh
+++ b/scripts/llvm/3.8.1/script.sh
@@ -10,14 +10,14 @@ MASON_VERSION=$(basename $HERE)
 source ${HERE}/../../${MASON_NAME}/base/common.sh
 
 function setup_release() {
-    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/llvm-${MASON_VERSION}.src.tar.xz"              ${MASON_BUILD_PATH}/                        6de84b7bb71e49ef2764d364c4318e01fda1e1e3
-    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/cfe-${MASON_VERSION}.src.tar.xz"               ${MASON_BUILD_PATH}/tools/clang             9a05f9c1c8dc865c064782dedbbbfb533c3909ac
-    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/compiler-rt-${MASON_VERSION}.src.tar.xz"       ${MASON_BUILD_PATH}/projects/compiler-rt    678cbff6e177a18f4e2d0662901a744163da3347
-    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/libcxx-${MASON_VERSION}.src.tar.xz"            ${MASON_BUILD_PATH}/projects/libcxx         d15220e86eb8480e58a4378a4c977bbb5463fb79
-    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/libcxxabi-${MASON_VERSION}.src.tar.xz"         ${MASON_BUILD_PATH}/projects/libcxxabi      b7508c64ab8e670062ee57a12ae1e542bcb2bfb4
-    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/libunwind-${MASON_VERSION}.src.tar.xz"         ${MASON_BUILD_PATH}/projects/libunwind      90c0184ca72e1999fec304f76bfa10340f038ee5
-    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/lld-${MASON_VERSION}.src.tar.xz"               ${MASON_BUILD_PATH}/tools/lld               416c36ded12ead42dc4739d52eabf22267300883
-    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/clang-tools-extra-${MASON_VERSION}.src.tar.xz" ${MASON_BUILD_PATH}/tools/clang/tools/extra ea40e36d54dc8c9bb21cbebcc872a3221a2ed685
+    get_llvm_project "http://llvm.org/releases/${MASON_VERSION}/llvm-${MASON_VERSION}.src.tar.xz"              ${MASON_BUILD_PATH}/                        6de84b7bb71e49ef2764d364c4318e01fda1e1e3
+    get_llvm_project "http://llvm.org/releases/${MASON_VERSION}/cfe-${MASON_VERSION}.src.tar.xz"               ${MASON_BUILD_PATH}/tools/clang             9a05f9c1c8dc865c064782dedbbbfb533c3909ac
+    get_llvm_project "http://llvm.org/releases/${MASON_VERSION}/compiler-rt-${MASON_VERSION}.src.tar.xz"       ${MASON_BUILD_PATH}/projects/compiler-rt    678cbff6e177a18f4e2d0662901a744163da3347
+    get_llvm_project "http://llvm.org/releases/${MASON_VERSION}/libcxx-${MASON_VERSION}.src.tar.xz"            ${MASON_BUILD_PATH}/projects/libcxx         d15220e86eb8480e58a4378a4c977bbb5463fb79
+    get_llvm_project "http://llvm.org/releases/${MASON_VERSION}/libcxxabi-${MASON_VERSION}.src.tar.xz"         ${MASON_BUILD_PATH}/projects/libcxxabi      b7508c64ab8e670062ee57a12ae1e542bcb2bfb4
+    get_llvm_project "http://llvm.org/releases/${MASON_VERSION}/libunwind-${MASON_VERSION}.src.tar.xz"         ${MASON_BUILD_PATH}/projects/libunwind      90c0184ca72e1999fec304f76bfa10340f038ee5
+    get_llvm_project "http://llvm.org/releases/${MASON_VERSION}/lld-${MASON_VERSION}.src.tar.xz"               ${MASON_BUILD_PATH}/tools/lld               416c36ded12ead42dc4739d52eabf22267300883
+    get_llvm_project "http://llvm.org/releases/${MASON_VERSION}/clang-tools-extra-${MASON_VERSION}.src.tar.xz" ${MASON_BUILD_PATH}/tools/clang/tools/extra ea40e36d54dc8c9bb21cbebcc872a3221a2ed685
 }
 
 mason_run "$@"

--- a/scripts/llvm/3.8.1/script.sh
+++ b/scripts/llvm/3.8.1/script.sh
@@ -10,14 +10,14 @@ MASON_VERSION=$(basename $HERE)
 source ${HERE}/../../${MASON_NAME}/base/common.sh
 
 function setup_release() {
-    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/llvm-${MASON_VERSION}.src.tar.xz"              ${MASON_BUILD_PATH}/                        538467e6028bbc9259b1e6e015d25845
-    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/cfe-${MASON_VERSION}.src.tar.xz"               ${MASON_BUILD_PATH}/tools/clang             4ff2f8844a786edb0220f490f7896080
-    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/compiler-rt-${MASON_VERSION}.src.tar.xz"       ${MASON_BUILD_PATH}/projects/compiler-rt    f140db073d2453f854fbe01cc46f3110
-    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/libcxx-${MASON_VERSION}.src.tar.xz"            ${MASON_BUILD_PATH}/projects/libcxx         1bc60150302ff76a0d79d6f9db22332e
-    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/libcxxabi-${MASON_VERSION}.src.tar.xz"         ${MASON_BUILD_PATH}/projects/libcxxabi      3c63b03ba2f30a01279ca63384a67773
-    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/libunwind-${MASON_VERSION}.src.tar.xz"         ${MASON_BUILD_PATH}/projects/libunwind      d66e2387e1d37a8a0c8fe6a0063a3bab
-    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/lld-${MASON_VERSION}.src.tar.xz"               ${MASON_BUILD_PATH}/tools/lld               68cd069bf99c71ebcfbe01d557c0e14d
-    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/clang-tools-extra-${MASON_VERSION}.src.tar.xz" ${MASON_BUILD_PATH}/tools/clang/tools/extra 6e49f285d0b366cc3cab782d8c92d382
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/llvm-${MASON_VERSION}.src.tar.xz"              ${MASON_BUILD_PATH}/                        6de84b7bb71e49ef2764d364c4318e01fda1e1e3
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/cfe-${MASON_VERSION}.src.tar.xz"               ${MASON_BUILD_PATH}/tools/clang             9a05f9c1c8dc865c064782dedbbbfb533c3909ac
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/compiler-rt-${MASON_VERSION}.src.tar.xz"       ${MASON_BUILD_PATH}/projects/compiler-rt    678cbff6e177a18f4e2d0662901a744163da3347
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/libcxx-${MASON_VERSION}.src.tar.xz"            ${MASON_BUILD_PATH}/projects/libcxx         d15220e86eb8480e58a4378a4c977bbb5463fb79
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/libcxxabi-${MASON_VERSION}.src.tar.xz"         ${MASON_BUILD_PATH}/projects/libcxxabi      b7508c64ab8e670062ee57a12ae1e542bcb2bfb4
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/libunwind-${MASON_VERSION}.src.tar.xz"         ${MASON_BUILD_PATH}/projects/libunwind      90c0184ca72e1999fec304f76bfa10340f038ee5
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/lld-${MASON_VERSION}.src.tar.xz"               ${MASON_BUILD_PATH}/tools/lld               416c36ded12ead42dc4739d52eabf22267300883
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/clang-tools-extra-${MASON_VERSION}.src.tar.xz" ${MASON_BUILD_PATH}/tools/clang/tools/extra ea40e36d54dc8c9bb21cbebcc872a3221a2ed685
 }
 
 mason_run "$@"

--- a/scripts/llvm/3.8.1/script.sh
+++ b/scripts/llvm/3.8.1/script.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+# dynamically take name of package from directory
+MASON_NAME=$(basename $(dirname $HERE))
+# dynamically take the version of the package from directory
+MASON_VERSION=$(basename $HERE)
+# inherit all functions from llvm base
+source ${HERE}/../../${MASON_NAME}/base/common.sh
+
+function setup_release() {
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/llvm-${MASON_VERSION}.src.tar.xz"              ${MASON_BUILD_PATH}/                        538467e6028bbc9259b1e6e015d25845
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/cfe-${MASON_VERSION}.src.tar.xz"               ${MASON_BUILD_PATH}/tools/clang             4ff2f8844a786edb0220f490f7896080
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/compiler-rt-${MASON_VERSION}.src.tar.xz"       ${MASON_BUILD_PATH}/projects/compiler-rt    f140db073d2453f854fbe01cc46f3110
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/libcxx-${MASON_VERSION}.src.tar.xz"            ${MASON_BUILD_PATH}/projects/libcxx         1bc60150302ff76a0d79d6f9db22332e
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/libcxxabi-${MASON_VERSION}.src.tar.xz"         ${MASON_BUILD_PATH}/projects/libcxxabi      3c63b03ba2f30a01279ca63384a67773
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/libunwind-${MASON_VERSION}.src.tar.xz"         ${MASON_BUILD_PATH}/projects/libunwind      d66e2387e1d37a8a0c8fe6a0063a3bab
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/lld-${MASON_VERSION}.src.tar.xz"               ${MASON_BUILD_PATH}/tools/lld               68cd069bf99c71ebcfbe01d557c0e14d
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/clang-tools-extra-${MASON_VERSION}.src.tar.xz" ${MASON_BUILD_PATH}/tools/clang/tools/extra 6e49f285d0b366cc3cab782d8c92d382
+}
+
+mason_run "$@"

--- a/scripts/llvm/3.9.0/.travis.yml
+++ b/scripts/llvm/3.9.0/.travis.yml
@@ -1,0 +1,9 @@
+language: generic
+
+env:
+  global:
+   - secure: "clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFnWLtmF3stlft5YWyc2kI+FI="
+   - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
+
+script:
+- echo "nothing to do since travis cannot compile something as large as llvm"

--- a/scripts/llvm/3.9.0/README.md
+++ b/scripts/llvm/3.9.0/README.md
@@ -65,10 +65,10 @@ To support c++11 we'd normally need to upgrade libstdc++ which would make it pro
 To accomplish this (c++11 build of clang++ and linking to libc++ instead of an upgraded libstdc++) we did:
 
 ```sh
-./mason install clang 3.8.0
-CLANG_38_PREFIX=$(./mason prefix clang 3.8.0)
-export CXX=${CLANG_38_PREFIX}/clang++-3.8
-export CC=${CLANG_38_PREFIX}/clang-3.8
+./mason install clang++ 3.8.1
+CLANG_38_PREFIX=$(./mason prefix clang++ 3.8.1)
+export CXX=${CLANG_38_PREFIX}/bin/clang++-3.8
+export CC=${CLANG_38_PREFIX}/bin/clang-3.8
 ./mason build llvm 3.9.0
 ```
 

--- a/scripts/llvm/3.9.0/README.md
+++ b/scripts/llvm/3.9.0/README.md
@@ -65,7 +65,7 @@ To support c++11 we'd normally need to upgrade libstdc++ which would make it pro
 To accomplish this (c++11 build of clang++ and linking to libc++ instead of an upgraded libstdc++) we did:
 
 ```sh
-./mason install clang++ 3.8.1
+./mason install clang 3.8.0
 CLANG_38_PREFIX=$(./mason prefix clang 3.8.0)
 export CXX=${CLANG_38_PREFIX}/bin/clang++-3.8
 export CC=${CLANG_38_PREFIX}/bin/clang-3.8

--- a/scripts/llvm/3.9.0/README.md
+++ b/scripts/llvm/3.9.0/README.md
@@ -66,7 +66,7 @@ To accomplish this (c++11 build of clang++ and linking to libc++ instead of an u
 
 ```sh
 ./mason install clang++ 3.8.1
-CLANG_38_PREFIX=$(./mason prefix clang++ 3.8.1)
+CLANG_38_PREFIX=$(./mason prefix clang 3.8.0)
 export CXX=${CLANG_38_PREFIX}/bin/clang++-3.8
 export CC=${CLANG_38_PREFIX}/bin/clang-3.8
 ./mason build llvm 3.9.0

--- a/scripts/llvm/3.9.0/README.md
+++ b/scripts/llvm/3.9.0/README.md
@@ -5,3 +5,116 @@ This is a package of all llvm tools. Multiple packages are based on repackaging 
   - clang++ 3.9.0
   - clang-tidy 3.9.0
   - clang-format 3.9.0
+
+### Details of package
+
+This package inherits from `scripts/llvm/base/common.sh`, which is a base configuration and not an actual package itself.
+
+Therefore to see the intricacies of how this package is built look in `scripts/llvm/base/common.sh`.
+
+The `scripts/llvm/base/common.sh` is used by both llvm 3.8.1 and llvm 3.9.0 packages (and future ones). It reduces duplication of package code and makes it easier to update the builds in one place to benefit all versions.
+
+The `scripts/llvm/3.9.0/script.sh` therefore sources `scripts/llvm/base/common.sh` and then overrides just the functions that need to be customized. At the time of writing this is only the `setup_release` function. It is customized in order to provide version specific md5 values which can ensure that upstream packages do not change without us noticing.
+
+### Details of builds
+
+ - Done on Sept 22, 2016 by @springmeyer
+ - OS X build done on OS X 10.11
+ - Linux build done on ubuntu precise
+
+The order and method of building was generally:
+
+```sh
+VERSION=3.9.0
+./mason build llvm ${VERSION}
+./mason publish llvm ${VERSION}
+./mason build clang++ ${VERSION}
+./mason publish clang++ ${VERSION}
+./mason build clang-tidy ${VERSION}
+./mason publish clang-tidy ${VERSION}
+./mason build clang-format ${VERSION}
+./mason publish clang-format ${VERSION}
+```
+
+#### OSX details
+
+On macOS we use the apple system clang++ to compile and link against the apple system libc++.
+
+```sh
+$ clang++ -v
+Apple LLVM version 7.3.0 (clang-703.0.31)
+Target: x86_64-apple-darwin15.6.0
+Thread model: posix
+InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
+```
+
+Therefore the llvm package was built like:
+
+```sh
+./mason build llvm 3.9.0
+```
+
+#### Linux details
+
+On linux we use precise in order to ensure that binaries can be run on ubuntu precise and newer platforms.
+
+We still want to compile clang++ in c++11 mode so we compile clang++ using a mason provided clang++.
+
+To support c++11 we'd normally need to upgrade libstdc++ which would make it problematic for the resulting binary to be portable to linux systems without that upgraded libstdc++. So we avoid this issue by instead linking clang++ to libc++, which itself will travel inside the clang++ package.
+
+To accomplish this (c++11 build of clang++ and linking to libc++ instead of an upgraded libstdc++) we did:
+
+```sh
+./mason install clang 3.8.0
+CLANG_38_PREFIX=$(./mason prefix clang 3.8.0)
+export CXX=${CLANG_38_PREFIX}/clang++-3.8
+export CC=${CLANG_38_PREFIX}/clang-3.8
+./mason build llvm 3.9.0
+```
+
+The reason `LD_LIBRARY_PATH` is set before the build is so that libc++.so can be found during linking. Once linked clang++ automatically uses the right @rpath on macOS and linux to find its own libc++.so at runtime.
+
+TODO:
+
+ - Modify the llvm 3.9.0 build scripts to build libc++ and libc++abi first.
+ - Then we should be able to point LD_LIBRARY_PATH at llvm 3.9.0's libc++.so to avoid potential ABI mismatch with the version provided by 3.8.0
+ - LD_LIBRARY_PATH would be pointed at the theoretical location of llvm 3.9.0's libc++, and that location would exist and become valid before llvm 3.9.0's clang++ is linked.
+
+
+### Testing of these new tools
+
+Once these packages were built I needed to test that they could be used to build and publish other mason packages. And I needed to be able to test that these packages worked for downstream users.
+
+To accomplish this I branched mason and changed the `MASON_PLATFORM_ID` to enable publishing new binaries with llvm 3.9.0 tools without overwriting existing binaries.
+
+```
+diff --git a/mason.sh b/mason.sh
+index 800216d..ccc1fcb 100644
+--- a/mason.sh
++++ b/mason.sh
+@@ -259,7 +259,7 @@ MASON_SLUG=${MASON_NAME}-${MASON_VERSION}
+ if [[ ${MASON_HEADER_ONLY} == true ]]; then
+     MASON_PLATFORM_ID=headers
+ else
+-    MASON_PLATFORM_ID=${MASON_PLATFORM}-${MASON_PLATFORM_VERSION}
++    MASON_PLATFORM_ID=${MASON_PLATFORM}-${MASON_PLATFORM_VERSION}-llvm390
+ fi
+ MASON_PREFIX=${MASON_ROOT}/${MASON_PLATFORM_ID}/${MASON_NAME}/${MASON_VERSION}
+ MASON_BINARIES=${MASON_PLATFORM_ID}/${MASON_NAME}/${MASON_VERSION}.tar.gz
+```
+
+But changing the `MASON_PLATFORM_ID` also means that you loose access to all existing binaries for building packages. To ensure I could still bootstrap the builds I seeded this new `MASON_PLATFORM_ID` with key build tools, including the previously built llvm tools being discussed here.
+
+```
+CUSTOM_PATH="llvm390"
+aws s3 sync --acl public-read s3://mason-binaries/linux-x86_64/llvm/ s3://mason-binaries/linux-x86_64-{CUSTOM_PATH}/llvm/
+aws s3 sync --acl public-read s3://mason-binaries/linux-x86_64/clang++/ s3://mason-binaries/linux-x86_64-{CUSTOM_PATH}/clang++/
+aws s3 sync --acl public-read s3://mason-binaries/linux-x86_64/cmake/ s3://mason-binaries/linux-x86_64-{CUSTOM_PATH}/cmake/
+aws s3 sync --acl public-read s3://mason-binaries/linux-x86_64/ccache/ s3://mason-binaries/linux-x86_64-{CUSTOM_PATH}/ccache/
+aws s3 sync --acl public-read s3://mason-binaries/linux-x86_64/ninja/ s3://mason-binaries/linux-x86_64-{CUSTOM_PATH}/ninja/
+aws s3 sync --acl public-read s3://mason-binaries/osx-x86_64/llvm/ s3://mason-binaries/osx-x86_64-{CUSTOM_PATH}/llvm/
+aws s3 sync --acl public-read s3://mason-binaries/osx-x86_64/clang++/ s3://mason-binaries/osx-x86_64-{CUSTOM_PATH}/clang++/
+aws s3 sync --acl public-read s3://mason-binaries/osx-x86_64/cmake/ s3://mason-binaries/osx-x86_64-{CUSTOM_PATH}/cmake/
+aws s3 sync --acl public-read s3://mason-binaries/osx-x86_64/ccache/ s3://mason-binaries/osx-x86_64-{CUSTOM_PATH}/ccache/
+aws s3 sync --acl public-read s3://mason-binaries/osx-x86_64/ninja/ s3://mason-binaries/osx-x86_64-{CUSTOM_PATH}/ninja/
+```

--- a/scripts/llvm/3.9.0/README.md
+++ b/scripts/llvm/3.9.0/README.md
@@ -1,0 +1,7 @@
+### llvm v3.9.0
+
+This is a package of all llvm tools. Multiple packages are based on repackaging the binaries from this one including:
+
+  - clang++ 3.9.0
+  - clang-tidy 3.9.0
+  - clang-format 3.9.0

--- a/scripts/llvm/3.9.0/README.md
+++ b/scripts/llvm/3.9.0/README.md
@@ -65,10 +65,10 @@ To support c++11 we'd normally need to upgrade libstdc++ which would make it pro
 To accomplish this (c++11 build of clang++ and linking to libc++ instead of an upgraded libstdc++) we did:
 
 ```sh
-./mason install clang 3.8.0
-CLANG_38_PREFIX=$(./mason prefix clang 3.8.0)
-export CXX=${CLANG_38_PREFIX}/bin/clang++-3.8
-export CC=${CLANG_38_PREFIX}/bin/clang-3.8
+./mason install clang++ 3.9.0
+CLANG_39_PREFIX=$(./mason prefix clang 3.8.0)
+export CXX=${CLANG_38_PREFIX}/bin/clang++-3.9
+export CC=${CLANG_38_PREFIX}/bin/clang-3.9
 ./mason build llvm 3.9.0
 ```
 

--- a/scripts/llvm/3.9.0/script.sh
+++ b/scripts/llvm/3.9.0/script.sh
@@ -10,15 +10,15 @@ MASON_VERSION=$(basename $HERE)
 source ${HERE}/../../${MASON_NAME}/base/common.sh
 
 function setup_release() {
-    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/llvm-${MASON_VERSION}.src.tar.xz"              ${MASON_BUILD_PATH}/                        00f5268479117c9c7f90d0f9e2f06485875f5444
-    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/cfe-${MASON_VERSION}.src.tar.xz"               ${MASON_BUILD_PATH}/tools/clang             465e70cfb1d8b3fb5d1f6577933f7b5014aca3bd
-    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/compiler-rt-${MASON_VERSION}.src.tar.xz"       ${MASON_BUILD_PATH}/projects/compiler-rt    7a2ea8a7257a739330d8f7cfe2bcb70939476f31
-    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/libcxx-${MASON_VERSION}.src.tar.xz"            ${MASON_BUILD_PATH}/projects/libcxx         248635c4821b9f2e4b620364c21a2596eed514cd
-    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/libcxxabi-${MASON_VERSION}.src.tar.xz"         ${MASON_BUILD_PATH}/projects/libcxxabi      04ffa28577ec3d935dcd69d137a2e478e71f2704
-    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/libunwind-${MASON_VERSION}.src.tar.xz"         ${MASON_BUILD_PATH}/projects/libunwind      32e17eaf6a5b769c244480bd32ab3c9cbdf6c97d
-    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/lld-${MASON_VERSION}.src.tar.xz"               ${MASON_BUILD_PATH}/tools/lld               e1829cd47a5c44ad6c68957056afe63879ad9610
-    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/clang-tools-extra-${MASON_VERSION}.src.tar.xz" ${MASON_BUILD_PATH}/tools/clang/tools/extra 8e7e118a769c76e70d5fb2ede66c8f5a2952f8d9
-    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/lldb-${MASON_VERSION}.src.tar.xz"              ${MASON_BUILD_PATH}/tools/lldb              988766cbb3d4a295b33dd11f51f7f20811bfa8f2
+    get_llvm_project "http://llvm.org/releases/${MASON_VERSION}/llvm-${MASON_VERSION}.src.tar.xz"              ${MASON_BUILD_PATH}/                        00f5268479117c9c7f90d0f9e2f06485875f5444
+    get_llvm_project "http://llvm.org/releases/${MASON_VERSION}/cfe-${MASON_VERSION}.src.tar.xz"               ${MASON_BUILD_PATH}/tools/clang             465e70cfb1d8b3fb5d1f6577933f7b5014aca3bd
+    get_llvm_project "http://llvm.org/releases/${MASON_VERSION}/compiler-rt-${MASON_VERSION}.src.tar.xz"       ${MASON_BUILD_PATH}/projects/compiler-rt    7a2ea8a7257a739330d8f7cfe2bcb70939476f31
+    get_llvm_project "http://llvm.org/releases/${MASON_VERSION}/libcxx-${MASON_VERSION}.src.tar.xz"            ${MASON_BUILD_PATH}/projects/libcxx         248635c4821b9f2e4b620364c21a2596eed514cd
+    get_llvm_project "http://llvm.org/releases/${MASON_VERSION}/libcxxabi-${MASON_VERSION}.src.tar.xz"         ${MASON_BUILD_PATH}/projects/libcxxabi      04ffa28577ec3d935dcd69d137a2e478e71f2704
+    get_llvm_project "http://llvm.org/releases/${MASON_VERSION}/libunwind-${MASON_VERSION}.src.tar.xz"         ${MASON_BUILD_PATH}/projects/libunwind      32e17eaf6a5b769c244480bd32ab3c9cbdf6c97d
+    get_llvm_project "http://llvm.org/releases/${MASON_VERSION}/lld-${MASON_VERSION}.src.tar.xz"               ${MASON_BUILD_PATH}/tools/lld               e1829cd47a5c44ad6c68957056afe63879ad9610
+    get_llvm_project "http://llvm.org/releases/${MASON_VERSION}/clang-tools-extra-${MASON_VERSION}.src.tar.xz" ${MASON_BUILD_PATH}/tools/clang/tools/extra 8e7e118a769c76e70d5fb2ede66c8f5a2952f8d9
+    get_llvm_project "http://llvm.org/releases/${MASON_VERSION}/lldb-${MASON_VERSION}.src.tar.xz"              ${MASON_BUILD_PATH}/tools/lldb              988766cbb3d4a295b33dd11f51f7f20811bfa8f2
 }
 
 mason_run "$@"

--- a/scripts/llvm/3.9.0/script.sh
+++ b/scripts/llvm/3.9.0/script.sh
@@ -18,6 +18,7 @@ function setup_release() {
     curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/libunwind-${MASON_VERSION}.src.tar.xz"         ${MASON_BUILD_PATH}/projects/libunwind      3e5c87c723a456be599727a444b1c166
     curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/lld-${MASON_VERSION}.src.tar.xz"               ${MASON_BUILD_PATH}/tools/lld               c23c895c0d855a0dc426af686538a95e
     curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/clang-tools-extra-${MASON_VERSION}.src.tar.xz" ${MASON_BUILD_PATH}/tools/clang/tools/extra f4f663068c77fc742113211841e94d5e
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/lldb-${MASON_VERSION}.src.tar.xz"              ${MASON_BUILD_PATH}/tools/lldb              968d053c3c3d7297983589164c6999e9
 }
 
 mason_run "$@"

--- a/scripts/llvm/3.9.0/script.sh
+++ b/scripts/llvm/3.9.0/script.sh
@@ -10,15 +10,15 @@ MASON_VERSION=$(basename $HERE)
 source ${HERE}/../../${MASON_NAME}/base/common.sh
 
 function setup_release() {
-    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/llvm-${MASON_VERSION}.src.tar.xz"              ${MASON_BUILD_PATH}/                        f2093e98060532449eb7d2fcfd0bc6c6
-    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/cfe-${MASON_VERSION}.src.tar.xz"               ${MASON_BUILD_PATH}/tools/clang             29e1d86bee422ab5345f5e9fb808d2dc
-    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/compiler-rt-${MASON_VERSION}.src.tar.xz"       ${MASON_BUILD_PATH}/projects/compiler-rt    b7ea34c9d744da16ffc0217b6990d095
-    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/libcxx-${MASON_VERSION}.src.tar.xz"            ${MASON_BUILD_PATH}/projects/libcxx         0a11efefd864ce6f321194e441f7e569
-    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/libcxxabi-${MASON_VERSION}.src.tar.xz"         ${MASON_BUILD_PATH}/projects/libcxxabi      d02642308e22e614af6b061b9b4fedfa
-    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/libunwind-${MASON_VERSION}.src.tar.xz"         ${MASON_BUILD_PATH}/projects/libunwind      3e5c87c723a456be599727a444b1c166
-    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/lld-${MASON_VERSION}.src.tar.xz"               ${MASON_BUILD_PATH}/tools/lld               c23c895c0d855a0dc426af686538a95e
-    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/clang-tools-extra-${MASON_VERSION}.src.tar.xz" ${MASON_BUILD_PATH}/tools/clang/tools/extra f4f663068c77fc742113211841e94d5e
-    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/lldb-${MASON_VERSION}.src.tar.xz"              ${MASON_BUILD_PATH}/tools/lldb              968d053c3c3d7297983589164c6999e9
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/llvm-${MASON_VERSION}.src.tar.xz"              ${MASON_BUILD_PATH}/                        00f5268479117c9c7f90d0f9e2f06485875f5444
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/cfe-${MASON_VERSION}.src.tar.xz"               ${MASON_BUILD_PATH}/tools/clang             465e70cfb1d8b3fb5d1f6577933f7b5014aca3bd
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/compiler-rt-${MASON_VERSION}.src.tar.xz"       ${MASON_BUILD_PATH}/projects/compiler-rt    7a2ea8a7257a739330d8f7cfe2bcb70939476f31
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/libcxx-${MASON_VERSION}.src.tar.xz"            ${MASON_BUILD_PATH}/projects/libcxx         248635c4821b9f2e4b620364c21a2596eed514cd
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/libcxxabi-${MASON_VERSION}.src.tar.xz"         ${MASON_BUILD_PATH}/projects/libcxxabi      04ffa28577ec3d935dcd69d137a2e478e71f2704
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/libunwind-${MASON_VERSION}.src.tar.xz"         ${MASON_BUILD_PATH}/projects/libunwind      32e17eaf6a5b769c244480bd32ab3c9cbdf6c97d
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/lld-${MASON_VERSION}.src.tar.xz"               ${MASON_BUILD_PATH}/tools/lld               e1829cd47a5c44ad6c68957056afe63879ad9610
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/clang-tools-extra-${MASON_VERSION}.src.tar.xz" ${MASON_BUILD_PATH}/tools/clang/tools/extra 8e7e118a769c76e70d5fb2ede66c8f5a2952f8d9
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/lldb-${MASON_VERSION}.src.tar.xz"              ${MASON_BUILD_PATH}/tools/lldb              988766cbb3d4a295b33dd11f51f7f20811bfa8f2
 }
 
 mason_run "$@"

--- a/scripts/llvm/3.9.0/script.sh
+++ b/scripts/llvm/3.9.0/script.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+# dynamically take name of package from directory
+MASON_NAME=$(basename $(dirname $HERE))
+# dynamically take the version of the package from directory
+MASON_VERSION=$(basename $HERE)
+# inherit all functions from llvm base
+source ${HERE}/../../${MASON_NAME}/base/common.sh
+
+function setup_release() {
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/llvm-${MASON_VERSION}.src.tar.xz"              ${MASON_BUILD_PATH}/                        f2093e98060532449eb7d2fcfd0bc6c6
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/cfe-${MASON_VERSION}.src.tar.xz"               ${MASON_BUILD_PATH}/tools/clang             29e1d86bee422ab5345f5e9fb808d2dc
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/compiler-rt-${MASON_VERSION}.src.tar.xz"       ${MASON_BUILD_PATH}/projects/compiler-rt    b7ea34c9d744da16ffc0217b6990d095
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/libcxx-${MASON_VERSION}.src.tar.xz"            ${MASON_BUILD_PATH}/projects/libcxx         0a11efefd864ce6f321194e441f7e569
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/libcxxabi-${MASON_VERSION}.src.tar.xz"         ${MASON_BUILD_PATH}/projects/libcxxabi      d02642308e22e614af6b061b9b4fedfa
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/libunwind-${MASON_VERSION}.src.tar.xz"         ${MASON_BUILD_PATH}/projects/libunwind      3e5c87c723a456be599727a444b1c166
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/lld-${MASON_VERSION}.src.tar.xz"               ${MASON_BUILD_PATH}/tools/lld               c23c895c0d855a0dc426af686538a95e
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/clang-tools-extra-${MASON_VERSION}.src.tar.xz" ${MASON_BUILD_PATH}/tools/clang/tools/extra f4f663068c77fc742113211841e94d5e
+}
+
+mason_run "$@"

--- a/scripts/llvm/4.x/.travis.yml
+++ b/scripts/llvm/4.x/.travis.yml
@@ -1,0 +1,9 @@
+language: generic
+
+env:
+  global:
+   - secure: "clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFnWLtmF3stlft5YWyc2kI+FI="
+   - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
+
+script:
+- echo "nothing to do since travis cannot compile something as large as llvm"

--- a/scripts/llvm/4.x/README.md
+++ b/scripts/llvm/4.x/README.md
@@ -1,0 +1,3 @@
+### llvm v4.x
+
+Development package of llvm git head

--- a/scripts/llvm/4.x/script.sh
+++ b/scripts/llvm/4.x/script.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+# dynamically take name of package from directory
+MASON_NAME=$(basename $(dirname $HERE))
+# dynamically take the version of the package from directory
+MASON_VERSION=$(basename $HERE)
+# inherit all functions from llvm base
+source ${HERE}/../../${MASON_NAME}/base/common.sh
+
+
+#     git_get https://github.com/include-what-you-use/include-what-you-use.git ${LLVM_RELEASE}/llvm/tools/clang/tools/include-what-you-use
+
+function setup_release() {
+    get_llvm_project "http://llvm.org/git/llvm.git"              ${MASON_BUILD_PATH}
+    get_llvm_project "http://llvm.org/git/clang.git"             ${MASON_BUILD_PATH}/tools/clang
+    get_llvm_project "http://llvm.org/git/compiler-rt.git"       ${MASON_BUILD_PATH}/projects/compiler-rt
+    get_llvm_project "http://llvm.org/git/libcxx.git"            ${MASON_BUILD_PATH}/projects/libcxx
+    get_llvm_project "http://llvm.org/git/libcxxabi.git"         ${MASON_BUILD_PATH}/projects/libcxxabi
+    get_llvm_project "http://llvm.org/git/libunwind.git"         ${MASON_BUILD_PATH}/projects/libunwind
+    get_llvm_project "http://llvm.org/git/lld.git"               ${MASON_BUILD_PATH}/tools/lld
+    get_llvm_project "http://llvm.org/git/clang-tools-extra.git" ${MASON_BUILD_PATH}/tools/clang/tools/extra
+    get_llvm_project "http://llvm.org/git/lldb.git"              ${MASON_BUILD_PATH}/tools/lldb
+}
+
+mason_run "$@"

--- a/scripts/llvm/base/common.sh
+++ b/scripts/llvm/base/common.sh
@@ -66,6 +66,7 @@ function mason_load_source {
     mkdir -p "${MASON_ROOT}/.cache"
     cd "${MASON_ROOT}/.cache"
     export MASON_BUILD_PATH=${MASON_ROOT}/.build/llvm-${MASON_VERSION}
+    mkdir -p "${MASON_ROOT}/.build"
     if [[ -d ${MASON_BUILD_PATH}/ ]]; then
         rm -rf ${MASON_BUILD_PATH}/
     fi
@@ -115,7 +116,7 @@ function mason_compile {
     export CXXFLAGS="-stdlib=libc++ ${CXXFLAGS//-mmacosx-version-min=10.8}"
     # llvm may request c++14 instead so let's not force c++11
     # TODO: -fvisibility=hidden breaks just lldb
-    export CXXFLAGS="-stdlib=libc++ ${CXXFLAGS//-std=c++11}"
+    export CXXFLAGS="${CXXFLAGS//-std=c++11}"
     export LDFLAGS="-stdlib=libc++ ${LDFLAGS//-mmacosx-version-min=10.8}"
 
     if [[ $(uname -s) == 'Linux' ]]; then

--- a/scripts/llvm/base/common.sh
+++ b/scripts/llvm/base/common.sh
@@ -135,6 +135,9 @@ function mason_compile {
      -DCMAKE_CXX_COMPILER_LAUNCHER="${MASON_CCACHE}/bin/ccache" \
      -DCMAKE_CXX_COMPILER="$CXX" \
      -DCMAKE_C_COMPILER="$CC" \
+     -DLIBCXX_ENABLE_ASSERTIONS=OFF \
+     -DLIBCXX_ENABLE_SHARED=OFF \
+     -DLIBCXXABI_USE_LLVM_UNWINDER=ON \
      -DLLVM_ENABLE_ASSERTIONS=OFF \
      -DCLANG_VENDOR="mapbox/mason" \
      -DCLANG_REPOSITORY_STRING="https://github.com/mapbox/mason" \

--- a/scripts/llvm/base/common.sh
+++ b/scripts/llvm/base/common.sh
@@ -30,7 +30,7 @@ function curl_get_and_uncompress() {
     else
         mason_substep "already downloaded $1 to ${local_file}"
     fi
-    MD5_SUM=$(get_md5 -q ${local_file})
+    MD5_SUM=$(get_md5 ${local_file})
     if [[ ${EXPECTED_MD5:-false} == false ]]; then
         mason_error "Warning: no expected m5, actual was ${MD5_SUM}"
     else

--- a/scripts/llvm/base/common.sh
+++ b/scripts/llvm/base/common.sh
@@ -5,6 +5,14 @@ MASON_LIB_FILE=bin/clang
 
 . ${MASON_DIR}/mason.sh
 
+function get_md5() {
+    if [[ $(uname -s) == 'Darwin' ]]; then
+        md5 -q $1
+    else
+        md5sum $1 | cut -d ' ' -f1
+    fi
+}
+
 # we use this custom function rather than "mason_download" since we need to easily grab multiple packages
 function curl_get_and_uncompress() {
     local URL=${1}
@@ -22,7 +30,7 @@ function curl_get_and_uncompress() {
     else
         mason_substep "already downloaded $1 to ${local_file}"
     fi
-    MD5_SUM=$(md5 -q ${local_file})
+    MD5_SUM=$(get_md5 -q ${local_file})
     if [[ ${EXPECTED_MD5:-false} == false ]]; then
         mason_error "Warning: no expected m5, actual was ${MD5_SUM}"
     else

--- a/scripts/llvm/base/common.sh
+++ b/scripts/llvm/base/common.sh
@@ -153,8 +153,8 @@ function mason_compile {
     ${MASON_NINJA}/bin/ninja cxxabi -v -j${MASON_CONCURRENCY}
     ${MASON_NINJA}/bin/ninja cxx -v -j${MASON_CONCURRENCY}
     # not move the host compilers libc++ and libc++abi shared libs out of the way
-    mkdir backup_shlibs
-    mv $(dirname $(dirname $CXX))/lib/*cxx*so backup_shlibs/
+    mkdir -p /tmp/backup_shlibs
+    mv $(dirname $(dirname $CXX))/lib/*c++*so /tmp/backup_shlibs/
     # then make everything else
     ${MASON_NINJA}/bin/ninja -j${MASON_CONCURRENCY}
     # install it all

--- a/scripts/llvm/base/common.sh
+++ b/scripts/llvm/base/common.sh
@@ -152,9 +152,11 @@ function mason_compile {
     ${MASON_NINJA}/bin/ninja unwind -v -j${MASON_CONCURRENCY}
     ${MASON_NINJA}/bin/ninja cxxabi -v -j${MASON_CONCURRENCY}
     ${MASON_NINJA}/bin/ninja cxx -v -j${MASON_CONCURRENCY}
-    # not move the host compilers libc++ and libc++abi shared libs out of the way
-    mkdir -p /tmp/backup_shlibs
-    mv $(dirname $(dirname $CXX))/lib/*c++*so /tmp/backup_shlibs/
+    # no move the host compilers libc++ and libc++abi shared libs out of the way
+    if [[ ${CXX_BOOTSTRAP:-false} != false ]]; then
+        mkdir -p /tmp/backup_shlibs
+        mv $(dirname $(dirname $CXX))/lib/*c++*so /tmp/backup_shlibs/
+    fi
     # then make everything else
     ${MASON_NINJA}/bin/ninja -j${MASON_CONCURRENCY}
     # install it all
@@ -165,7 +167,9 @@ function mason_compile {
     rm -f "clang++-${MAJOR_MINOR}"
     ln -s "clang++" "clang++-${MAJOR_MINOR}"
     # restore host compilers sharedlibs
-    cp -r backup_shlibs/* $(dirname $(dirname $CXX))/lib/
+    if [[ ${CXX_BOOTSTRAP:-false} != false ]]; then
+        cp -r /tmp/backup_shlibs/* $(dirname $(dirname $CXX))/lib/
+    fi
 }
 
 function mason_cflags {

--- a/scripts/llvm/base/common.sh
+++ b/scripts/llvm/base/common.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+
+MASON_NAME=llvm
+MASON_LIB_FILE=bin/clang
+
+. ${MASON_DIR}/mason.sh
+
+# we use this custom function rather than "mason_download" since we need to easily grab multiple packages
+function curl_get_and_uncompress() {
+    local URL=${1}
+    local TO_DIR=${2}
+    if [[ ${TO_DIR:-false} == false ]]; then
+        mason_error "TO_DIR unset"
+        exit 1
+    fi
+    local EXPECTED_MD5=${3:-false}
+    local file_basename=$(basename ${URL})
+    local local_file=$(pwd)/${file_basename}
+    if [ ! -f ${local_file} ] ; then
+        mason_step "Downloading $1 to ${local_file}"
+        curl --retry 3 -f -L -O "${URL}"
+    else
+        mason_substep "already downloaded $1 to ${local_file}"
+    fi
+    MD5_SUM=$(md5 -q ${local_file})
+    if [[ ${EXPECTED_MD5:-false} == false ]]; then
+        mason_error "Warning: no expected m5, actual was ${MD5_SUM}"
+    else
+        if [[ $3 != ${MD5_SUM} ]]; then
+            mason_error "Error: md5 mismatch ${EXPECTED_MD5} (expected) != ${MD5_SUM} (actual)"
+            exit 1
+        else
+            mason_success "Success: md5 matched: ${EXPECTED_MD5} (expected) == ${MD5_SUM} (actual)"
+        fi
+    fi
+    mason_step "uncompressing ${local_file}"
+    tar xf ${local_file}
+    local uncompressed_dir=${file_basename/.tar.xz}
+    mason_step "moving ${uncompressed_dir} into place at ${TO_DIR}"
+    mv ${uncompressed_dir} ${TO_DIR}
+
+}
+
+# Note: override this function to set custom md5
+function setup_release() {
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/llvm-${MASON_VERSION}.src.tar.xz"              ${MASON_BUILD_PATH}/                        
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/cfe-${MASON_VERSION}.src.tar.xz"               ${MASON_BUILD_PATH}/tools/clang             
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/compiler-rt-${MASON_VERSION}.src.tar.xz"       ${MASON_BUILD_PATH}/projects/compiler-rt    
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/libcxx-${MASON_VERSION}.src.tar.xz"            ${MASON_BUILD_PATH}/projects/libcxx         
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/libcxxabi-${MASON_VERSION}.src.tar.xz"         ${MASON_BUILD_PATH}/projects/libcxxabi      
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/libunwind-${MASON_VERSION}.src.tar.xz"         ${MASON_BUILD_PATH}/projects/libunwind      
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/lld-${MASON_VERSION}.src.tar.xz"               ${MASON_BUILD_PATH}/tools/lld               
+    curl_get_and_uncompress "http://llvm.org/releases/${MASON_VERSION}/clang-tools-extra-${MASON_VERSION}.src.tar.xz" ${MASON_BUILD_PATH}/tools/clang/tools/extra 
+}
+
+function mason_load_source {
+    mkdir -p "${MASON_ROOT}/.cache"
+    cd "${MASON_ROOT}/.cache"
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/llvm-${MASON_VERSION}
+    if [[ -d ${MASON_BUILD_PATH}/ ]]; then
+        rm -rf ${MASON_BUILD_PATH}/
+    fi
+    # NOTE: this setup_release can be overridden per package to assert on different md5
+    setup_release
+}
+
+function mason_prepare_compile {
+    CCACHE_VERSION=3.3.1
+    CMAKE_VERSION=3.6.2
+    NINJA_VERSION=1.7.1
+
+    ${MASON_DIR}/mason install ccache ${CCACHE_VERSION}
+    MASON_CCACHE=$(${MASON_DIR}/mason prefix ccache ${CCACHE_VERSION})
+    ${MASON_DIR}/mason install cmake ${CMAKE_VERSION}
+    MASON_CMAKE=$(${MASON_DIR}/mason prefix cmake ${CMAKE_VERSION})
+    ${MASON_DIR}/mason install ninja ${NINJA_VERSION}
+    MASON_NINJA=$(${MASON_DIR}/mason prefix ninja ${NINJA_VERSION})
+}
+
+function mason_compile {
+    export CXX="${CXX:-clang++}"
+    export CC="${CC:-clang}"
+    mkdir -p ./build
+    cd ./build
+    CMAKE_EXTRA_ARGS=""
+    if [[ $(uname -s) == 'Darwin' ]]; then
+        # This is a stable location for libc++ headers from the system
+        SYSTEM_LIBCXX_HEADERS="/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/"
+        # This is the location of C headers on 10.11
+        OSX_10_11_SDK_C_HEADERS="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/usr/include/"
+        # This is the location of C headers on >= 10.12 which is a symlink to the versioned SDK
+        OSX_10_12_AND_GREATER_SDK_HEADERS="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/"
+        # This allows this version of clang to find the headers from only a command line tools install (no xcode installed)
+        # It is debatable whether this should be supported
+        COMMAND_LINE_TOOLS_C_HEADERS="/usr/include"
+        CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DC_INCLUDE_DIRS=:${SYSTEM_LIBCXX_HEADERS}:${OSX_10_12_AND_GREATER_SDK_HEADERS}:${OSX_10_11_SDK_C_HEADERS}:${COMMAND_LINE_TOOLS_C_HEADERS}"
+        CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DCLANG_DEFAULT_CXX_STDLIB=libc++"
+        CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DDEFAULT_SYSROOT=/"
+        CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DCMAKE_OSX_DEPLOYMENT_TARGET=10.11"
+        CMAKE_EXTRA_ARGS="${CMAKE_EXTRA_ARGS} -DLLVM_CREATE_XCODE_TOOLCHAIN=ON"
+    fi
+    # we link to libc++ even on linux to avoid runtime dependency on libstdc++:
+    # https://github.com/mapbox/mason/issues/252
+    export CXXFLAGS="-stdlib=libc++ ${CXXFLAGS//-mmacosx-version-min=10.8}"
+    export LDFLAGS="-stdlib=libc++ ${LDFLAGS//-mmacosx-version-min=10.8}"
+    ${MASON_CMAKE}/bin/cmake ../ -G Ninja -DCMAKE_INSTALL_PREFIX=${MASON_PREFIX} \
+     -DCMAKE_BUILD_TYPE=Release \
+     -DCMAKE_CXX_COMPILER_LAUNCHER="${MASON_CCACHE}/bin/ccache" \
+     -DCMAKE_CXX_COMPILER="$CXX" \
+     -DCMAKE_C_COMPILER="$CC" \
+     -DLLVM_ENABLE_ASSERTIONS=OFF \
+     -DCLANG_VENDOR="mapbox/mason" \
+     -DCLANG_REPOSITORY_STRING="https://github.com/mapbox/mason" \
+     -DCLANG_VENDOR_UTI="org.mapbox.llvm" \
+     -DCMAKE_EXE_LINKER_FLAGS="${LDFLAGS}" \
+     -DCMAKE_CXX_FLAGS="${CXXFLAGS}" \
+     -DCMAKE_MAKE_PROGRAM=${MASON_NINJA}/bin/ninja \
+     ${CMAKE_EXTRA_ARGS}
+    ${MASON_NINJA}/bin/ninja -j${MASON_CONCURRENCY} -k5
+    ${MASON_NINJA}/bin/ninja install -k5
+    cd ${MASON_PREFIX}/bin/
+    MAJOR_MINOR=$(echo $MASON_VERSION | cut -d '.' -f1-2)
+    # set up symlinks for clang++ to match what llvm.org binaries provide
+    rm -f "clang++-${MAJOR_MINOR}"
+    ln -s "clang++" "clang++-${MAJOR_MINOR}"
+}
+
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}


### PR DESCRIPTION
Adds packages for llvm 3.8.1, 3.9.0, and 4.x from git HEAD. These include binaries for clang, compiler-rt, libcxx, clang-tool-extras, etc. The goal is, after testing, to move Mason to defaulting to either 3.8.1 or 3.9.0 for its core linux compiler as per #251. Which version can be discussed at #251 - this PR is about getting new compilers available.

Adds a package for `clang++` which is a slimmed down repackaging of the llvm binaries for a given version to include just the pieces necessary to build C/C++ programs:
  - clang++/clang
  - lib/clang headers
  - share/
  - libLTO (for -flto)
  - libc++/libc++abi

Adds packages for `clang-tidy` and `clang-format`, which like the `clang++` package above, is a slimmed down binary repackaged from the source llvm build with the minimal command line tool for fast installs.

Note: there is no package named `clang` for `3.8.1` or `3.9.0`. What was previous named `clang` for the `3.8.0` is now called `llvm` because it includes a whole lot more than just `clang`. To get `clang/clang++` install the `clang++` package.

New in these packages:
 - clang++ now links against libc++ on linux to avoid libstdc++ runtime dep (#252)
 - now using md5 checks for llvm downloads
 - support for macOS 10.12

These packages were built using a very powerful AWS `Ubuntu 12.04.5 LTS (Precise Pangolin)` instance (not travis) because llvm takes too long to compile for travis. These packages were compiled with Mason provided clang 3.8.0.

Next actions:

 - [ ] @springmeyer is going to branch mason to test building new mason packages with these compilers
  - A custom s3 prefix or path will be used to avoid overwriting existing binaries while testing)
  - An s3 sync command will be run to bootstrap that new s3 path with a few key build dependencies: https://gist.github.com/springmeyer/b7f0351df61400c3175235872ddfc640
 - [ ] @springmeyer is going to branch mbgl-native, osrm, and mapnik to test these new compilers + newly compiled deps
   - Will test both `-D_GLIBCXX_USE_CXX11_ABI=0` and `-D_GLIBCXX_USE_CXX11_ABI=1` against gcc5/6
 - [x] review/questions on this PR: @kkaefer @jfirebaugh @tmpsantos @1ec5 
 - [x] Merge this PR, then move forward with #251
 - [ ] Make modifications to .travis.yml following #252 (no need for `libstdc++-5-dev` flag for C programs).