### PR TITLE
Fix boost_regex packages

### DIFF
--- a/scripts/boost_libregex_icu/1.61.0/script.sh
+++ b/scripts/boost_libregex_icu/1.61.0/script.sh
@@ -5,10 +5,10 @@ HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
 
 # key properties unique to this library
 THIS_DIR=$(basename $(dirname $HERE))
-# Note: cannot duduce from directory since it is named in a custom way
+# Note: cannot deduce from directory since it is named in a custom way
 #BOOST_LIBRARY=${THIS_DIR#boost_lib}
 BOOST_LIBRARY=regex
-MASON_NAME=boost_lib${BOOST_LIBRARY}
+MASON_NAME=boost_lib${BOOST_LIBRARY}_icu
 MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
 # hack for inconsistently named test lib
 if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then

--- a/scripts/boost_libregex_icu/1.62.0/script.sh
+++ b/scripts/boost_libregex_icu/1.62.0/script.sh
@@ -5,10 +5,10 @@ HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
 
 # key properties unique to this library
 THIS_DIR=$(basename $(dirname $HERE))
-# Note: cannot duduce from directory since it is named in a custom way
+# Note: cannot deduce from directory since it is named in a custom way
 #BOOST_LIBRARY=${THIS_DIR#boost_lib}
 BOOST_LIBRARY=regex
-MASON_NAME=boost_lib${BOOST_LIBRARY}
+MASON_NAME=boost_lib${BOOST_LIBRARY}_icu
 MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
 # hack for inconsistently named test lib
 if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then

--- a/scripts/boost_libregex_icu/1.63.0/script.sh
+++ b/scripts/boost_libregex_icu/1.63.0/script.sh
@@ -5,10 +5,10 @@ HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
 
 # key properties unique to this library
 THIS_DIR=$(basename $(dirname $HERE))
-# Note: cannot duduce from directory since it is named in a custom way
+# Note: cannot deduce from directory since it is named in a custom way
 #BOOST_LIBRARY=${THIS_DIR#boost_lib}
 BOOST_LIBRARY=regex
-MASON_NAME=boost_lib${BOOST_LIBRARY}
+MASON_NAME=boost_lib${BOOST_LIBRARY}_icu
 MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
 # hack for inconsistently named test lib
 if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then


### PR DESCRIPTION
This fixes a problem with the boost_regex packages. The context is that there are two variants of `boost_libregex`: one has no runtime dependencies and another depends on icu. This fixes a problem whereby the icu variant was incorrectly named and could overwrite the package for the non-icu variant. This did not happen for 1.61 and 1.62 but did for 1.63 (due to the ordering of publishing).

TODO: binaries should be immutable to prevent bugs like this - as sketched out at https://github.com/mapbox/mason/issues/67#issuecomment-221112427.

/cc @danpat 
