### PR TITLE
Further minimize or-tools build

### DIFF
--- a/scripts/gflags/2.1.2/.travis.yml
+++ b/scripts/gflags/2.1.2/.travis.yml
@@ -1,0 +1,21 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
+           - pandoc
+
+script:
+- if [[ $(uname -s) == 'Darwin' ]]; then brew install pandoc || true; fi;
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/gflags/2.1.2/.travis.yml
+++ b/scripts/gflags/2.1.2/.travis.yml
@@ -3,19 +3,11 @@ language: generic
 matrix:
   include:
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.2
       compiler: clang
     - os: linux
       sudo: false
-      addons:
-        apt:
-          sources:
-           - ubuntu-toolchain-r-test
-          packages:
-           - libstdc++-5-dev
-           - pandoc
 
 script:
-- if [[ $(uname -s) == 'Darwin' ]]; then brew install pandoc || true; fi;
 - ./mason build ${MASON_NAME} ${MASON_VERSION}
 - ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/gflags/2.1.2/script.sh
+++ b/scripts/gflags/2.1.2/script.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+MASON_NAME=gflags
+MASON_VERSION=2.1.2
+MASON_LIB_FILE=lib/libgflags.a
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        https://github.com/gflags/${MASON_NAME}/archive/v${MASON_VERSION}.tar.gz \
+        6810db9e9cb378bfc0b0fb250f27f4416df5beec
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
+}
+
+function mason_prepare_compile {
+    CCACHE_VERSION=3.3.1
+    ${MASON_DIR}/mason install ccache ${CCACHE_VERSION}
+    MASON_CCACHE=$(${MASON_DIR}/mason prefix ccache ${CCACHE_VERSION})
+    ${MASON_DIR}/mason install cmake 3.7.1
+    ${MASON_DIR}/mason link cmake 3.7.1
+}
+
+function mason_compile {
+    rm -rf build
+    mkdir -p build
+    cd build
+    CMAKE_PREFIX_PATH=${MASON_ROOT}/.link \
+    ${MASON_ROOT}/.link/bin/cmake \
+        -DCMAKE_INSTALL_PREFIX=${MASON_PREFIX} \
+        -DCMAKE_CXX_COMPILER_LAUNCHER="${MASON_CCACHE}/bin/ccache" \
+        -DCMAKE_BUILD_TYPE=Release
+        ..
+    make VERBOSE=1 -j${MASON_CONCURRENCY}
+    make install
+
+}
+
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    echo ${MASON_PREFIX}/${MASON_LIB_FILE}
+}
+
+mason_run "$@"

