### PR TITLE
Fixes for lua 5.2.4 and luabind built against it

### DIFF
--- a/scripts/lua/5.2.4/.travis.yml
+++ b/scripts/lua/5.2.4/.travis.yml
@@ -1,23 +1,22 @@
-language: cpp
+language: generic
 
 sudo: false
 
 matrix:
   include:
     - os: osx
-      compiler: clang
+      osx_image: xcode7.3
     - os: linux
       compiler: clang
-
+      addons:
+        apt:
+          sources: [ 'ubuntu-toolchain-r-test' ]
+          packages: [ 'libstdc++-5-dev' ]
 env:
   global:
-   - secure: "clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFnWLtmF3stlft5YWyc2kI+FI="
-   - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
-
-before_install:
+   - secure: "clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFn"
+   - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDV"
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}
-
-after_success:
 - ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/lua/5.2.4/.travis.yml
+++ b/scripts/lua/5.2.4/.travis.yml
@@ -14,8 +14,8 @@ matrix:
           packages: [ 'libstdc++-5-dev' ]
 env:
   global:
-   - secure: "clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFn"
-   - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDV"
+   - secure: "clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFnWLtmF3stlft5YWyc2kI+FI="
+   - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/lua/5.2.4/patch.diff
+++ b/scripts/lua/5.2.4/patch.diff
@@ -1,0 +1,17 @@
+diff --git a/src/Makefile b/src/Makefile
+index 7b4b2b7..c1e3507 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -6,9 +6,9 @@
+ # Your platform. See PLATS for possible values.
+ PLAT= none
+ 
+-CC= gcc
+-CFLAGS= -O2 -Wall -DLUA_COMPAT_ALL $(SYSCFLAGS) $(MYCFLAGS)
+-LDFLAGS= $(SYSLDFLAGS) $(MYLDFLAGS)
++CC := $(CC)
++CFLAGS := -O3 -DNDEBUG -Wall -DLUA_COMPAT_ALL $(SYSCFLAGS) $(MYCFLAGS)
++LDFLAGS := $(SYSLDFLAGS) $(MYLDFLAGS)
+ LIBS= -lm $(SYSLIBS) $(MYLIBS)
+ 
+ AR= ar rcu

--- a/scripts/lua/5.2.4/script.sh
+++ b/scripts/lua/5.2.4/script.sh
@@ -17,7 +17,9 @@ function mason_load_source {
 }
 
 function mason_compile {
-    make generic CC=$CC CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}" INSTALL_TOP=${MASON_PREFIX} install
+    mason_step "Loading patch ${MASON_DIR}/scripts/${MASON_NAME}/${MASON_VERSION}/patch.diff"
+    patch -N -p1 < ${MASON_DIR}/scripts/${MASON_NAME}/${MASON_VERSION}/patch.diff
+    make generic CC=$CC MYCFLAGS="${CFLAGS}" MYLDFLAGS="${LDFLAGS}" INSTALL_TOP=${MASON_PREFIX} install
 }
 
 function mason_cflags {

--- a/scripts/luabind_lua524/e414c57bcb687bb3091b7c55bbff6947f052e46b/.travis.yml
+++ b/scripts/luabind_lua524/e414c57bcb687bb3091b7c55bbff6947f052e46b/.travis.yml
@@ -1,24 +1,22 @@
-language: cpp
+language: generic
 
 sudo: false
 
 matrix:
   include:
     - os: osx
-      compiler: clang
+      osx_image: xcode7.3
     - os: linux
       compiler: clang
-
+      addons:
+        apt:
+          sources: [ 'ubuntu-toolchain-r-test' ]
+          packages: [ 'libstdc++-5-dev' ]
 env:
   global:
-   - secure: "clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFnWLtmF3stlft5YWyc2kI+FI="
-   - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
-
-before_install:
-- source ./scripts/setup_cpp11_toolchain.sh
+   - secure: "clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFn"
+   - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDV"
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}
-
-after_success:
 - ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/luabind_lua524/e414c57bcb687bb3091b7c55bbff6947f052e46b/.travis.yml
+++ b/scripts/luabind_lua524/e414c57bcb687bb3091b7c55bbff6947f052e46b/.travis.yml
@@ -14,8 +14,8 @@ matrix:
           packages: [ 'libstdc++-5-dev' ]
 env:
   global:
-   - secure: "clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFn"
-   - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDV"
+   - secure: "clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFnWLtmF3stlft5YWyc2kI+FI="
+   - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/luabind_lua524/e414c57bcb687bb3091b7c55bbff6947f052e46b/script.sh
+++ b/scripts/luabind_lua524/e414c57bcb687bb3091b7c55bbff6947f052e46b/script.sh
@@ -20,16 +20,18 @@ function mason_prepare_compile {
     cd $(dirname ${MASON_ROOT})
     ${MASON_DIR}/mason install lua 5.2.4
     MASON_LUA=$(${MASON_DIR}/mason prefix lua 5.2.4)
-    ${MASON_DIR}/mason install boost 1.57.0
-    MASON_BOOST_HEADERS=$(${MASON_DIR}/mason prefix boost 1.57.0)
-    SYSTEM_ZLIB="/usr"
+    ${MASON_DIR}/mason install boost 1.61.0
+    MASON_BOOST_HEADERS=$(${MASON_DIR}/mason prefix boost 1.61.0)
+    ${MASON_DIR}/mason install cmake 3.5.2
+    MASON_CMAKE=$(${MASON_DIR}/mason prefix cmake 3.5.2)
 }
 
 function mason_compile {
+    rm -rf build
     mkdir build
     cd build
-    cmake
-    cmake ../ -DCMAKE_INSTALL_PREFIX=${MASON_PREFIX} \
+    ${MASON_CMAKE}/bin/cmake ../ -DCMAKE_INSTALL_PREFIX=${MASON_PREFIX} \
+      -DCMAKE_CXX_FLAGS="${CXXFLAGS} -DLUA_COMPAT_ALL" \
       -DLUA_LIBRARIES=${MASON_LUA}/lib \
       -DLUA_INCLUDE_DIR=${MASON_LUA}/include \
       -DBOOST_INCLUDEDIR=${MASON_BOOST_HEADERS}/include \


### PR DESCRIPTION
Fixes:
  - proper passing of optimization flags: #254
  - retargets luabind against latest boost
  - builds luabind with same flag as lua `-DLUA_COMPAT_ALL` (no evidence this is needed, but good for consistency)