### PR TITLE
Cross-compiler toolchain fixes

### DIFF
--- a/scripts/gcc/4.9.2-cortex_a9-hf/script.sh
+++ b/scripts/gcc/4.9.2-cortex_a9-hf/script.sh
@@ -28,4 +28,8 @@ function mason_ldflags {
     :
 }
 
+function mason_static_libs {
+    :
+}
+
 mason_run "$@"

--- a/scripts/gcc/4.9.2-cortex_a9/script.sh
+++ b/scripts/gcc/4.9.2-cortex_a9/script.sh
@@ -29,4 +29,8 @@ function mason_ldflags {
     :
 }
 
+function mason_static_libs {
+    :
+}
+
 mason_run "$@"

--- a/scripts/gcc/4.9.2-i686/script.sh
+++ b/scripts/gcc/4.9.2-i686/script.sh
@@ -29,4 +29,8 @@ function mason_ldflags {
     :
 }
 
+function mason_static_libs {
+    :
+}
+
 mason_run "$@"

--- a/scripts/gcc/5.3.0-cortex_a9-hf/script.sh
+++ b/scripts/gcc/5.3.0-cortex_a9-hf/script.sh
@@ -36,4 +36,8 @@ function mason_ldflags {
     :
 }
 
+function mason_static_libs {
+    :
+}
+
 mason_run "$@"

--- a/scripts/gcc/5.3.0-cortex_a9/script.sh
+++ b/scripts/gcc/5.3.0-cortex_a9/script.sh
@@ -36,4 +36,8 @@ function mason_ldflags {
     :
 }
 
+function mason_static_libs {
+    :
+}
+
 mason_run "$@"

--- a/scripts/gcc/5.3.0-i686/script.sh
+++ b/scripts/gcc/5.3.0-i686/script.sh
@@ -2,7 +2,7 @@
 
 MASON_NAME=gcc
 MASON_VERSION=5.3.0-i686
-MASON_LIB_FILE=root/bin/arm-i686-linux-gnueabi-gcc
+MASON_LIB_FILE=root/bin/i686-pc-linux-gnu-gcc
 
 . ${MASON_DIR}/mason.sh
 

--- a/scripts/gcc/5.3.0-i686/script.sh
+++ b/scripts/gcc/5.3.0-i686/script.sh
@@ -36,4 +36,8 @@ function mason_ldflags {
     :
 }
 
+function mason_static_libs {
+    :
+}
+
 mason_run "$@"


### PR DESCRIPTION
This PR:
- Fixes `MASON_LIB_FILE` for gcc 5.3.0-i686 - this is used in various places in `mason.sh` to perform package checks.
- Added no-op `mason_static_libs` for all gcc cross-compiler toolchain packages.

Fixes the build error in https://travis-ci.org/mapbox/mason/jobs/199379072#L168.