### PR TITLE
Only set MASON_DYNLIB_SUFFIX=tbd for system packages

### DIFF
--- a/mason.sh
+++ b/mason.sh
@@ -47,7 +47,7 @@ if [ ${MASON_PLATFORM} = 'osx' ]; then
         MASON_SDK_ROOT=${MASON_XCODE_ROOT}/Platforms/MacOSX.platform/Developer
         MASON_SDK_PATH="${MASON_SDK_ROOT}/SDKs/MacOSX${MASON_SDK_VERSION}.sdk"
 
-        if [[  ${MASON_SDK_VERSION%%.*} -ge 10 && ${MASON_SDK_VERSION##*.} -ge 11 ]]; then
+        if [[ ${MASON_SYSTEM_PACKAGE} && ${MASON_SDK_VERSION%%.*} -ge 10 && ${MASON_SDK_VERSION##*.} -ge 11 ]]; then
             export MASON_DYNLIB_SUFFIX="tbd"
         else
             export MASON_DYNLIB_SUFFIX="dylib"


### PR DESCRIPTION
Apple started using tbd for system libraries. But the rest of the world still uses dylib. Mason does package a few libraries as shared (notably tbb) that need to know MASON_DYNLIB_SUFFIX is `dylib` on OSX.

refs https://github.com/mapbox/mason/pull/131#r56075159

/cc @kkaefer @jfirebaugh 