--- a/scripts/gflags/2.1.2/script.sh
+++ b/scripts/gflags/2.1.2/script.sh
@@ -32,7 +32,7 @@ function mason_compile {
     ${MASON_ROOT}/.link/bin/cmake \
         -DCMAKE_INSTALL_PREFIX=${MASON_PREFIX} \
         -DCMAKE_CXX_COMPILER_LAUNCHER="${MASON_CCACHE}/bin/ccache" \
-        -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_BUILD_TYPE=Release \
         ..
     make VERBOSE=1 -j${MASON_CONCURRENCY}
     make install

--- a/scripts/gflags/2.1.2/script.sh
+++ b/scripts/gflags/2.1.2/script.sh
@@ -20,8 +20,8 @@ function mason_prepare_compile {
     CCACHE_VERSION=3.3.1
     ${MASON_DIR}/mason install ccache ${CCACHE_VERSION}
     MASON_CCACHE=$(${MASON_DIR}/mason prefix ccache ${CCACHE_VERSION})
-    ${MASON_DIR}/mason install cmake 3.7.1
-    ${MASON_DIR}/mason link cmake 3.7.1
+    ${MASON_DIR}/mason install cmake 3.7.2
+    ${MASON_DIR}/mason link cmake 3.7.2
 }
 
 function mason_compile {

--- a/scripts/or-tools/5.1/.travis.yml
+++ b/scripts/or-tools/5.1/.travis.yml
@@ -3,15 +3,11 @@ language: generic
 matrix:
   include:
     - os: osx
-      osx_image: xcode8
+      osx_image: xcode8.2
       compiler: clang
     - os: linux
-      compiler: gcc
       sudo: false
-      addons:
-        apt:
-          sources: [ 'ubuntu-toolchain-r-test' ]
-          packages: [ 'subversion', 'git','bison','flex','python-setuptools','python-dev','autoconf','libtool','zlib1g-dev','texinfo','help2man','gawk','g++','curl','texlive','cmake','gettext','m4','unzip']
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/or-tools/5.1/.travis.yml
+++ b/scripts/or-tools/5.1/.travis.yml
@@ -7,6 +7,12 @@ matrix:
       compiler: clang
     - os: linux
       sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-4.9-dev
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/or-tools/5.1/patch.diff
+++ b/scripts/or-tools/5.1/patch.diff
@@ -119,3 +119,27 @@ index 003352c..b3f3ee1 100755
    POST_LIB =
    BISON = dependencies/install/bin/bison
    FLEX = dependencies/install/bin/flex
+diff --git a/src/constraint_solver/constraint_solveri.h b/src/constraint_solver/constraint_solveri.h
+index 1a5efbd..8f1419c 100644
+--- a/src/constraint_solver/constraint_solveri.h
++++ b/src/constraint_solver/constraint_solveri.h
+@@ -63,6 +63,7 @@
+ #include "base/integral_types.h"
+ #include "base/logging.h"
+ #include "base/sysinfo.h"
++#include "base/casts.h"
+ #include "base/timer.h"
+ #include "base/join.h"
+ #include "base/sparse_hash.h"
+@@ -252,9 +253,9 @@ inline uint64 Hash1(int value) { return Hash1(static_cast<uint32>(value)); }
+ 
+ inline uint64 Hash1(void* const ptr) {
+ #if defined(ARCH_K8) || defined(__powerpc64__) || defined(__aarch64__)
+-  return Hash1(reinterpret_cast<uint64>(ptr));
++  return Hash1(bit_cast<uint64>(ptr));
+ #else
+-  return Hash1(reinterpret_cast<uint32>(ptr));
++  return Hash1(bit_cast<uint32>(ptr));
+ #endif
+ }
+ 

--- a/scripts/or-tools/5.1/patch.diff
+++ b/scripts/or-tools/5.1/patch.diff
@@ -1,6 +1,8 @@
---- makefiles/Makefile.third_party.unix.orig	2017-02-08 05:51:21.000000000 -0800
-+++ makefiles/Makefile.third_party.unix	2017-02-08 05:39:25.000000000 -0800
-@@ -285,7 +285,7 @@
+diff --git a/makefiles/Makefile.third_party.unix b/makefiles/Makefile.third_party.unix
+index f2b3403..c82d55d 100755
+--- a/makefiles/Makefile.third_party.unix
++++ b/makefiles/Makefile.third_party.unix
+@@ -285,7 +285,7 @@ dependencies/sources/cbc-$(CBC_TAG)/Makefile: dependencies/sources/cbc-$(CBC_TAG
  	cd dependencies/sources/cbc-$(CBC_TAG) && $(SET_PATH) $(SET_COMPILER) ./configure --prefix=$(OR_ROOT_FULL)/dependencies/install --disable-bzlib --without-lapack --enable-static --enable-shared --with-pic ADD_CXXFLAGS="-DCBC_THREAD_SAFE -DCBC_NO_INTERRUPT $(MAC_VERSION)"
  
  dependencies/sources/cbc-$(CBC_TAG)/Makefile.in:
@@ -9,7 +11,7 @@
  
  # Install pcre (dependency of SWIG).
  dependencies/install/bin/pcretest: dependencies/sources/pcre-$(PCRE_TAG)/Makefile $(ACLOCAL_TARGET)
-@@ -351,6 +351,8 @@
+@@ -351,6 +351,8 @@ dependencies/install/bin/bison: dependencies/sources/bison-$(BISON_TAG)/Makefile
  
  dependencies/sources/bison-$(BISON_TAG)/Makefile: dependencies/sources/bison-$(BISON_TAG)/configure $(ACLOCAL_TARGET)
  	cd dependencies/sources/bison-$(BISON_TAG) && $(SET_PATH) autoreconf
@@ -18,7 +20,7 @@
  	cd dependencies/sources/bison-$(BISON_TAG) && $(SET_PATH) ./configure --prefix=$(OR_ROOT_FULL)/dependencies/install
  
  dependencies/sources/bison-$(BISON_TAG)/configure: dependencies/archives/bison-$(BISON_TAG).tar.gz
-@@ -396,18 +398,22 @@
+@@ -396,18 +398,22 @@ dependencies/sources/libtool-$(LIBTOOL_TAG)/Makefile: dependencies/sources/libto
  
  dependencies/sources/libtool-$(LIBTOOL_TAG)/configure: dependencies/archives/libtool-$(LIBTOOL_TAG).tar.gz
  	cd dependencies/sources && tar xvzmf ../archives/libtool-$(LIBTOOL_TAG).tar.gz
@@ -42,3 +44,78 @@
  	cd dependencies/sources/automake-$(AUTOMAKE_TAG) && $(SET_PATH) ./configure --prefix=$(OR_ROOT_FULL)/dependencies/install
  
  dependencies/sources/automake-$(AUTOMAKE_TAG)/configure: dependencies/archives/automake-$(AUTOMAKE_TAG).tar.gz
+@@ -471,22 +477,22 @@ makefile_third_party: Makefile.local
+ Makefile.local: makefiles/Makefile.third_party.unix
+ 	-$(DEL) Makefile.local
+ 	@echo Generating Makefile.local
+-	@echo $(SELECTED_JDK_DEF)>> Makefile.local
+-	@echo UNIX_PYTHON_VER = $(DETECTED_PYTHON_VERSION)>> Makefile.local
+-	@echo PATH_TO_CSHARP_COMPILER = $(DETECTED_MCS_BINARY)>> Makefile.local
+-	@echo CLR_KEYFILE = bin/or-tools.snk>> Makefile.local
++	#@echo $(SELECTED_JDK_DEF)>> Makefile.local
++	#@echo UNIX_PYTHON_VER = $(DETECTED_PYTHON_VERSION)>> Makefile.local
++	#@echo PATH_TO_CSHARP_COMPILER = $(DETECTED_MCS_BINARY)>> Makefile.local
++	#@echo CLR_KEYFILE = bin/or-tools.snk>> Makefile.local
+ 	@echo >> Makefile.local
+-	@echo $(GLPK_MAKEFILE)>> Makefile.local
+-	@echo $(SCIP_MAKEFILE)>> Makefile.local
+-	@echo \# Define UNIX_SLM_DIR to use Sulum Optimization.>> Makefile.local
+-	@echo \# Define UNIX_GUROBI_DIR and GUROBI_LIB_VERSION to use Gurobi.>> Makefile.local
+-	@echo \# Define UNIX_CPLEX_DIR to use CPLEX.>> Makefile.local
++	#@echo $(GLPK_MAKEFILE)>> Makefile.local
++	#@echo $(SCIP_MAKEFILE)>> Makefile.local
++	#@echo \# Define UNIX_SLM_DIR to use Sulum Optimization.>> Makefile.local
++	#@echo \# Define UNIX_GUROBI_DIR and GUROBI_LIB_VERSION to use Gurobi.>> Makefile.local
++	#@echo \# Define UNIX_CPLEX_DIR to use CPLEX.>> Makefile.local
+ 	@echo >> Makefile.local
+ 	@echo UNIX_GFLAGS_DIR = $(OR_ROOT_FULL)/dependencies/install>> Makefile.local
+ 	@echo UNIX_PROTOBUF_DIR = $(OR_ROOT_FULL)/dependencies/install>> Makefile.local
+ 	@echo UNIX_SPARSEHASH_DIR = $(OR_ROOT_FULL)/dependencies/install>> Makefile.local
+-	@echo UNIX_SWIG_BINARY = $(OR_ROOT_FULL)/dependencies/install/bin/swig>> Makefile.local
+-	@echo UNIX_CLP_DIR = $(OR_ROOT_FULL)/dependencies/install>> Makefile.local
+-	@echo UNIX_CBC_DIR = $(OR_ROOT_FULL)/dependencies/install>> Makefile.local
+-	@echo UNIX_SCIP_TAG = $(SCIP_TAG)>> Makefile.local
+-	@echo UNIX_SULUM_VERSION = $(SULUM_TAG) >> Makefile.local
+\ No newline at end of file
++	#@echo UNIX_SWIG_BINARY = $(OR_ROOT_FULL)/dependencies/install/bin/swig>> Makefile.local
++	#@echo UNIX_CLP_DIR = $(OR_ROOT_FULL)/dependencies/install>> Makefile.local
++	#@echo UNIX_CBC_DIR = $(OR_ROOT_FULL)/dependencies/install>> Makefile.local
++	#@echo UNIX_SCIP_TAG = $(SCIP_TAG)>> Makefile.local
++	#@echo UNIX_SULUM_VERSION = $(SULUM_TAG) >> Makefile.local
+\ No newline at end of file
+diff --git a/makefiles/Makefile.unix b/makefiles/Makefile.unix
+index 003352c..b3f3ee1 100755
+--- a/makefiles/Makefile.unix
++++ b/makefiles/Makefile.unix
+@@ -102,7 +102,7 @@ endif
+ SWIG_INC = $(GLPK_SWIG) $(CLP_SWIG) $(CBC_SWIG) $(SCIP_SWIG) $(SLM_SWIG) $(GUROBI_SWIG) $(CPLEX_SWIG) -DUSE_GLOP -DUSE_BOP
+ 
+ # Compilation flags
+-DEBUG = -O4 -DNDEBUG
++DEBUG = -O3 -DNDEBUG
+ JNIDEBUG = -O1 -DNDEBUG
+ 
+ # Check wether CBC/CLP need a coin subdir in library.
+@@ -118,8 +118,8 @@ ifdef UNIX_CLP_DIR
+ endif
+ 
+ ifeq ($(PLATFORM),LINUX)
+-  CCC = g++ -fPIC -std=c++0x -fwrapv
+-  DYNAMIC_LD = g++ -shared
++  CCC = clang++ -fPIC -std=c++11 -fwrapv
++  DYNAMIC_LD = clang++ -shared
+   CMAKE = cmake
+   ifeq ($(PTRLENGTH),64)
+     ARCH = -DARCH_K8
+@@ -181,9 +181,9 @@ ifeq ($(PLATFORM),LINUX)
+   JNI_LIB_EXT = so
+   LIB_SUFFIX = so
+   SWIG_LIB_SUFFIX = so
+-  LINK_CMD = g++ -shared
++  LINK_CMD = clang++ -shared
+   LINK_PREFIX = -o # Need the space.
+-  PRE_LIB = -Wl,-rpath $(OR_ROOT_FULL)/lib -L$(OR_ROOT_FULL)/lib -l
++  PRE_LIB = -Wl,-z,origin -Wl,-rpath=\$$ORIGIN
+   POST_LIB =
+   BISON = dependencies/install/bin/bison
+   FLEX = dependencies/install/bin/flex

--- a/scripts/or-tools/5.1/script.sh
+++ b/scripts/or-tools/5.1/script.sh
@@ -70,16 +70,22 @@ function mason_compile {
     make ortoolslibs -j${MASON_CONCURRENCY}
 
     if [[ $(uname -s) == "Darwin" ]] ; then
-        install_name_tool -id @rpath/libortools.dylib lib/libortools.dylib
+        install_name_tool -id @loader_path/libortools.dylib lib/libortools.dylib
     fi
 
     mkdir -p ${MASON_PREFIX}/lib/
     cp -r lib/libortools* ${MASON_PREFIX}/lib/
 
-    mkdir -p "${MASON_PREFIX}/include"
+    mkdir -p "${MASON_PREFIX}/include/or-tools/"
 
     for i in {algorithms,base,bop,constraint_solver,glop,graph,linear_solver,sat,util}; do
-        cp -r src/$i ${MASON_PREFIX}/include/
+        cp -r src/$i ${MASON_PREFIX}/include/or-tools/
+    done
+
+    for i in {algorithms,base,bop,constraint_solver,glop,graph,linear_solver,sat,util}; do
+        if [[ -d src/gen/$i ]]; then
+            cp -r src/gen/$i/*h ${MASON_PREFIX}/include/or-tools/$i/ || true
+        fi
     done
 
 }

--- a/scripts/or-tools/5.1/script.sh
+++ b/scripts/or-tools/5.1/script.sh
@@ -17,10 +17,6 @@ function mason_load_source {
 }
 
 function mason_prepare_compile {
-    ${MASON_DIR}/mason install cmake 3.7.2
-    export PATH=$(${MASON_DIR}/mason prefix cmake 3.7.2)/bin:${PATH}
-    ${MASON_DIR}/mason install ccache 3.3.1
-    MASON_CCACHE=$(${MASON_DIR}/mason prefix ccache 3.3.1)/bin/ccache
     ${MASON_DIR}/mason install gflags 2.1.2
     MASON_GFLAGS=$(${MASON_DIR}/mason prefix gflags 2.1.2)
     ${MASON_DIR}/mason install protobuf 3.0.0

--- a/scripts/or-tools/5.1/script.sh
+++ b/scripts/or-tools/5.1/script.sh
@@ -34,9 +34,6 @@ function mason_ldflags {
 }
 
 function mason_compile {
-    git init .
-    git add makefiles tools Makefile
-    git commit -a -m "all"
 
     # The following patch to the build script disables some of the more useless
     # and heavyweight parts of the build, like building the automake and autoconf


### PR DESCRIPTION
This PR attempts to tame the # of dependencies needed to build `or-tools` and moves to pulling the remaining dependencies from mason packages instead of letting or-tools build them.

/cc @danpat