### PR TITLE
Update install documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,3 @@ install:
 
 script:
 - ./test/all.sh
-# Below we test installing based on the recommended method
-# get the latest tag
-- TAG_NAME=$(cat mason | grep MASON_RELEASED_VERSION= | cut -c25-29)
-# Test installing via curl to /tmp
-- curl -sSfL https://github.com/mapbox/mason/archive/v${TAG_NAME}.tar.gz | tar --gunzip --extract --strip-components=1 --exclude="*md" --exclude="test*" --directory=/tmp
-# ensure the command works
-- ./tmp/mason install zlib 1.2.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,10 @@ install:
 
 script:
 - ./test/all.sh
+# Below we test installing based on the recommended method
+# get the latest tag
+- TAG_NAME=$(cat mason | grep MASON_RELEASED_VERSION= | cut -c25-29)
+# Test installing via curl to /tmp
+- curl -sSfL https://github.com/mapbox/mason/archive/v${TAG_NAME}.tar.gz | tar --gunzip --extract --strip-components=1 --exclude="*md" --exclude="test*" --directory=/tmp
+# ensure the command works
+- ./tmp/mason install zlib 1.2.8

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Mason is unlike all of the above package managers because:
 
 ## Installation
 
+There are three recommended ways to install mason: via curl, via a submodule, or via bundling `mason.cmake`
+
 #### Curl install
 
 To install mason locally:
@@ -81,6 +83,24 @@ mason_packages: $(MASON)
     $(MASON) install geometry 0.7.0
     $(MASON) install variant 1.1.0
 ```
+
+#### mason.cmake
+
+Copy the https://raw.githubusercontent.com/mapbox/mason/master/mason.cmake into your cmake project. A common convention is to place it at `<your project>/cmake/mason`
+
+```
+mkdir cmake
+wget -O cmake/mason.cmake https://raw.githubusercontent.com/mapbox/mason/master/mason.cmake
+````
+
+Then in your `CmakeLists.txt` install packages like:
+
+```cmake
+mason_use(<package name> VERSION <package version> HEADER_ONLY)
+```
+
+Note: Leave out `HEADER_ONLY` if the package is a [pre-compiled library](https://github.com/mapbox/cpp/blob/master/glossary.md#precompiled-library). You can see if a package is `HEADER_ONLY` by looking inside the `script.sh` for `MASON_HEADER_ONLY=true` like https://github.com/mapbox/mason/blob/68871660b74023234fa96d482898c820a55bd4bf/scripts/geometry/0.9.0/script.sh#L5
+
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -32,20 +32,30 @@ Mason is unlike all of the above package managers because:
 
 ## Installation
 
-#### Symlink
+#### Curl install
 
-You need to install Mason to your user directory into `~/.mason`.
+To install mason locally:
 
-```bash
-git clone -b master --single-branch https://github.com/mapbox/mason.git ~/.mason
-sudo ln -s ~/.mason/mason /usr/local/bin/mason
+```sh
+mkdir ./mason
+curl -sSfL https://github.com/mapbox/mason/archive/v0.8.0.tar.gz | tar --gunzip --extract --strip-components=1 --exclude="*md" --exclude="test*" --directory=./mason
 ```
 
-The second line is optional.
+Then you can use the `mason` command like: `./mason/mason install <package> <version>`
+
+To install mason globally (to /tmp):
+
+```sh
+curl -sSfL https://github.com/mapbox/mason/archive/v0.8.0.tar.gz | tar --gunzip --extract --strip-components=1 --exclude="*md" --exclude="test*" --directory=/tmp
+```
+
+Then you can use the `mason` command like: `/tmp/mason install <package> <version>`
 
 #### Submodule
 
-Mason can be added a submodule to your repository instead of creating a global symlink. This is helpful for other contributors to get set up quickly. Make sure to include the final part of the following command `.mason/` so your submodule path has the leading `.` instead of just being `mason/`.
+Mason can also be added a submodule to your repository. This is helpful for other contributors to get set up quickly.
+
+Optionally a convention when using submodules, is to place the submodule at a path starting with `.` to make the directory hidden to most file browsers. If you want your mason folder hidden then make sure to include the final part of the following command `.mason/` so your submodule path has the leading `.` instead of just being `mason/`.
 
 ```bash
 git submodule add git@github.com:mapbox/mason.git .mason/

--- a/contributing.md
+++ b/contributing.md
@@ -1,6 +1,7 @@
 # Release process
 
 - Increment version at the top of `mason`
+- Increment the version in the [Readme](https://github.com/mapbox/mason/blob/master/README.md#installation)
 - Update changelog
 - Ensure tests are passing
 - Tag a release:

--- a/test/all.sh
+++ b/test/all.sh
@@ -12,3 +12,4 @@ $(dirname $0)/c_install_symlink_includes.sh
 $(dirname $0)/cpp11_header_install.sh
 $(dirname $0)/cpp11_install.sh
 $(dirname $0)/cpp11_build.sh
+$(dirname $0)/install_mason_from_tag.sh

--- a/test/install_mason_from_tag.sh
+++ b/test/install_mason_from_tag.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+# Test installing based on the recommended method
+# get the latest tag
+TAG_NAME=$(cat mason | grep MASON_RELEASED_VERSION= | cut -c25-29)
+echo "found ${TAG_NAME}"
+
+# if the current tag is available, test installing it
+if [[ $(git tag -l) =~ ${TAG_NAME} ]]; then
+    # Test installing via curl to /tmp
+    curl -sSfL https://github.com/mapbox/mason/archive/v${TAG_NAME}.tar.gz | tar --gunzip --extract --strip-components=1 --exclude="*md" --exclude="test*" --directory=/tmp
+    # ensure the command works
+    ./tmp/mason install zlib 1.2.8
+fi


### PR DESCRIPTION
Our main readme had install documentation that was very out of date.

The latest mason bash program no longer has to be installed in `~/.mason` (it can be installed anywhere) and also offers `mason.cmake` which is recommended to use for `cmake` based projects. We are also versioning `mason` releases to keep packages stable and so this recommends installing a versioned release for the bash program.

/cc @kkaefer for review

/cc @mattficke who noticed this way out of date documentation (thank you).