### PR TITLE
[WIP] Perf

### DIFF
--- a/scripts/elfutils/0.168/.travis.yml
+++ b/scripts/elfutils/0.168/.travis.yml
@@ -1,0 +1,21 @@
+language: generic
+
+matrix:
+  include:
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - g++-4.9
+
+# note: elfutils must be compiled with gcc (see script.sh)
+install:
+  - export CXX=g++-4.9
+  - export CC=gcc-4.9
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/elfutils/0.168/script.sh
+++ b/scripts/elfutils/0.168/script.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+MASON_NAME=elfutils
+MASON_VERSION=0.168
+MASON_LIB_FILE=lib/libelf.a
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        https://sourceware.org/elfutils/ftp/${MASON_VERSION}/${MASON_NAME}-${MASON_VERSION}.tar.bz2 \
+        a2b4185e2fdca39a9818328017ba0192a6d5d6d4
+
+    mason_extract_tar_bz2
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
+}
+
+function mason_prepare_compile {
+    ${MASON_DIR}/mason install xz 5.2.3
+    MASON_XZ=$(${MASON_DIR}/mason prefix xz 5.2.3)
+    ${MASON_DIR}/mason install bzip2 1.0.6
+    MASON_BZIP2=$(${MASON_DIR}/mason prefix bzip2 1.0.6)
+    ${MASON_DIR}/mason install zlib 1.2.8
+    MASON_ZLIB=$(${MASON_DIR}/mason prefix zlib 1.2.8)
+}
+
+
+# note: must be compiled with gcc due to variable length array usage
+# clang at configure time will fail the gnu99 check with:
+# conftest.c:26:18: error: fields must have a constant size: 'variable length array in structure' extension will never be supported
+function mason_compile {
+    # knock out -Werror
+    perl -i -p -e "s/,,-Werror/,,/g;" config/eu.am
+    perl -i -p -e "s/,,-Werror/,,/g;" libdwfl/Makefile.in
+    perl -i -p -e "s/,,-Werror/,,/g;" backends/Makefile.in
+    perl -i -p -e "s/,,-Werror/,,/g;" lib/Makefile.in
+    perl -i -p -e "s/,,-Werror/,,/g;" libasm/Makefile.in
+    perl -i -p -e "s/,,-Werror/,,/g;" libcpu/Makefile.in
+    perl -i -p -e "s/,,-Werror/,,/g;" libdwelf/Makefile.in
+    perl -i -p -e "s/,,-Werror/,,/g;" libdw/Makefile.in
+    perl -i -p -e "s/,,-Werror/,,/g;" libebl/Makefile.in
+    perl -i -p -e "s/,,-Werror/,,/g;" libelf/Makefile.in
+    perl -i -p -e "s/,,-Werror/,,/g;" src/Makefile.in
+    perl -i -p -e "s/,,-Werror/,,/g;" tests/Makefile.in
+
+
+    # Note CXXFLAGS overrides the default of `-O2 -g`
+    export CFLAGS="${CFLAGS:-} -O3 -DNDEBUG -I${MASON_ZLIB}/include -I${MASON_BZIP2}/include -I${MASON_XZ}/include"
+    export LDFLAGS="${LDFLAGS:-} -L${MASON_ZLIB}/lib -L${MASON_BZIP2}/lib -L${MASON_XZ}/lib"
+
+    ./configure --prefix=${MASON_PREFIX} ${MASON_HOST_ARG} \
+     --with-lzma=${MASON_XZ} \
+     --with-bzlib=${MASON_BZIP2} \
+     --with-zlib=${MASON_ZLIB} \
+     --without-biarch \
+     --disable-shared \
+     --disable-dependency-tracking
+
+    make -j${MASON_CONCURRENCY} V=1
+    make install
+    rm ${MASON_PREFIX}/lib/*so
+}
+
+function mason_cflags {
+    echo "-I${MASON_PREFIX}/include"
+}
+
+function mason_ldflags {
+    :
+}
+
+mason_run "$@"

--- a/scripts/perf/4.9.9/.travis.yml
+++ b/scripts/perf/4.9.9/.travis.yml
@@ -1,0 +1,28 @@
+language: generic
+
+matrix:
+  include:
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          # apt:
+          #  make systemtap-sdt-dev bison flex libperl-dev
+          # yum:
+          #  make flex bison elfutils-libelf-devel elfutils-devel libunwind-devel xz-devel numactl-devel openssl-devel slang-devel gtk2-devel perl-ExtUtils-Embed python-devel binutils-devel audit-libs-devel
+          packages:
+           - bison
+           - flex
+           - g++-4.9
+           - systemtap-sdt-dev
+
+# note: perf must be compiled with gcc (see script.sh)
+install:
+  - export CXX=g++-4.9
+  - export CC=gcc-4.9
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/perf/4.9.9/patch.diff
+++ b/scripts/perf/4.9.9/patch.diff
@@ -1,0 +1,30 @@
+diff --git a/Makefile.config b/Makefile.config
+index cffdd9c..da97a9a 100644
+--- a/Makefile.config
++++ b/Makefile.config
+@@ -275,19 +275,19 @@ else
+   else
+     ifndef NO_LIBDW_DWARF_UNWIND
+       ifneq ($(feature-libdw-dwarf-unwind),1)
+-        NO_LIBDW_DWARF_UNWIND := 1
+-        msg := $(warning No libdw DWARF unwind found, Please install elfutils-devel/libdw-dev >= 0.158 and/or set LIBDW_DIR);
++        #NO_LIBDW_DWARF_UNWIND := 1
++        #msg := $(warning No libdw DWARF unwind found, Please install elfutils-devel/libdw-dev >= 0.158 and/or set LIBDW_DIR);
+       endif
+     endif
+     ifneq ($(feature-dwarf), 1)
+       msg := $(warning No libdw.h found or old libdw.h found or elfutils is older than 0.138, disables dwarf support. Please install new elfutils-devel/libdw-dev);
+       NO_DWARF := 1
+     else
+-      ifneq ($(feature-dwarf_getlocations), 1)
+-        msg := $(warning Old libdw.h, finding variables at given 'perf probe' point will not work, install elfutils-devel/libdw-dev >= 0.157);
+-      else
++      #ifneq ($(feature-dwarf_getlocations), 1)
++      #  msg := $(warning Old libdw.h, finding variables at given 'perf probe' point will not work, install elfutils-devel/libdw-dev >= 0.157);
++      #else
+         CFLAGS += -DHAVE_DWARF_GETLOCATIONS
+-      endif # dwarf_getlocations
++      #endif # dwarf_getlocations
+     endif # Dwarf support
+   endif # libelf support
+ endif # NO_LIBELF

--- a/scripts/perf/4.9.9/script.sh
+++ b/scripts/perf/4.9.9/script.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+MASON_NAME=perf
+MASON_VERSION=4.9.9
+MASON_LIB_FILE=bin/perf
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    # https://www.kernel.org/
+    # https://git.kernel.org/cgit/linux/kernel/git/stable/linux-stable.git/log/tools/perf
+    mason_download \
+        https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-${MASON_VERSION}.tar.xz \
+        b45b464dbf36c360fbeb5d73c4648b5f14d92fc9
+
+    mason_extract_tar_xz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/linux-${MASON_VERSION}
+}
+
+function mason_prepare_compile {
+    ${MASON_DIR}/mason install zlib 1.2.8
+    MASON_ZLIB=$(${MASON_DIR}/mason prefix zlib 1.2.8)
+    ${MASON_DIR}/mason install xz 5.2.3
+    MASON_XZ=$(${MASON_DIR}/mason prefix xz 5.2.3)
+    ${MASON_DIR}/mason install binutils 2.27
+    MASON_BINUTILS=$(${MASON_DIR}/mason prefix binutils 2.27)
+    ${MASON_DIR}/mason install slang 2.3.1
+    MASON_SLANG=$(${MASON_DIR}/mason prefix slang 2.3.1)
+    ${MASON_DIR}/mason install bzip2 1.0.6
+    MASON_BZIP2=$(${MASON_DIR}/mason prefix bzip2 1.0.6)
+    ${MASON_DIR}/mason install elfutils 0.168
+    MASON_ELFUTILS=$(${MASON_DIR}/mason prefix elfutils 0.168)
+    EXTRA_CFLAGS="-m64 -I${MASON_SLANG}/include -I${MASON_ZLIB}/include  -I${MASON_XZ}/include -I${MASON_BINUTILS}/include -I${MASON_BZIP2}/include -I${MASON_ELFUTILS}/include"
+    EXTRA_LDFLAGS="-L${MASON_BZIP2}/lib -L${MASON_ZLIB}/lib -L${MASON_XZ}/lib -L${MASON_SLANG}/lib  -L${MASON_ELFUTILS}/lib -L${MASON_BINUTILS}/lib"
+}
+
+# https://perf.wiki.kernel.org/index.php/Jolsa_Howto_Install_Sources
+# https://askubuntu.com/questions/50145/how-to-install-perf-monitoring-tool/306683
+# https://www.spinics.net/lists/linux-perf-users/msg03040.html
+# https://software.intel.com/en-us/articles/linux-perf-for-intel-vtune-Amplifier-XE
+function mason_compile {
+    # JOBS=${MASON_CONCURRENCY} \
+    cd tools/perf
+    # note: LIBELF is needed for symbols + node --perf_basic_prof_only_functions
+    # we set NO_LIBUNWIND since libdw is used from elfutils which is faster: https://lwn.net/Articles/579508/
+    make V=1 VF=1 \
+      prefix=${MASON_PREFIX} \
+      NO_LIBNUMA=1 \
+      NO_LIBAUDIT=1 \
+      NOLIBBIONIC=1 \
+      NO_LIBUNWIND=1 \
+      NO_BACKTRACE=1 \
+      NO_DWARF=1 \
+      NO_LIBCRYPTO=1 \
+      NO_LIBPERL=1 \
+      NO_GTK2=1 \
+      LDFLAGS="${EXTRA_LDFLAGS}" \
+      NO_LIBPYTHON=1 \
+      WERROR=0 \
+      EXTRA_CFLAGS="${EXTRA_CFLAGS}" \
+      install
+}
+
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
+mason_run "$@"

--- a/scripts/perf/4.9.9/script.sh
+++ b/scripts/perf/4.9.9/script.sh
@@ -40,18 +40,21 @@ function mason_prepare_compile {
 # https://www.spinics.net/lists/linux-perf-users/msg03040.html
 # https://software.intel.com/en-us/articles/linux-perf-for-intel-vtune-Amplifier-XE
 function mason_compile {
-    # JOBS=${MASON_CONCURRENCY} \
     cd tools/perf
-    # note: LIBELF is needed for symbols + node --perf_basic_prof_only_functions
+    # hack to enable libdw since I could not get the feature checks to work to autodetect libdw correctly
+    patch -N -p1 < ${MASON_DIR}/scripts/${MASON_NAME}/${MASON_VERSION}/patch.diff
     # we set NO_LIBUNWIND since libdw is used from elfutils which is faster: https://lwn.net/Articles/579508/
-    make V=1 VF=1 \
+    # note: LIBELF is needed for symbols + node --perf_basic_prof_only_functions
+    make \
+      LIBDW_LDFLAGS="-L${MASON_ELFUTILS}/lib -Wl,--start-group -lelf -lebl -lz -llzma -lbz2" \
+      LIBDW_CFLAGS="-I${MASON_ELFUTILS}/include" \
+      V=1 VF=1 \
       prefix=${MASON_PREFIX} \
       NO_LIBNUMA=1 \
       NO_LIBAUDIT=1 \
-      NOLIBBIONIC=1 \
       NO_LIBUNWIND=1 \
+      NO_BIONIC=1 \
       NO_BACKTRACE=1 \
-      NO_DWARF=1 \
       NO_LIBCRYPTO=1 \
       NO_LIBPERL=1 \
       NO_GTK2=1 \

--- a/scripts/slang/2.3.1/.travis.yml
+++ b/scripts/slang/2.3.1/.travis.yml
@@ -1,0 +1,10 @@
+language: generic
+
+matrix:
+  include:
+    - os: linux
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/slang/2.3.1/script.sh
+++ b/scripts/slang/2.3.1/script.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+MASON_NAME=slang
+MASON_VERSION=2.3.1
+MASON_LIB_FILE=lib/libslang.a
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        http://www.jedsoft.org/releases/slang/slang-${MASON_VERSION}.tar.bz2 \
+        8617d4745d1be3e086adb2fb8ca349a64711afc7
+
+    mason_extract_tar_bz2
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/slang-${MASON_VERSION}
+}
+
+function mason_compile {
+    export CFLAGS="${CFLAGS} -O3 -DNDEBUG"
+    ./configure --prefix=${MASON_PREFIX} ${MASON_HOST_ARG} \
+     --enable-static \
+     --disable-shared \
+     --disable-dependency-tracking
+
+    make V=1 install-static
+}
+
+function mason_cflags {
+    echo ${MASON_PREFIX}/include
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    echo ${MASON_PREFIX}/${MASON_LIB_FILE}
+}
+
+mason_run "$@"

--- a/scripts/xz/5.2.3/.travis.yml
+++ b/scripts/xz/5.2.3/.travis.yml
@@ -1,0 +1,12 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.2
+    - os: linux
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/xz/5.2.3/script.sh
+++ b/scripts/xz/5.2.3/script.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+MASON_NAME=xz
+MASON_VERSION=5.2.3
+MASON_LIB_FILE=lib/liblzma.a
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        http://tukaani.org/xz/xz-${MASON_VERSION}.tar.gz \
+        147ce202755a3d846dc17479999671c7cadf0c2f
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/xz-${MASON_VERSION}
+}
+
+function mason_compile {
+    export CFLAGS="${CFLAGS:-} -O3 -DNDEBUG"
+
+    ./configure \
+        --prefix=${MASON_PREFIX} \
+        ${MASON_HOST_ARG} \
+        --enable-static \
+        --with-pic \
+        --disable-shared \
+        --disable-dependency-tracking
+
+    V=1 VERBOSE=1 make install -j${MASON_CONCURRENCY}
+}
+
+function mason_cflags {
+    echo -I${MASON_PREFIX}/include
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    echo ${MASON_PREFIX}/${MASON_LIB_FILE}
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"


### PR DESCRIPTION
Perf binaries from latest linux kernel. Also adds dependencies:

 - liblzma.a / xz 5.2.3 (compression)
 - slang 2.3.1 (used for perf console UI)
 - elfutils 0.168

This package works on all recent ubuntu versions >= precise (and RHEL 6), independent of kernel version of the host.

`>= node 4.4.0` is needed for using `--perf_basic_prof_only_functions` to generate `/tmp/perf-<pid>.map` files for perf