### PR TITLE
zstd 1.1.3 adjustments

### DIFF
--- a/scripts/zstd/1.1.3/.travis.yml
+++ b/scripts/zstd/1.1.3/.travis.yml
@@ -1,16 +1,14 @@
-language: cpp
-
-sudo: false
+language: generic
 
 matrix:
   include:
     - os: osx
       compiler: clang
+      osx_image: xcode8.2
     - os: linux
       compiler: clang
+      sudo: false
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}
-
-after_success:
 - ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/zstd/1.1.3/script.sh
+++ b/scripts/zstd/1.1.3/script.sh
@@ -2,26 +2,45 @@
 
 MASON_NAME=zstd
 MASON_VERSION=1.1.3
-MASON_LIB_FILE=bin/zstd
+MASON_LIB_FILE=lib/libzstd.a
 
 . ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
-        https://github.com/facebook/zstd/archive/v1.1.3.tar.gz \
+        https://github.com/facebook/${MASON_NAME}/archive/v${MASON_VERSION}.tar.gz \
         5e90d0399b3d41851a8ab53db733ab06ab60f484
 
     mason_extract_tar_gz
 
-    export MASON_BUILD_PATH=${MASON_ROOT}/.build/zstd-${MASON_VERSION}
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
 }
 
 function mason_compile {
-    make install PREFIX=${MASON_PREFIX}
+    # CFLAGS overrides defaults (-O3), so we add back optimization
+    export CFLAGS="${CFLAGS} -O3"
+    # install the release version of the command line tools
+    make -C programs zstd-release install -j${MASON_CONCURRENCY} PREFIX=${MASON_PREFIX}
+    # install the release version of the library
+    make -C lib lib-release install -j${MASON_CONCURRENCY} PREFIX=${MASON_PREFIX}
+    # Now clear out the shared libs since we only want to package static libs
+    rm -f ${MASON_PREFIX}/lib/lib{*.so*,*.dylib}
 }
 
 function mason_clean {
     make clean
+}
+
+function mason_cflags {
+    echo -I${MASON_PREFIX}/include
+}
+
+function mason_static_libs {
+    echo ${MASON_PREFIX}/${MASON_LIB_FILE}
+}
+
+function mason_ldflags {
+    echo -L${MASON_PREFIX}/lib
 }
 
 mason_run "$@"


### PR DESCRIPTION
@apendleton please merge this if it looks okay. We have a longstanding problem in mason whereby we set `CFLAGS` and `CXXFLAGS` but they don't have optimizations flags `-O3 -DNDEBUG`. And most autotools (configure && make) based tools let `CFLAGS` override their internal optimization flags. So, until we consider adding `-O3` to the default flags we need to add them manually per script to ensure that we get fully optimized binaries. I've made this adjustment to the zstd script and also ensured we package only static libs to ensure that downstream apps will prefer static linking and benefit automatically from the portability.