### PR TITLE
Ensure broken packages stop hard on `mason_config` error

### DIFF
--- a/mason.sh
+++ b/mason.sh
@@ -565,7 +565,7 @@ function mason_try_binary {
 
 function mason_pkgconfig {
     MASON_PKGCONFIG_FILES=""
-    for pkgconfig_file in ${MASON_PKGCONFIG_FILE}; do
+    for pkgconfig_file in ${MASON_PKGCONFIG_FILE:-}; do
         MASON_PKGCONFIG_FILES="${MASON_PKGCONFIG_FILES} ${MASON_PREFIX}/${pkgconfig_file}"
     done
     echo pkg-config ${MASON_PKGCONFIG_FILES}

--- a/mason.sh
+++ b/mason.sh
@@ -505,7 +505,8 @@ function mason_config {
 function mason_write_config {
     local INI_FILE
     INI_FILE="${MASON_PREFIX}/mason.ini"
-    echo "`mason_config`" > "${INI_FILE}"
+    MASON_INI_DATA=$(set -e;mason_config)
+    echo "${MASON_INI_DATA}" > "${INI_FILE}"
     mason_substep "Wrote configuration file ${INI_FILE}:"
     cat ${INI_FILE}
 }
@@ -574,14 +575,14 @@ function mason_cflags {
     local FLAGS
     FLAGS=$(set -e;`mason_pkgconfig` --static --cflags)
     # Replace double-prefix in case we use a sysroot.
-    echo ${FLAGS//${MASON_SYSROOT}${MASON_PREFIX}/${MASON_PREFIX}}
+    echo ${FLAGS//${MASON_SYSROOT:-}${MASON_PREFIX}/${MASON_PREFIX}}
 }
 
 function mason_ldflags {
     local FLAGS
     FLAGS=$(set -e;`mason_pkgconfig` --static --libs)
     # Replace double-prefix in case we use a sysroot.
-    echo ${FLAGS//${MASON_SYSROOT}${MASON_PREFIX}/${MASON_PREFIX}}
+    echo ${FLAGS//${MASON_SYSROOT:-}${MASON_PREFIX}/${MASON_PREFIX}}
 }
 
 function mason_static_libs {

--- a/mason.sh
+++ b/mason.sh
@@ -572,6 +572,10 @@ function mason_pkgconfig {
 }
 
 function mason_cflags {
+    if [[ ! ${MASON_PKGCONFIG_FILE:-} ]]; then
+        mason_error " The MASON_PKGCONFIG_FILE variable not found in script.sh. Please either provide this variable or override both mason_cflags"
+        exit 1
+    fi
     local FLAGS
     FLAGS=$(set -e;`mason_pkgconfig` --static --cflags)
     # Replace double-prefix in case we use a sysroot.
@@ -579,6 +583,10 @@ function mason_cflags {
 }
 
 function mason_ldflags {
+    if [[ ! ${MASON_PKGCONFIG_FILE:-} ]]; then
+        mason_error " The MASON_PKGCONFIG_FILE variable not found in script.sh. Please either provide this variable or override both mason_cflags"
+        exit 1
+    fi
     local FLAGS
     FLAGS=$(set -e;`mason_pkgconfig` --static --libs)
     # Replace double-prefix in case we use a sysroot.

--- a/mason.sh
+++ b/mason.sh
@@ -573,7 +573,7 @@ function mason_pkgconfig {
 
 function mason_cflags {
     if [[ ! ${MASON_PKGCONFIG_FILE:-} ]]; then
-        mason_error " The MASON_PKGCONFIG_FILE variable not found in script.sh. Please either provide this variable or override both mason_cflags"
+        mason_error " The MASON_PKGCONFIG_FILE variable not found in script.sh. Please either provide this variable or override the mason_cflags function hook"
         exit 1
     fi
     local FLAGS
@@ -584,7 +584,7 @@ function mason_cflags {
 
 function mason_ldflags {
     if [[ ! ${MASON_PKGCONFIG_FILE:-} ]]; then
-        mason_error " The MASON_PKGCONFIG_FILE variable not found in script.sh. Please either provide this variable or override both mason_cflags"
+        mason_error " The MASON_PKGCONFIG_FILE variable not found in script.sh. Please either provide this variable or override the mason_ldflags function hook"
         exit 1
     fi
     local FLAGS

--- a/scripts/binutils/2.27/script.sh
+++ b/scripts/binutils/2.27/script.sh
@@ -31,8 +31,16 @@ function mason_compile {
     make install
 }
 
+function mason_cflags {
+    echo -I${MASON_PREFIX}/include
+}
+
 function mason_ldflags {
     :
+}
+
+function mason_static_libs {
+    echo ${MASON_PREFIX}/${MASON_LIB_FILE}
 }
 
 function mason_clean {

--- a/scripts/expat/2.1.1/script.sh
+++ b/scripts/expat/2.1.1/script.sh
@@ -12,7 +12,7 @@ function mason_load_source {
         https://downloads.sourceforge.net/project/expat/expat/${MASON_VERSION}/expat-${MASON_VERSION}.tar.bz2 \
         b3cebe2010e3679624c44609d08cfd5b1d9a55de
 
-    mason_extract_tar_gz
+    mason_extract_tar_bz2
 
     export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
 }

--- a/scripts/expat/2.1.1/script.sh
+++ b/scripts/expat/2.1.1/script.sh
@@ -9,8 +9,8 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/expat.pc
 
 function mason_load_source {
     mason_download \
-        https://fossies.org/linux/www/expat-${MASON_VERSION}.tar.gz \
-        b939d8395c87b077f3562fca0096c03728b71e1f
+        https://downloads.sourceforge.net/project/expat/expat/${MASON_VERSION}/expat-${MASON_VERSION}.tar.bz2 \
+        b3cebe2010e3679624c44609d08cfd5b1d9a55de
 
     mason_extract_tar_gz
 

--- a/test/all.sh
+++ b/test/all.sh
@@ -13,3 +13,4 @@ $(dirname $0)/cpp11_header_install.sh
 $(dirname $0)/cpp11_install.sh
 $(dirname $0)/cpp11_build.sh
 $(dirname $0)/install_mason_from_tag.sh
+$(dirname $0)/broken_package_must_error.sh

--- a/test/assert.sh
+++ b/test/assert.sh
@@ -8,3 +8,12 @@ function assertEqual() {
         CODE=1
     fi
 }
+
+function assertContains() {
+    if [[ "$1" =~ "$2" ]]; then
+        echo -e "\033[1m\033[32mok\033[0m - Found string $2 in output ($3)"
+    else
+        echo -e "\033[1m\033[31mnot ok\033[0m - Did not find string '$2' in '$1' ($3)"
+        CODE=1
+    fi
+}

--- a/test/broken_package_must_error.sh
+++ b/test/broken_package_must_error.sh
@@ -5,15 +5,31 @@ CODE=0
 source $(dirname $0)/assert.sh
 
 function finish {
-  rm -rf ./scripts/unbound_var
+  rm -rf ./scripts/broken
 }
 
 trap finish EXIT
 
-mkdir -p ./scripts/unbound_var/0.0.0
-cp -r $(dirname $0)/fixtures/broken-packages/unbound_var.sh ./scripts/unbound_var/0.0.0/script.sh
+function place_broken() {
+    rm -rf ./scripts/broken/0.0.0
+    mkdir -p ./scripts/broken/0.0.0
+    cp -r $(dirname $0)/fixtures/broken-packages/${1} ./scripts/broken/0.0.0/script.sh
+}
 
-./mason build unbound_var 0.0.0
+RESULT=0
+RETURN=0
+function test_one() {
+    place_broken ${1}
+    RESULT=$(./mason build broken 0.0.0 2>&1)
+    RETURN=$?
+    rm -rf ./scripts/broken
+}
 
-assertEqual "$?" "1" "errors on unbound variable"
+test_one unbound_var.sh
+assertEqual "${RETURN}" "1" "got expected error code"
+assertContains "${RESULT}" "unbound variable" "got expected output"
 
+test_one undefined_MASON_PKGCONFIG_FILE.sh
+assertEqual "${RETURN}" "1" "got expected error code"
+expected_error="The MASON_PKGCONFIG_FILE variable not found in script.sh. Please either provide this variable or override the mason_cflags function hook"
+assertContains "${RESULT}" "${expected_error}" "got expected output"

--- a/test/broken_package_must_error.sh
+++ b/test/broken_package_must_error.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+CODE=0
+
+source $(dirname $0)/assert.sh
+
+function finish {
+  rm -rf ./scripts/unbound_var
+}
+
+trap finish EXIT
+
+mkdir -p ./scripts/unbound_var/0.0.0
+cp -r $(dirname $0)/fixtures/broken-packages/unbound_var.sh ./scripts/unbound_var/0.0.0/script.sh
+
+./mason build unbound_var 0.0.0
+
+assertEqual "$?" "1" "errors on unbound variable"
+

--- a/test/c_build.sh
+++ b/test/c_build.sh
@@ -3,8 +3,8 @@
 set -e -u
 set -o pipefail
 
-./mason build expat 2.0.1
-./mason build expat 2.0.2
+./mason build expat 2.1.1
+./mason build expat 2.2.0
 ./mason build libzip 1.1.3
 ./mason build zlib 1.2.8
 ./mason build libuv 0.11.29

--- a/test/c_build.sh
+++ b/test/c_build.sh
@@ -3,6 +3,8 @@
 set -e -u
 set -o pipefail
 
-./mason build sqlite 3.8.8.1
-./mason build libuv 0.10.28
+./mason build expat 2.0.1
+./mason build expat 2.0.2
+./mason build libzip 1.1.3
+./mason build zlib 1.2.8
 ./mason build libuv 0.11.29

--- a/test/fixtures/broken-packages/unbound_var.sh
+++ b/test/fixtures/broken-packages/unbound_var.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+MASON_NAME=unbound_var
+MASON_VERSION=0.0.0
+MASON_LIB_FILE=${UNBOUND_VARIABLE}
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    echo ${UNBOUND_VARIABLE}
+}
+
+function mason_compile {
+    :
+}
+
+function mason_ldflags {
+    echo ${UNBOUND_VARIABLE}
+}
+
+mason_run "$@"

--- a/test/fixtures/broken-packages/unbound_var.sh
+++ b/test/fixtures/broken-packages/unbound_var.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-MASON_NAME=unbound_var
+MASON_NAME=broken
 MASON_VERSION=0.0.0
 MASON_LIB_FILE=${UNBOUND_VARIABLE}
 

--- a/test/fixtures/broken-packages/undefined_MASON_PKGCONFIG_FILE.sh
+++ b/test/fixtures/broken-packages/undefined_MASON_PKGCONFIG_FILE.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+MASON_NAME=broken
+MASON_VERSION=0.0.0
+MASON_LIB_FILE=lib/this.a
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
+    mkdir -p ${MASON_BUILD_PATH}
+}
+
+function mason_compile {
+    mkdir -p ${MASON_PREFIX}/lib
+    touch ${MASON_PREFIX}/lib/this.a
+}
+
+mason_run "$@"

--- a/test/unit.sh
+++ b/test/unit.sh
@@ -15,6 +15,4 @@ fi
 VAL=$(./mason --version)
 assertEqual "$?" "0" "able to run ./mason --version"
 
-# TODO - build an intentionally broken package
-
 exit $CODE

--- a/test/unit.sh
+++ b/test/unit.sh
@@ -15,4 +15,6 @@ fi
 VAL=$(./mason --version)
 assertEqual "$?" "0" "able to run ./mason --version"
 
+# TODO - build an intentionally broken package
+
 exit $CODE


### PR DESCRIPTION
This changes `mason` such that if `mason_config` fails, we will stop abruptly with an error and will avoid potentially publishing packages with a busted `mason.ini`.

It also:

 - Fixes #370 to ensure that `mason.ini` can be correctly generated even when `MASON_SYSROOT` is not passed (to avoid a regression from #356)
 - Fixes a few packages to not error due to invalid usage uncovered by #356

