### PR TITLE
Boost 1.62 fixes

### DIFF
--- a/scripts/boost/1.62.0/.travis.yml
+++ b/scripts/boost/1.62.0/.travis.yml
@@ -1,6 +1,9 @@
 language: generic
 
-sudo: false
+matrix:
+  include:
+    - os: linux
+      sudo: false
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost/1.62.0/common.sh
+++ b/scripts/boost/1.62.0/common.sh
@@ -58,7 +58,7 @@ function mason_ldflags {
     local LOCAL_LDFLAGS
     LOCAL_LDFLAGS="-L${MASON_PREFIX}/lib"
     if [[ ${BOOST_LIBRARY:-false} != false ]]; then
-        LOCAL_LDFLAGS="${LOCAL_LDFLAGS} -l${BOOST_LIBRARY}"
+        LOCAL_LDFLAGS="${LOCAL_LDFLAGS} -lboost_${BOOST_LIBRARY}"
     fi
     echo $LOCAL_LDFLAGS
 }

--- a/scripts/boost/1.62.0/script.sh
+++ b/scripts/boost/1.62.0/script.sh
@@ -8,7 +8,6 @@ source ${HERE}/base.sh
 # this package is the one that is header-only
 MASON_NAME=boost
 MASON_HEADER_ONLY=true
-unset MASON_LIB_FILE
 
 # setup mason env
 . ${MASON_DIR}/mason.sh
@@ -49,6 +48,14 @@ function mason_compile {
 >    return ::open(name, (int)mode,S_IRUSR|S_IWUSR);
 "
 
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
 }
 
 mason_run "$@"

--- a/utils/new_boost.sh
+++ b/utils/new_boost.sh
@@ -46,6 +46,7 @@ for lib in $(find scripts/ -maxdepth 1 -type dir -name 'boost_lib*' -print); do
     fi
 done
 
+./mason trigger boost ${NEW_VERSION}
 for lib in $(find scripts/ -maxdepth 1 -type dir -name 'boost_lib*' -print); do
     echo "running ./mason build $(basename $lib) ${NEW_VERSION}"
     ./mason trigger $(basename $lib) ${NEW_VERSION}


### PR DESCRIPTION
This fixes a few errors specific to the boost 1.62 packages. Previous packages were somewhat immune since they do not have mason.ini files. This fixes the generation of the mason.ini for boost 1.62.0 such that:

  - The header-only `boost` package does not report ldflags and static_libs
  - The library name is correct for ldflags for the actual libraries

