### PR TITLE
jemalloc 4.4.0 (fixes for latest linux)

### DIFF
--- a/scripts/jemalloc/4.4.0/.travis.yml
+++ b/scripts/jemalloc/4.4.0/.travis.yml
@@ -1,0 +1,14 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.2
+      compiler: clang
+    - os: linux
+      compiler: clang
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/jemalloc/4.4.0/script.sh
+++ b/scripts/jemalloc/4.4.0/script.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+MASON_NAME=jemalloc
+MASON_VERSION=4.4.0
+MASON_LIB_FILE=bin/jeprof
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        https://github.com/jemalloc/jemalloc/releases/download/${MASON_VERSION}/jemalloc-${MASON_VERSION}.tar.bz2 \
+        90f752aeb070639f5f8fd5d87a86cf9cc2ddc8f3
+
+    mason_extract_tar_bz2
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
+}
+
+function mason_compile {
+    # warning: CFLAGS overwrites jemalloc CFLAGS, so we need to add back the jemalloc defaults
+    export CFLAGS="${CFLAGS} -std=gnu11 -Wall -pipe -O3 -funroll-loops -DNDEBUG -D_REENTRANT"
+    ./configure --prefix=${MASON_PREFIX}
+    make -j${MASON_CONCURRENCY} VERBOSE=1
+    make install
+}
+
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"


### PR DESCRIPTION
Latest jemalloc plays more nicely with recent linux kernels:

> Refactor madvise(2) configuration so that MADV_FREE is detected and utilized on Linux 4.5 and newer. (@jasone)
> Mark partially purged arena chunks as non-huge-page. This improves interaction with Linux's transparent huge page functionality. (@jasone)

Refs:

 - https://github.com/jemalloc/jemalloc/releases/tag/4.4.0
 -  https://www.digitalocean.com/company/blog/transparent-huge-pages-and-alternative-memory-allocators/