### PR TITLE
llnode 1.4.1

### DIFF
--- a/scripts/llnode/1.4.1/.travis.yml
+++ b/scripts/llnode/1.4.1/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.2
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-4.8-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/llnode/1.4.1/.travis.yml
+++ b/scripts/llnode/1.4.1/.travis.yml
@@ -7,12 +7,6 @@ matrix:
       compiler: clang
     - os: linux
       sudo: false
-      addons:
-        apt:
-          sources:
-           - ubuntu-toolchain-r-test
-          packages:
-           - libstdc++-4.8-dev
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/llnode/1.4.1/script.sh
+++ b/scripts/llnode/1.4.1/script.sh
@@ -24,11 +24,11 @@ function mason_prepare_compile {
 
 function mason_compile {
     git clone --depth 1 https://chromium.googlesource.com/external/gyp.git tools/gyp
-    export CXXFLAGS="-stdlib=libc++ ${CXXFLAGS}"
-    export LDFLAGS="-stdlib=libc++ ${LDFLAGS}"
     # ../src/llv8.cc:256:43: error: expected ')'
      #snprintf(tmp, sizeof(tmp), " fn=0x%016" PRIx64, fn.raw());
-    perl -i -p -e "s/#include <vector>/#include <vector>\n#include <cstdint>/g;" src/llscan.cc
+    # need to define STDC macros since libc++ adheres to spec: http://en.cppreference.com/w/cpp/types/integer
+    export CXXFLAGS="-stdlib=libc++ ${CXXFLAGS} -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS"
+    export LDFLAGS="-stdlib=libc++ ${LDFLAGS}"
     ./gyp_llnode -Dlldb_build_dir=${LLVM_PATH} -Dlldb_dir=${LLVM_PATH}
     make -C out/ -j${MASON_CONCURRENCY} V=1
     mkdir -p ${MASON_PREFIX}/lib
@@ -44,7 +44,7 @@ function mason_cflags {
 }
 
 function mason_ldflags {
-    -L${MASON_PREFIX} -llnode
+    echo -L${MASON_PREFIX} -llnode
 }
 
 function mason_static_libs {

--- a/scripts/llnode/1.4.1/script.sh
+++ b/scripts/llnode/1.4.1/script.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+MASON_NAME=llnode
+MASON_VERSION=1.4.1
+MASON_LIB_FILE=lib/llnode.${MASON_DYNLIB_SUFFIX}
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        https://github.com/nodejs/llnode/archive/v${MASON_VERSION}.tar.gz \
+        b7ff83ff4686fdeb15517310b6e048c9c864794a
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
+}
+
+function mason_prepare_compile {
+    LLVM_VERSION=3.9.1
+    ${MASON_DIR}/mason install llvm 3.9.1
+    LLVM_PATH=$(${MASON_DIR}/mason prefix llvm 3.9.1)
+}
+
+function mason_compile {
+    git clone --depth 1 https://chromium.googlesource.com/external/gyp.git tools/gyp
+    export LDFLAGS="-stdlib=libc++ ${LDFLAGS}"
+    ./gyp_llnode -Dlldb_build_dir=${LLVM_PATH} -Dlldb_dir=${LLVM_PATH}
+    make -C out/ -j${MASON_CONCURRENCY} V=1
+    mkdir -p ${MASON_PREFIX}/lib
+    cp ./out/Release/llnode* ${MASON_PREFIX}/lib/
+}
+
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    -L${MASON_PREFIX} -llnode
+}
+
+function mason_static_libs {
+    :
+}
+
+mason_run "$@"

--- a/scripts/llnode/1.4.1/script.sh
+++ b/scripts/llnode/1.4.1/script.sh
@@ -26,6 +26,9 @@ function mason_compile {
     git clone --depth 1 https://chromium.googlesource.com/external/gyp.git tools/gyp
     export CXXFLAGS="-stdlib=libc++ ${CXXFLAGS}"
     export LDFLAGS="-stdlib=libc++ ${LDFLAGS}"
+    # ../src/llv8.cc:256:43: error: expected ')'
+     #snprintf(tmp, sizeof(tmp), " fn=0x%016" PRIx64, fn.raw());
+    perl -i -p -e "s/#include <vector>/#include <vector>\n#include <cstdint>/g;" src/llscan.cc
     ./gyp_llnode -Dlldb_build_dir=${LLVM_PATH} -Dlldb_dir=${LLVM_PATH}
     make -C out/ -j${MASON_CONCURRENCY} V=1
     mkdir -p ${MASON_PREFIX}/lib

--- a/scripts/llnode/1.4.1/script.sh
+++ b/scripts/llnode/1.4.1/script.sh
@@ -29,6 +29,11 @@ function mason_compile {
     # need to define STDC macros since libc++ adheres to spec: http://en.cppreference.com/w/cpp/types/integer
     export CXXFLAGS="-stdlib=libc++ ${CXXFLAGS} -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS"
     export LDFLAGS="-stdlib=libc++ ${LDFLAGS}"
+    # per the llvm package, on linux we statically link libc++ for full portability
+    # while on osx we use the system libc++
+    if [[ -f ${LLVM_PATH}/lib/libc++.a ]]; then
+        export LDFLAGS="-Wl,--whole-archive ${LLVM_PATH}/lib/libc++.a ${LLVM_PATH}/lib/libc++abi.a ${LDFLAGS}"
+    fi
     ./gyp_llnode -Dlldb_build_dir=${LLVM_PATH} -Dlldb_dir=${LLVM_PATH}
     make -C out/ -j${MASON_CONCURRENCY} V=1
     mkdir -p ${MASON_PREFIX}/lib

--- a/scripts/llnode/1.4.1/script.sh
+++ b/scripts/llnode/1.4.1/script.sh
@@ -24,11 +24,16 @@ function mason_prepare_compile {
 
 function mason_compile {
     git clone --depth 1 https://chromium.googlesource.com/external/gyp.git tools/gyp
+    export CXXFLAGS="-stdlib=libc++ ${CXXFLAGS}"
     export LDFLAGS="-stdlib=libc++ ${LDFLAGS}"
     ./gyp_llnode -Dlldb_build_dir=${LLVM_PATH} -Dlldb_dir=${LLVM_PATH}
     make -C out/ -j${MASON_CONCURRENCY} V=1
     mkdir -p ${MASON_PREFIX}/lib
-    cp ./out/Release/llnode* ${MASON_PREFIX}/lib/
+    if [[ $(uname -s) == 'Darwin' ]]; then
+        cp ./out/Release/llnode* ${MASON_PREFIX}/lib/
+    else
+        cp ./out/Release/lib.target/llnode* ${MASON_PREFIX}/lib/
+    fi
 }
 
 function mason_cflags {


### PR DESCRIPTION
Adds a binary for https://github.com/nodejs/llnode.

Can be loaded into lldb like:

```
mason install lldb 3.9.1
mason install llnode 1.4.1
$(mason prefix lldb 3.9.1)/bin/lldb --batch -o "plugin load $(.mason/mason prefix llnode 1.4.1)/lib/llnode.so" -o "v8"  -o "quit"
(lldb) plugin load /usr/local/src/mason_packages/linux-x86_64/llnode/1.4.1/lib/llnode.so
(lldb) v8
     Node.js helpers

Syntax: v8

The following subcommands are supported:

      bt              -- Show a backtrace with node.js JavaScript functions and their args. An optional argument is accepted; if that argument is a number, it specifies the number of frames to display. Otherwise all frames will be
                         dumped.
                         
                         Syntax: v8 bt [number]
      findjsinstances -- List all objects which share the specified map.
                         Accepts the same options as `v8 inspect`
      findjsobjects   -- List all object types and instance counts grouped by map and sorted by instance count.
                         Requires `LLNODE_RANGESFILE` environment variable to be set to a file containing memory ranges for the core file being debugged.
                         There are scripts for generating this file on Linux and Mac in the scripts directory of the llnode repository.
      findrefs        -- Finds all the object properties which meet the search criteria.
                         The default is to list all the object properties that reference the specified value.
                         Flags:
                         
                          * -v, --value expr     - all properties that refer to the specified JavaScript object (default)
                          * -n, --name  name     - all properties with the specified name
                          * -s, --string string  - all properties that refer to the specified JavaScript string value
                         
      inspect         -- Print detailed description and contents of the JavaScript value.
                         
                         Possible flags (all optional):
                         
                          * -F, --full-string    - print whole string without adding ellipsis
                          * -m, --print-map      - print object's map address
                          * -s, --print-source   - print source code for function objects
                          * --string-length num  - print maximum of `num` characters in string
                         
                         Syntax: v8 inspect [flags] expr
      nodeinfo        -- Print information about Node.js
      print           -- Print short description of the JavaScript value.
                         
                         Syntax: v8 print expr
      source          -- Source code information

For more help on any particular subcommand, type 'help <command> <subcommand>'.
(lldb) quit
```

It can also be loaded into the default plugin directory to avoid needing to run `plugin load <path>` each time. 

On linux this would be:

```
mkdir -p /usr/lib/lldb/plugins
cp $(.mason/mason prefix llnode 1.4.1)/lib/llnode.so /usr/lib/lldb/plugins/
```

On OS X this would be:

```
mkdir -p "${HOME}/Library/Application Support/LLDB/PlugIns/"
cp $(.mason/mason prefix llnode 1.4.1)/lib/llnode.so "${HOME}/Library/Application Support/LLDB/PlugIns/"
```
