### PR TITLE
Binutils latest

### DIFF
--- a/scripts/binutils/f0e9390be/.travis.yml
+++ b/scripts/binutils/f0e9390be/.travis.yml
@@ -1,0 +1,20 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
+           - bison
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/binutils/f0e9390be/.travis.yml
+++ b/scripts/binutils/f0e9390be/.travis.yml
@@ -14,6 +14,7 @@ matrix:
           packages:
            - libstdc++-5-dev
            - bison
+           - texinfo
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/binutils/f0e9390be/script.sh
+++ b/scripts/binutils/f0e9390be/script.sh
@@ -23,6 +23,7 @@ function mason_compile {
         --enable-plugins \
         --enable-static \
         --disable-shared \
+        --disable-werror \
         --disable-dependency-tracking
 
     make -j${MASON_CONCURRENCY}

--- a/scripts/binutils/f0e9390be/script.sh
+++ b/scripts/binutils/f0e9390be/script.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+MASON_NAME=binutils
+MASON_VERSION=f0e9390be
+MASON_LIB_FILE=bin/ld
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
+    git clone git://sourceware.org/git/binutils-gdb.git ${MASON_BUILD_PATH}
+    cd ${MASON_BUILD_PATH}
+    git checkout f0e9390be5bbfa3ee777d81dacfccd713ebddb68
+    cd ../
+}
+
+function mason_compile {
+    # we unset CFLAGS otherwise they will clobber defaults inside binutils
+    unset CFLAGS
+    ./configure \
+        --prefix=${MASON_PREFIX} \
+        --enable-gold \
+        --enable-plugins \
+        --enable-static \
+        --disable-shared \
+        --disable-dependency-tracking
+
+    make -j${MASON_CONCURRENCY}
+    make install
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"


### PR DESCRIPTION
Adds package for binutils git HEAD. Motivation for this package is to see if `-flto` + `clang++ 3.9.0` + `ld.gold` works. Currently seeing segfaults in `ld.gold` with `clang++ 3.9.0` and `-flto`.