### PR TITLE
geojson 0.3.1

### DIFF
--- a/scripts/geojson/0.3.1-hpp/.travis.yml
+++ b/scripts/geojson/0.3.1-hpp/.travis.yml
@@ -1,0 +1,61 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode7
+      env: MASON_PLATFORM=ios
+      compiler: clang
+    - os: osx
+      osx_image: xcode7.2
+      env: MASON_PLATFORM=ios
+      compiler: clang
+    - os: osx
+      osx_image: xcode7.3
+      env: MASON_PLATFORM=ios
+      compiler: clang
+    - os: osx
+      osx_image: xcode7
+      env: MASON_PLATFORM=osx
+      compiler: clang
+    - os: linux
+      compiler: gcc
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++6
+           - g++-5
+      env: MASON_PLATFORM=linux
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v5
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v7
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v8
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=x86
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=x86-64
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=mips
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=mips-64
+
+env:
+  global:
+   - secure: "clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFnWLtmF3stlft5YWyc2kI+FI="
+   - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
+
+script:
+- |
+  if [[ ${MASON_PLATFORM} == 'linux' ]]; then
+    export CXX=g++-5
+    export CC=gcc-5
+  fi
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+
+after_success:
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/geojson/0.3.1-hpp/script.sh
+++ b/scripts/geojson/0.3.1-hpp/script.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+MASON_NAME=geojson
+MASON_VERSION=0.3.1
+MASON_HEADER_ONLY=true
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        https://github.com/mapbox/geojson-cpp/archive/v${MASON_VERSION}.tar.gz \
+        2014db07a5525628e43a9fec36809b04417e1cda
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/geojson-cpp-${MASON_VERSION}
+}
+
+function mason_compile {
+    mkdir -p ${MASON_PREFIX}/include/
+    cp -r include/mapbox ${MASON_PREFIX}/include/mapbox
+}
+
+function mason_cflags {
+    echo "-I${MASON_PREFIX}/include"
+}
+
+function mason_ldflags {
+    :
+}
+
+mason_run "$@"

--- a/scripts/geojson/0.3.1/.travis.yml
+++ b/scripts/geojson/0.3.1/.travis.yml
@@ -1,0 +1,61 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode7
+      env: MASON_PLATFORM=ios
+      compiler: clang
+    - os: osx
+      osx_image: xcode7.2
+      env: MASON_PLATFORM=ios
+      compiler: clang
+    - os: osx
+      osx_image: xcode7.3
+      env: MASON_PLATFORM=ios
+      compiler: clang
+    - os: osx
+      osx_image: xcode7
+      env: MASON_PLATFORM=osx
+      compiler: clang
+    - os: linux
+      compiler: gcc
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++6
+           - g++-5
+      env: MASON_PLATFORM=linux
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v5
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v7
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v8
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=x86
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=x86-64
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=mips
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=mips-64
+
+env:
+  global:
+   - secure: "clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFnWLtmF3stlft5YWyc2kI+FI="
+   - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
+
+script:
+- |
+  if [[ ${MASON_PLATFORM} == 'linux' ]]; then
+    export CXX=g++-5
+    export CC=gcc-5
+  fi
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+
+after_success:
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/geojson/0.3.1/script.sh
+++ b/scripts/geojson/0.3.1/script.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+LIB_VERSION=0.3.1
+CXXABI=-D_GLIBCXX_USE_CXX11_ABI=1
+
+MASON_NAME=geojson
+MASON_VERSION=${LIB_VERSION}
+MASON_LIB_FILE=lib/libgeojson.a
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        https://github.com/mapbox/geojson-cpp/archive/v${LIB_VERSION}.tar.gz \
+        2014db07a5525628e43a9fec36809b04417e1cda
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/geojson-cpp-${LIB_VERSION}
+}
+
+function mason_compile {
+    make clean
+    CXXFLAGS="$CXXFLAGS $CXXABI" MASON=${MASON_DIR}/mason make
+    mkdir -p ${MASON_PREFIX}/{include,lib}
+    cp -r include/mapbox ${MASON_PREFIX}/include/mapbox
+    mv build/libgeojson.a ${MASON_PREFIX}/lib
+}
+
+function mason_cflags {
+    echo -I${MASON_PREFIX}/include
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    echo ${MASON_PREFIX}/lib/libgeojson.a
+}
+
+mason_run "$@"


### PR DESCRIPTION
Added header only package and static library package. They get published on different locations. On `cmake` one can choose by doing:
```
mason_use(geojson VERSION 0.3.1 HEADER_ONLY)
```
or:
```
mason_use(geojson VERSION 0.3.1)
```

/cc @kkaefer @springmeyer 