### PR TITLE
Omnibus mesa 13.0.3

### DIFF
--- a/scripts/mesa/13.0.3/.travis.yml
+++ b/scripts/mesa/13.0.3/.travis.yml
@@ -1,0 +1,28 @@
+language: generic
+
+matrix:
+  include:
+    - os: linux
+      sudo: false
+      dist: trusty
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-4.8-dev
+           - pkg-config
+           - libpthread-stubs0-dev
+           - libssl-dev
+           - x11proto-gl-dev
+           - libx11-dev
+           - libxext-dev
+           - libxcb1-dev
+           - libdrm-dev
+           - valgrind
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+
+after_success:
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/mesa/13.0.3/script.sh
+++ b/scripts/mesa/13.0.3/script.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+MASON_NAME=mesa
+MASON_VERSION=13.0.3
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        https://mesa.freedesktop.org/archive/${MASON_VERSION}/mesa-${MASON_VERSION}.tar.gz \
+        c65114c3566674642f698580efc136fe1fe19c67
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/mesa-${MASON_VERSION}
+}
+
+function mason_prepare_compile {
+    LLVM_VERSION=3.8.1-libstdcxx
+    ${MASON_DIR}/mason install llvm ${LLVM_VERSION}
+    MASON_LLVM=$(${MASON_DIR}/mason prefix llvm ${LLVM_VERSION})
+}
+
+function mason_compile {
+    CFLAGS=-g CXXFLAGS=-g \
+    ./configure \
+        --prefix=${MASON_PREFIX} \
+        ${MASON_HOST_ARG} \
+        --enable-opengl \
+        --enable-gles1 \
+        --enable-gles2 \
+        --enable-egl \
+        --disable-osmesa \
+        --enable-gallium-osmesa \
+        --enable-gbm \
+        --enable-dri \
+        --disable-dri3 \
+        --enable-gallium-llvm \
+        --enable-glx \
+        --enable-glx-tls \
+        --enable-texture-float \
+        --enable-shared-glapi \
+        --enable-valgrind \
+        --with-dri-drivers=swrast \
+        --with-gallium-drivers=swrast \
+        --with-egl-platforms=x11,drm,surfaceless \
+        --disable-llvm-shared-libs \
+        --with-llvm-prefix=${MASON_LLVM} \
+        --with-sha1=libcrypto
+
+    make
+    make install
+}
+
+function mason_cflags {
+    echo -I${MASON_PREFIX}/include
+}
+
+function mason_ldflags {
+    # We include just the library path. Users are expected to provide additional flags
+    # depending on which of the packaged libraries they actually want to link:
+    #
+    #    * For GLX: -lGL -lX11
+    #    * For EGL: -lGLESv2 -lEGL -lgbm
+    #    * For OSMesa: -lOSMesa
+    #
+    echo -L${MASON_PREFIX}/lib
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"


### PR DESCRIPTION
This build of mesa includes all the variants we might want to use in a single package:

* libGL (GLX, DRI, and Gallium LLVM based implementation)
* libEGL + libGLEs (EGL, X11, DRI, and Gallium LLVM based implementation)
* libOSMesa (Gallium LLVM based implementation)

This package is set up so that using it does _not_ automatically trigger any particular library to be linked. The package user is responsible for supplying the appropriate `-l` arguments depending on the desired library:

* For GLX: `-lGL -lX11`
* For EGL: `-lGLESv2 -lEGL -lgbm`
* For OSMesa: `-lOSMesa`

LLVM is statically linked (fixes #280).

Other differences from previous packagings of mesa:

* It's built with `CFLAGS=-g CXXFLAGS=-g`, for debuggability.
* It's built with `--enable-valgrind` to try to cut down on valgrind false positives.
* It's built with `--enable-glx` (same as `--enable-glx=dri`), rather than `--enable-glx=gallium-xlib`, because the latter is incompatible with `--enable-dri`, which we need for EGL.
* Building with it won't add the mason mesa lib directory to the built output's rpath. You'll need to set `LD_LIBRARY_PATH` if you want to actually use the mason mesa .so's at runtime. (You probably want to do this in CI but use drivers with hardware acceleration in production.)

Important learnings obtained over the course of several days of investigation:

* Travis does not support the "drm" platform for EGL -- the "x11" platform must be used. I haven't yet tried "surfaceless" (https://github.com/mapbox/mapbox-gl-native/issues/7020).
* OSMesa works only with `--enable-gallium-osmesa`. The `--enable-osmesa` option produces rendering artifacts in GL Native. Basically, we want to build such that we use the Gallium llvmpipe software renderer no matter what library interface we use (GLX, EGL, or OSMesa).
* There's a bug in Travis's trusty node image that prevents GLX from working out of the box: https://github.com/travis-ci/travis-ci/issues/7198

cc @springmeyer @brunoabinader 