### PR TITLE
jemalloc 4.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,12 @@
 language: generic
 
 matrix:
-  exclude:
-    - os: linux
   include:
     - os: osx
-      osx_image: xcode7.3
+      osx_image: xcode8
       compiler: clang
     - os: linux
       sudo: false
-      addons:
-        apt:
-          sources:
-           - ubuntu-toolchain-r-test
-          packages:
-           - libstdc++-5-dev
 
 install:
 - |

--- a/scripts/jemalloc/4.2.1/.travis.yml
+++ b/scripts/jemalloc/4.2.1/.travis.yml
@@ -1,0 +1,23 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+    - os: linux
+      compiler: clang
+      sudo: false
+      addons:
+        apt:
+          sources: [ 'ubuntu-toolchain-r-test' ]
+          packages: [ 'libstdc++-5-dev' ]
+
+env:
+  global:
+   - secure: "clCFM3prHnDocZ8lXlimPxAogvFirD1Zx8cMcFJ/XpkTA/0pCgnhpArM4y/NzLHR57pNZTSCr3p6XZI1c1iTG4Zm8x0sK2A4aTFRahypXNy/e+LzAbtd1y1+dEEDwlJvNNGxizQX4frhOgSNQFDFnWLtmF3stlft5YWyc2kI+FI="
+   - secure: "jKJErCng8Sk8YJ0IN2FX3lhv7G1LeudMfFBAXViZaXn8w/gWPs+SlfXQmIJ5SruU7U2GQKnAhzbjwXjVAgAh8OAblzny0DDm5Lh5WmwkgAP8JH1LpsBwCYx2S/v8qyR4DX1RVhHS8mQu298180ZDVgGccw+hd8xrE/S5TEQcNfQ="
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/jemalloc/4.2.1/script.sh
+++ b/scripts/jemalloc/4.2.1/script.sh
@@ -11,13 +11,14 @@ function mason_load_source {
         https://github.com/jemalloc/jemalloc/releases/download/${MASON_VERSION}/jemalloc-${MASON_VERSION}.tar.bz2 \
         6bd515d75d192ac82f3171d36a998e0e6e77ac8a
 
-    mason_extract_tar_gz
+    mason_extract_tar_bz2
 
     export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
 }
 
 function mason_compile {
-    unset CFLAGS
+    # warning: CFLAGS overwrites jemalloc CFLAGS, so we need to add back the jemalloc defaults
+    export CFLAGS="${CFLAGS} -std=gnu99 -Wall -pipe -O3 -funroll-loops"
     ./configure --prefix=${MASON_PREFIX}
     make -j${MASON_CONCURRENCY} VERBOSE=1
     make install

--- a/scripts/jemalloc/4.2.1/script.sh
+++ b/scripts/jemalloc/4.2.1/script.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+MASON_NAME=jemalloc
+MASON_VERSION=4.2.1
+MASON_LIB_FILE=bin/jeprof
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        https://github.com/jemalloc/jemalloc/releases/download/${MASON_VERSION}/jemalloc-${MASON_VERSION}.tar.bz2 \
+        6bd515d75d192ac82f3171d36a998e0e6e77ac8a
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
+}
+
+function mason_compile {
+    unset CFLAGS
+    ./configure --prefix=${MASON_PREFIX}
+    make -j${MASON_CONCURRENCY} VERBOSE=1
+    make install
+}
+
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"

--- a/utils/toolchain.sh
+++ b/utils/toolchain.sh
@@ -3,10 +3,10 @@
 set -eu
 set -o pipefail
 
-CLANG_VERSION="3.8.0"
-./mason install clang ${CLANG_VERSION}
-export PATH=$(./mason prefix clang ${CLANG_VERSION})/bin:${PATH}
-export CXX=clang++-3.8
-export CC=clang-3.8
+CLANG_VERSION="3.9.0"
+./mason install clang++ ${CLANG_VERSION}
+export PATH=$(./mason prefix clang++ ${CLANG_VERSION})/bin:${PATH}
+export CXX=clang++-3.9
+export CC=clang-3.9
 
 set +eu


### PR DESCRIPTION
Adds latest jemalloc release. Motivation for putting this together was to get access to a jemalloc `jeprof` tool with per thread heap profiling. Also the latest 4.x series purports to have better performance than 3.x (latest apt package on trusty is 3.5.1).

/cc @mikemorris @yhahn 