### PR TITLE
Bundles CMake 3.7.2 for Boost 1.63, see #310.

### DIFF
--- a/scripts/cmake/3.7.2/.travis.yml
+++ b/scripts/cmake/3.7.2/.travis.yml
@@ -1,0 +1,18 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+    - os: linux
+      compiler: clang
+      sudo: false
+      addons:
+        apt:
+          sources: [ 'ubuntu-toolchain-r-test' ]
+          packages: [ 'libstdc++-5-dev' ]
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/cmake/3.7.2/script.sh
+++ b/scripts/cmake/3.7.2/script.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+MASON_NAME=cmake
+MASON_VERSION=3.7.2
+MASON_LIB_FILE=bin/cmake
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        http://www.cmake.org/files/v3.7/cmake-${MASON_VERSION}.tar.gz \
+        35e73aad419b0dca4d5f8e8ba483e29ff54b7f05
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
+}
+
+function mason_compile {
+    ./configure --prefix=${MASON_PREFIX}
+    make -j${MASON_CONCURRENCY} VERBOSE=1
+    make install
+    # remove non-essential things to save on package size
+    rm -f ${MASON_PREFIX}/bin/ccmake
+    rm -f ${MASON_PREFIX}/bin/cmakexbuild
+    rm -f ${MASON_PREFIX}/bin/cpack
+    rm -f ${MASON_PREFIX}/bin/ctest
+    rm -rf ${MASON_PREFIX}/share/cmake-*/Help
+    ls -lh ${MASON_PREFIX}/bin/
+}
+
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"


### PR DESCRIPTION
We bundle Boost 1.63 but CMake before 3.7.2 lack `FindBoost.cmake` support for Boost 1.63.

cc @springmeyer 