### PR TITLE
Error on undefined variables

### DIFF
--- a/mason
+++ b/mason
@@ -4,7 +4,7 @@ MASON_COMMAND=$1 ; shift
 MASON_NAME=$1 ; shift
 MASON_VERSION=$1 ; shift
 
-set -e
+set -eu
 set -o pipefail
 
 MASON_RELEASED_VERSION="0.7.0"

--- a/mason
+++ b/mason
@@ -84,4 +84,8 @@ fi
 . ${MASON_DIR}/mason.sh
 
 export MASON_DIR
-bash "${MASON_DIR}/scripts/${MASON_NAME}/${MASON_VERSION}/script.sh" "${MASON_COMMAND}" "$@"
+if [ -d "${MASON_DIR}/scripts/${MASON_NAME}/${MASON_VERSION}-${MASON_PLATFORM_VERSION}" ]; then
+    bash "${MASON_DIR}/scripts/${MASON_NAME}/${MASON_VERSION}-${MASON_PLATFORM_VERSION}/script.sh" "${MASON_COMMAND}" "$@"
+else
+    bash "${MASON_DIR}/scripts/${MASON_NAME}/${MASON_VERSION}/script.sh" "${MASON_COMMAND}" "$@"
+fi

--- a/mason.sh
+++ b/mason.sh
@@ -96,8 +96,8 @@ elif [ ${MASON_PLATFORM} = 'linux' ]; then
     export MASON_DYNLIB_SUFFIX="so"
 
     # Assume current system is the target platform
-    if [ -z ${MASON_PLATFORM_VERSION} ] ; then
-        export MASON_PLATFORM_VERSION=`uname -m`
+    if [ ${MASON_PLATFORM_VERSION:-} ] ; then
+        export MASON_PLATFORM_VERSION=$(uname -m)
     fi
 
     export CFLAGS="-fPIC"

--- a/mason.sh
+++ b/mason.sh
@@ -121,7 +121,7 @@ elif [ ${MASON_PLATFORM} = 'linux' ]; then
     fi
 
 elif [ ${MASON_PLATFORM} = 'android' ]; then
-    case "${MASON_PLATFORM_VERSION}" in
+    case "${MASON_PLATFORM_VERSION:-}" in
         arm-v5-9) export MASON_ANDROID_ABI=arm-v5 ;;
         arm-v7-9) export MASON_ANDROID_ABI=arm-v7 ;;
         arm-v8-21) export MASON_ANDROID_ABI=arm-v8 ;;

--- a/mason.sh
+++ b/mason.sh
@@ -1,4 +1,4 @@
-set -e
+set -eu
 set -o pipefail
 # set -x
 
@@ -47,7 +47,7 @@ if [ ${MASON_PLATFORM} = 'osx' ]; then
         MASON_SDK_ROOT=${MASON_XCODE_ROOT}/Platforms/MacOSX.platform/Developer
         MASON_SDK_PATH="${MASON_SDK_ROOT}/SDKs/MacOSX${MASON_SDK_VERSION}.sdk"
 
-        if [[ ${MASON_SYSTEM_PACKAGE} && ${MASON_SDK_VERSION%%.*} -ge 10 && ${MASON_SDK_VERSION##*.} -ge 11 ]]; then
+        if [[ ${MASON_SYSTEM_PACKAGE:-} && ${MASON_SDK_VERSION%%.*} -ge 10 && ${MASON_SDK_VERSION##*.} -ge 11 ]]; then
             export MASON_DYNLIB_SUFFIX="tbd"
         else
             export MASON_DYNLIB_SUFFIX="dylib"

--- a/mason.sh
+++ b/mason.sh
@@ -96,14 +96,14 @@ elif [ ${MASON_PLATFORM} = 'linux' ]; then
     export MASON_DYNLIB_SUFFIX="so"
 
     # Assume current system is the target platform
-    if [ ${MASON_PLATFORM_VERSION:-} ] ; then
+    if [ ! ${MASON_PLATFORM_VERSION:-} ] ; then
         export MASON_PLATFORM_VERSION=$(uname -m)
     fi
 
     export CFLAGS="-fPIC"
     export CXXFLAGS="${CFLAGS} -std=c++11"
 
-    if [ `uname -m` != ${MASON_PLATFORM_VERSION} ] ; then
+    if [ $(uname -m) != ${MASON_PLATFORM_VERSION} ] ; then
         # Install the cross compiler
         MASON_XC_PACKAGE_NAME=gcc
         MASON_XC_PACKAGE_VERSION=${MASON_XC_GCC_VERSION:-5.3.0}-${MASON_PLATFORM_VERSION}

--- a/scripts/gcc/5.3.0-cortex_a9-hf/script.sh
+++ b/scripts/gcc/5.3.0-cortex_a9-hf/script.sh
@@ -20,6 +20,10 @@ function mason_try_binary {
     mason_success "Installed toolchain setup files at ${MASON_PREFIX}"
 }
 
+function mason_build {
+    :
+}
+
 function mason_load_source {
     :
 }

--- a/scripts/gcc/5.3.0-cortex_a9/script.sh
+++ b/scripts/gcc/5.3.0-cortex_a9/script.sh
@@ -20,6 +20,10 @@ function mason_try_binary {
     mason_success "Installed toolchain setup files at ${MASON_PREFIX}"
 }
 
+function mason_build {
+    :
+}
+
 function mason_load_source {
     :
 }

--- a/scripts/gcc/5.3.0-i686/script.sh
+++ b/scripts/gcc/5.3.0-i686/script.sh
@@ -20,6 +20,10 @@ function mason_try_binary {
     mason_success "Installed toolchain setup files at ${MASON_PREFIX}"
 }
 
+function mason_build {
+    :
+}
+
 function mason_load_source {
     :
 }


### PR DESCRIPTION
I'm surprised we've been living without this. Undefined variables can cause major headaches in package scripts.sh. I just hit this with a `cp -r ${VARIABLE}/ ${MASON_PREFIX}/bin` where VARIABLE was undefined so mason attempted to copy my whole user folder. #neveragain