### PR TITLE
Add latest node v4.x v6.x

### DIFF
--- a/scripts/node/4.7.3/.travis.yml
+++ b/scripts/node/4.7.3/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.2
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-4.9-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/node/4.7.3/.travis.yml
+++ b/scripts/node/4.7.3/.travis.yml
@@ -7,12 +7,6 @@ matrix:
       compiler: clang
     - os: linux
       sudo: false
-      addons:
-        apt:
-          sources:
-           - ubuntu-toolchain-r-test
-          packages:
-           - libstdc++-4.9-dev
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/node/4.7.3/patch.diff
+++ b/scripts/node/4.7.3/patch.diff
@@ -1,0 +1,92 @@
+diff --git a/common.gypi b/common.gypi
+index 4aa8f91..c014b86 100644
+--- a/common.gypi
++++ b/common.gypi
+@@ -67,7 +67,7 @@
+           'v8_enable_handle_zapping': 1,
+         },
+         'defines': [ 'DEBUG', '_DEBUG' ],
+-        'cflags': [ '-g', '-O0' ],
++        'cflags': [ '-glldb', '-g', '-O0' ],
+         'conditions': [
+           ['target_arch=="x64"', {
+             'msvs_configuration_platform': 'x64',
+@@ -109,13 +109,22 @@
+         },
+         'xcode_settings': {
+           'GCC_OPTIMIZATION_LEVEL': '0', # stop gyp from defaulting to -Os
++          'GCC_GENERATE_DEBUGGING_SYMBOLS':'NO', # avoid adding -gdwarf-2
++          'OTHER_CFLAGS': ['-glldb','-g'], # https://clang.llvm.org/docs/UsersManual.html#controlling-debugger-tuning
++          'OTHER_CPLUSPLUSFLAGS': ['-glldb','-g'] # https://clang.llvm.org/docs/UsersManual.html#controlling-debugger-tuning
+         },
+       },
+       'Release': {
+         'variables': {
+           'v8_enable_handle_zapping': 0,
+         },
+-        'cflags': [ '-O3', '-ffunction-sections', '-fdata-sections' ],
++        'cflags': [ '-O3', '-glldb', '-gline-tables-only' ],
++        'xcode_settings': {
++          'GCC_OPTIMIZATION_LEVEL': '3', # stop gyp from defaulting to -Os
++          'GCC_GENERATE_DEBUGGING_SYMBOLS':'NO', # avoid adding -gdwarf-2
++          'OTHER_CFLAGS': ['-glldb','-g'], # https://clang.llvm.org/docs/UsersManual.html#controlling-debugger-tuning
++          'OTHER_CPLUSPLUSFLAGS': ['-glldb','-gline-tables-only'] # https://clang.llvm.org/docs/UsersManual.html#controlling-debugger-tuning
++        },
+         'conditions': [
+           ['target_arch=="x64"', {
+             'msvs_configuration_platform': 'x64',
+@@ -269,7 +278,7 @@
+       }],
+       [ 'OS in "linux freebsd openbsd solaris android aix"', {
+         'cflags': [ '-Wall', '-Wextra', '-Wno-unused-parameter', ],
+-        'cflags_cc': [ '-fno-rtti', '-fno-exceptions', '-std=gnu++0x' ],
++        'cflags_cc': [ '-fno-rtti', '-fno-exceptions', '-std=c++11' ],
+         'ldflags': [ '-rdynamic' ],
+         'target_conditions': [
+           # The 1990s toolchain on SmartOS can't handle thin archives.
+@@ -352,7 +361,7 @@
+           'GCC_ENABLE_PASCAL_STRINGS': 'NO',        # No -mpascal-strings
+           'GCC_THREADSAFE_STATICS': 'NO',           # -fno-threadsafe-statics
+           'PREBINDING': 'NO',                       # No -Wl,-prebind
+-          'MACOSX_DEPLOYMENT_TARGET': '10.5',       # -mmacosx-version-min=10.5
++          'MACOSX_DEPLOYMENT_TARGET': '10.11',       # -mmacosx-version-min=10.5
+           'USE_HEADERMAP': 'NO',
+           'OTHER_CFLAGS': [
+             '-fno-strict-aliasing',
+@@ -379,7 +388,7 @@
+           ['clang==1', {
+             'xcode_settings': {
+               'GCC_VERSION': 'com.apple.compilers.llvm.clang.1_0',
+-              'CLANG_CXX_LANGUAGE_STANDARD': 'gnu++0x',  # -std=gnu++0x
++              'CLANG_CXX_LANGUAGE_STANDARD': 'c++11',
+             },
+           }],
+         ],
+diff --git a/src/util.h b/src/util.h
+index f96fb77..861d002 100644
+--- a/src/util.h
++++ b/src/util.h
+@@ -8,11 +8,7 @@
+ #include <stddef.h>
+ #include <stdlib.h>
+ 
+-#ifdef __APPLE__
+-#include <tr1/type_traits>  // NOLINT(build/c++tr1)
+-#else
+ #include <type_traits>  // std::remove_reference
+-#endif
+ 
+ namespace node {
+ 
+@@ -27,11 +23,7 @@ inline void* Realloc(void* pointer, size_t size);
+ inline void* Malloc(size_t size);
+ inline void* Calloc(size_t n, size_t size);
+ 
+-#ifdef __APPLE__
+-template <typename T> using remove_reference = std::tr1::remove_reference<T>;
+-#else
+ template <typename T> using remove_reference = std::remove_reference<T>;
+-#endif
+ 
+ #define FIXED_ONE_BYTE_STRING(isolate, string)                                \
+   (node::OneByteString((isolate), (string), sizeof(string) - 1))

--- a/scripts/node/4.7.3/script.sh
+++ b/scripts/node/4.7.3/script.sh
@@ -51,7 +51,7 @@ function mason_compile {
 
     echo "making binary"
     # we use `make binary` to hook into PORTABLE=1
-    BUILDTYPE=Debug PREFIX=${MASON_PREFIX} CONFIG_FLAGS="--debug --with-dtrace" make binary -j${MASON_CONCURRENCY}
+    BUILDTYPE=Debug PREFIX=${MASON_PREFIX} CONFIG_FLAGS="--debug" make binary -j${MASON_CONCURRENCY}
     ls
     echo "uncompressing binary"
     tar -xf *.tar.gz

--- a/scripts/node/4.7.3/script.sh
+++ b/scripts/node/4.7.3/script.sh
@@ -46,7 +46,7 @@ function mason_compile {
     export CXXFLAGS="${CXXFLAGS} -std=c++11 -stdlib=libc++"
     export LDFLAGS="${LDFLAGS} -std=c++11 -stdlib=libc++"
     if [[ $(uname -s) == 'Linux' ]]; then
-        export LDFLAGS="${LDFLAGS} -lc++abi"
+        export LDFLAGS="${LDFLAGS} -Wl,--start-group -lc++abi"
     fi
 
     echo "making binary"

--- a/scripts/node/4.7.3/script.sh
+++ b/scripts/node/4.7.3/script.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+MASON_NAME=node
+MASON_VERSION=4.7.3
+MASON_LIB_FILE=bin/node
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        https://nodejs.org/dist/v${MASON_VERSION}/node-v${MASON_VERSION}.tar.gz \
+        df5098f93bbd08fa76b17ca7abdb0398755d36bb
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/node-v${MASON_VERSION}
+}
+
+function mason_prepare_compile {
+    CCACHE_VERSION=3.3.1
+    CLANG_VERSION=3.9.1
+
+    ${MASON_DIR}/mason install ccache ${CCACHE_VERSION}
+    MASON_CCACHE=$(${MASON_DIR}/mason prefix ccache ${CCACHE_VERSION})
+    ${MASON_DIR}/mason install clang++ ${CLANG_VERSION}
+    MASON_CLANG=$(${MASON_DIR}/mason prefix clang++ ${CLANG_VERSION})
+    export CXX="${MASON_CCACHE}/bin/ccache ${MASON_CLANG}/bin/clang++"
+    export CC="${MASON_CCACHE}/bin/ccache ${MASON_CLANG}/bin/clang"
+    export LINK=${MASON_CLANG}/bin/clang++
+}
+
+function mason_compile {
+    mason_step "Loading patch"
+#    git init .
+#    git add .
+#    git commit -a -m "All"
+    patch -N -p1 < ${MASON_DIR}/scripts/${MASON_NAME}/${MASON_VERSION}/patch.diff
+#    exit 0
+
+    # disable icu
+    export BUILD_INTL_FLAGS="--with-intl=none"
+    export BUILD_DOWNLOAD_FLAGS=" "
+    export DISABLE_V8_I18N=1
+    export TAG=v${MASON_VERSION}
+
+    export CXXFLAGS="${CXXFLAGS} -std=c++11 -stdlib=libc++"
+    export LDFLAGS="${LDFLAGS} -std=c++11 -stdlib=libc++"
+    if [[ $(uname -s) == 'Linux' ]]; then
+        export LDFLAGS="${LDFLAGS} -lc++abi"
+    fi
+
+    echo "making binary"
+    # we use `make binary` to hook into PORTABLE=1
+    BUILDTYPE=Debug PREFIX=${MASON_PREFIX} CONFIG_FLAGS="--debug --with-dtrace" make binary -j${MASON_CONCURRENCY}
+    ls
+    echo "uncompressing binary"
+    tar -xf *.tar.gz
+    echo "making dir"
+    mkdir -p ${MASON_PREFIX}
+    echo "copying over"
+    cp -r node-v${MASON_VERSION}*/* ${MASON_PREFIX}/
+    # the release does not package the node debug binary `node_g` so we manually copy over now
+    cp out/Debug/node ${MASON_PREFIX}/bin/node_g
+}
+
+function mason_cflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
+
+function mason_ldflags {
+    :
+}
+
+mason_run "$@"

--- a/scripts/node/4.7.3/script.sh
+++ b/scripts/node/4.7.3/script.sh
@@ -30,12 +30,12 @@ function mason_prepare_compile {
 }
 
 function mason_compile {
+    # init a git repo to avoid the nodejs Makefile
+    # complaining about changes that it detects in the parent directory
+    git init .
+
     mason_step "Loading patch"
-#    git init .
-#    git add .
-#    git commit -a -m "All"
     patch -N -p1 < ${MASON_DIR}/scripts/${MASON_NAME}/${MASON_VERSION}/patch.diff
-#    exit 0
 
     # disable icu
     export BUILD_INTL_FLAGS="--with-intl=none"
@@ -51,7 +51,7 @@ function mason_compile {
 
     echo "making binary"
     # we use `make binary` to hook into PORTABLE=1
-    BUILDTYPE=Debug PREFIX=${MASON_PREFIX} CONFIG_FLAGS="--debug" make binary -j${MASON_CONCURRENCY}
+    V= BUILDTYPE=Debug PREFIX=${MASON_PREFIX} CONFIG_FLAGS="--debug" make binary -j${MASON_CONCURRENCY}
     ls
     echo "uncompressing binary"
     tar -xf *.tar.gz

--- a/scripts/node/6.9.5/.travis.yml
+++ b/scripts/node/6.9.5/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.2
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-4.9-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/node/6.9.5/.travis.yml
+++ b/scripts/node/6.9.5/.travis.yml
@@ -7,12 +7,6 @@ matrix:
       compiler: clang
     - os: linux
       sudo: false
-      addons:
-        apt:
-          sources:
-           - ubuntu-toolchain-r-test
-          packages:
-           - libstdc++-4.9-dev
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/node/6.9.5/patch.diff
+++ b/scripts/node/6.9.5/patch.diff
@@ -62,6 +62,19 @@ index 8a3179d..dc01575 100644
              },
            }],
          ],
+diff --git a/deps/v8/src/lookup.h b/deps/v8/src/lookup.h
+index 3fbd9b4..961303c 100644
+--- a/deps/v8/src/lookup.h
++++ b/deps/v8/src/lookup.h
+@@ -179,7 +179,7 @@ class LookupIterator final BASE_EMBEDDED {
+   Handle<Object> GetReceiver() const { return receiver_; }
+ 
+   Handle<JSObject> GetStoreTarget() const {
+-    DCHECK(receiver->IsJSObject());
++    DCHECK(receiver_->IsJSObject());
+     if (receiver_->IsJSGlobalProxy()) {
+       Map* map = JSGlobalProxy::cast(*receiver_)->map();
+       if (map->has_hidden_prototype()) {
 diff --git a/src/util.h b/src/util.h
 index ecd5b12..aa7c41e 100644
 --- a/src/util.h

--- a/scripts/node/6.9.5/patch.diff
+++ b/scripts/node/6.9.5/patch.diff
@@ -62,3 +62,36 @@ index 8a3179d..dc01575 100644
              },
            }],
          ],
+diff --git a/src/util.h b/src/util.h
+index ecd5b12..aa7c41e 100644
+--- a/src/util.h
++++ b/src/util.h
+@@ -11,16 +11,8 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ 
+-// OSX 10.9 defaults to libc++ which provides a C++11 <type_traits> header.
+-#if defined(__APPLE__) && __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 1090
+-#define USE_TR1_TYPE_TRAITS
+-#endif
+ 
+-#ifdef USE_TR1_TYPE_TRAITS
+-#include <tr1/type_traits>  // NOLINT(build/c++tr1)
+-#else
+ #include <type_traits>  // std::remove_reference
+-#endif
+ 
+ namespace node {
+ 
+@@ -47,11 +39,7 @@ NO_RETURN void Abort();
+ NO_RETURN void Assert(const char* const (*args)[4]);
+ void DumpBacktrace(FILE* fp);
+ 
+-#ifdef USE_TR1_TYPE_TRAITS
+-template <typename T> using remove_reference = std::tr1::remove_reference<T>;
+-#else
+ template <typename T> using remove_reference = std::remove_reference<T>;
+-#endif
+ 
+ #define FIXED_ONE_BYTE_STRING(isolate, string)                                \
+   (node::OneByteString((isolate), (string), sizeof(string) - 1))

--- a/scripts/node/6.9.5/patch.diff
+++ b/scripts/node/6.9.5/patch.diff
@@ -1,0 +1,64 @@
+diff --git a/common.gypi b/common.gypi
+index 8a3179d..dc01575 100644
+--- a/common.gypi
++++ b/common.gypi
+@@ -67,7 +67,7 @@
+           'v8_enable_handle_zapping': 1,
+         },
+         'defines': [ 'DEBUG', '_DEBUG' ],
+-        'cflags': [ '-g', '-O0' ],
++        'cflags': [ '-glldb', '-g', '-O0' ],
+         'conditions': [
+           ['target_arch=="x64"', {
+             'msvs_configuration_platform': 'x64',
+@@ -108,13 +108,22 @@
+         },
+         'xcode_settings': {
+           'GCC_OPTIMIZATION_LEVEL': '0', # stop gyp from defaulting to -Os
++          'GCC_GENERATE_DEBUGGING_SYMBOLS':'NO', # avoid adding -gdwarf-2
++          'OTHER_CFLAGS': ['-glldb','-g'], # https://clang.llvm.org/docs/UsersManual.html#controlling-debugger-tuning
++          'OTHER_CPLUSPLUSFLAGS': ['-glldb','-g'] # https://clang.llvm.org/docs/UsersManual.html#controlling-debugger-tuning
+         },
+       },
+       'Release': {
+         'variables': {
+           'v8_enable_handle_zapping': 0,
+         },
+-        'cflags': [ '-O3' ],
++        'cflags': [ '-O3', '-glldb', '-gline-tables-only'],
++        'xcode_settings': {
++          'GCC_OPTIMIZATION_LEVEL': '3', # stop gyp from defaulting to -Os
++          'GCC_GENERATE_DEBUGGING_SYMBOLS':'NO', # avoid adding -gdwarf-2
++          'OTHER_CFLAGS': ['-glldb','-g'], # https://clang.llvm.org/docs/UsersManual.html#controlling-debugger-tuning
++          'OTHER_CPLUSPLUSFLAGS': ['-glldb','-gline-tables-only'] # https://clang.llvm.org/docs/UsersManual.html#controlling-debugger-tuning
++        },
+         'conditions': [
+           ['target_arch=="x64"', {
+             'msvs_configuration_platform': 'x64',
+@@ -268,7 +277,7 @@
+       }],
+       [ 'OS in "linux freebsd openbsd solaris android aix"', {
+         'cflags': [ '-Wall', '-Wextra', '-Wno-unused-parameter', ],
+-        'cflags_cc': [ '-fno-rtti', '-fno-exceptions', '-std=gnu++0x' ],
++        'cflags_cc': [ '-fno-rtti', '-fno-exceptions', '-std=c++11' ],
+         'ldflags': [ '-rdynamic' ],
+         'target_conditions': [
+           # The 1990s toolchain on SmartOS can't handle thin archives.
+@@ -352,7 +361,7 @@
+           'GCC_ENABLE_PASCAL_STRINGS': 'NO',        # No -mpascal-strings
+           'GCC_THREADSAFE_STATICS': 'NO',           # -fno-threadsafe-statics
+           'PREBINDING': 'NO',                       # No -Wl,-prebind
+-          'MACOSX_DEPLOYMENT_TARGET': '10.7',       # -mmacosx-version-min=10.7
++          'MACOSX_DEPLOYMENT_TARGET': '10.11',       # -mmacosx-version-min=10.7
+           'USE_HEADERMAP': 'NO',
+           'OTHER_CFLAGS': [
+             '-fno-strict-aliasing',
+@@ -384,7 +393,7 @@
+           ['clang==1', {
+             'xcode_settings': {
+               'GCC_VERSION': 'com.apple.compilers.llvm.clang.1_0',
+-              'CLANG_CXX_LANGUAGE_STANDARD': 'gnu++0x',  # -std=gnu++0x
++              'CLANG_CXX_LANGUAGE_STANDARD': 'c++11',
+             },
+           }],
+         ],

--- a/scripts/node/6.9.5/script.sh
+++ b/scripts/node/6.9.5/script.sh
@@ -51,7 +51,7 @@ function mason_compile {
 
     echo "making binary"
     # we use `make binary` to hook into PORTABLE=1
-    BUILDTYPE=Debug PREFIX=${MASON_PREFIX} CONFIG_FLAGS="--debug --with-dtrace" make binary -j${MASON_CONCURRENCY}
+    BUILDTYPE=Debug PREFIX=${MASON_PREFIX} CONFIG_FLAGS="--debug" make binary -j${MASON_CONCURRENCY}
     ls
     echo "uncompressing binary"
     tar -xf *.tar.gz

--- a/scripts/node/6.9.5/script.sh
+++ b/scripts/node/6.9.5/script.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+MASON_NAME=node
+MASON_VERSION=6.9.5
+MASON_LIB_FILE=bin/node
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        https://nodejs.org/dist/v${MASON_VERSION}/node-v${MASON_VERSION}.tar.gz \
+        835f9898c8571479bd90fbbba45b36ffc6aca65c
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/node-v${MASON_VERSION}
+}
+
+function mason_prepare_compile {
+    CCACHE_VERSION=3.3.1
+    CLANG_VERSION=3.9.1
+
+    ${MASON_DIR}/mason install ccache ${CCACHE_VERSION}
+    MASON_CCACHE=$(${MASON_DIR}/mason prefix ccache ${CCACHE_VERSION})
+    ${MASON_DIR}/mason install clang++ ${CLANG_VERSION}
+    MASON_CLANG=$(${MASON_DIR}/mason prefix clang++ ${CLANG_VERSION})
+    export CXX="${MASON_CCACHE}/bin/ccache ${MASON_CLANG}/bin/clang++"
+    export CC="${MASON_CCACHE}/bin/ccache ${MASON_CLANG}/bin/clang"
+    export LINK=${MASON_CLANG}/bin/clang++
+}
+
+function mason_compile {
+    mason_step "Loading patch"]
+    #rm -rf .git
+    #git init .
+    #git add .
+    #git commit -a -m "All"
+    patch -N -p1 < ${MASON_DIR}/scripts/${MASON_NAME}/${MASON_VERSION}/patch.diff
+    #exit 0
+    # disable icu
+    export BUILD_INTL_FLAGS="--with-intl=none"
+    export BUILD_DOWNLOAD_FLAGS=" "
+    export DISABLE_V8_I18N=1
+    export TAG=v${MASON_VERSION}
+
+    export CXXFLAGS="${CXXFLAGS} -std=c++11 -stdlib=libc++"
+    export LDFLAGS="${LDFLAGS} -std=c++11 -stdlib=libc++"
+    if [[ $(uname -s) == 'Linux' ]]; then
+        export LDFLAGS="${LDFLAGS} -lc++abi"
+    fi
+
+    echo "making binary"
+    # we use `make binary` to hook into PORTABLE=1
+    BUILDTYPE=Debug PREFIX=${MASON_PREFIX} CONFIG_FLAGS="--debug --with-dtrace" make binary -j${MASON_CONCURRENCY}
+    ls
+    echo "uncompressing binary"
+    tar -xf *.tar.gz
+    echo "making dir"
+    mkdir -p ${MASON_PREFIX}
+    echo "copying over"
+    cp -r node-v${MASON_VERSION}*/* ${MASON_PREFIX}/
+    # the release does not package the node debug binary `node_g` so we manually copy over now
+    cp out/Debug/node ${MASON_PREFIX}/bin/node_g
+}
+
+function mason_cflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
+
+function mason_ldflags {
+    :
+}
+
+mason_run "$@"

--- a/scripts/node/6.9.5/script.sh
+++ b/scripts/node/6.9.5/script.sh
@@ -46,7 +46,7 @@ function mason_compile {
     export CXXFLAGS="${CXXFLAGS} -std=c++11 -stdlib=libc++"
     export LDFLAGS="${LDFLAGS} -std=c++11 -stdlib=libc++"
     if [[ $(uname -s) == 'Linux' ]]; then
-        export LDFLAGS="${LDFLAGS} -lc++abi"
+        export LDFLAGS="${LDFLAGS} -Wl,--start-group -lc++abi"
     fi
 
     echo "making binary"

--- a/scripts/node/6.9.5/script.sh
+++ b/scripts/node/6.9.5/script.sh
@@ -30,13 +30,13 @@ function mason_prepare_compile {
 }
 
 function mason_compile {
-    mason_step "Loading patch"]
-    #rm -rf .git
-    #git init .
-    #git add .
-    #git commit -a -m "All"
+    # init a git repo to avoid the nodejs Makefile
+    # complaining about changes that it detects in the parent directory
+    git init .
+
+    mason_step "Loading patch"
     patch -N -p1 < ${MASON_DIR}/scripts/${MASON_NAME}/${MASON_VERSION}/patch.diff
-    #exit 0
+
     # disable icu
     export BUILD_INTL_FLAGS="--with-intl=none"
     export BUILD_DOWNLOAD_FLAGS=" "
@@ -51,7 +51,7 @@ function mason_compile {
 
     echo "making binary"
     # we use `make binary` to hook into PORTABLE=1
-    BUILDTYPE=Debug PREFIX=${MASON_PREFIX} CONFIG_FLAGS="--debug" make binary -j${MASON_CONCURRENCY}
+    V= BUILDTYPE=Debug PREFIX=${MASON_PREFIX} CONFIG_FLAGS="--debug" make binary -j${MASON_CONCURRENCY}
     ls
     echo "uncompressing binary"
     tar -xf *.tar.gz


### PR DESCRIPTION
Adds:

 - node v4.7.3
 - node v6.9.5

Details:

- Include both release builds (./bin/node) and debug builds (./bin/node_g)
- Release builds are patched to compile with `-O3` (fastest) rather than `-Os` (fast, but not at the cost of size)
- Debug builds are patched to compile with `-glldb` for best debugging with lldb and llnode (#333)
- Both build and linked against libc++ instead of libstdc++

Gochas:

  - OS X builds take too long for travis, so osx versions were published locally.

Future work:

  - Use these packages as starting points for builds with address sanitizer-instrumented libc++