### PR TITLE
libosmium 2.12.0 and osmium-tool 1.6.0 

### DIFF
--- a/scripts/bzip2/1.0.6/script.sh
+++ b/scripts/bzip2/1.0.6/script.sh
@@ -25,7 +25,7 @@ function read_link() {
 }
 
 function mason_compile {
-    make install PREFIX=${MASON_PREFIX} CC="$CC" CFLAGS="$CFLAGS" LDFLAGS="$LDFLAGS"
+    make install PREFIX=${MASON_PREFIX} CC="$CC" CFLAGS="$CFLAGS -O3 -DNDEBUG" LDFLAGS="$LDFLAGS"
     # symlinks are not portable, so now we recurse into /bin directory
     # and fix them to be portable by being relative
     cd ${MASON_PREFIX}/bin

--- a/scripts/bzip2/1.0.6/script.sh
+++ b/scripts/bzip2/1.0.6/script.sh
@@ -25,7 +25,7 @@ function read_link() {
 }
 
 function mason_compile {
-    make install PREFIX=${MASON_PREFIX} CC="$CC" CFLAGS="$CFLAGS -O3 -DNDEBUG" LDFLAGS="$LDFLAGS"
+    make install PREFIX=${MASON_PREFIX} CC="${CC}" CFLAGS="${CFLAGS} -O3 -DNDEBUG" LDFLAGS="${LDFLAGS:-}"
     # symlinks are not portable, so now we recurse into /bin directory
     # and fix them to be portable by being relative
     cd ${MASON_PREFIX}/bin

--- a/scripts/libosmium/2.12.0/.travis.yml
+++ b/scripts/libosmium/2.12.0/.travis.yml
@@ -1,0 +1,11 @@
+language: generic
+
+matrix:
+  include:
+    - os: linux
+      compiler: clang
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/libosmium/2.12.0/script.sh
+++ b/scripts/libosmium/2.12.0/script.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+MASON_NAME=libosmium
+MASON_VERSION=2.12.0
+MASON_HEADER_ONLY=true
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        https://github.com/osmcode/${MASON_NAME}/archive/v${MASON_VERSION}.tar.gz \
+        f5951d2f51b9554ca7ed24253429208da176792d
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
+}
+
+function mason_compile {
+    mkdir -p ${MASON_PREFIX}/include/
+    cp -r include/osmium ${MASON_PREFIX}/include/osmium
+}
+
+function mason_cflags {
+    echo "-I${MASON_PREFIX}/include"
+}
+
+function mason_ldflags {
+    :
+}
+
+mason_run "$@"

--- a/scripts/osmium-tool/1.6.0/.travis.yml
+++ b/scripts/osmium-tool/1.6.0/.travis.yml
@@ -1,0 +1,21 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
+           - pandoc
+
+script:
+- if [[ $(uname -s) == 'Darwin' ]]; then brew install pandoc || true; fi;
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/osmium-tool/1.6.0/script.sh
+++ b/scripts/osmium-tool/1.6.0/script.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+MASON_NAME=osmium-tool
+MASON_VERSION=1.6.0
+MASON_LIB_FILE=bin/osmium
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        https://github.com/osmcode/${MASON_NAME}/archive/v${MASON_VERSION}.tar.gz \
+        c69b0b41c664faebf7cf18587a02d097f1ac4a61
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
+}
+
+function mason_prepare_compile {
+    CCACHE_VERSION=3.3.1
+    ${MASON_DIR}/mason install ccache ${CCACHE_VERSION}
+    MASON_CCACHE=$(${MASON_DIR}/mason prefix ccache ${CCACHE_VERSION})
+    ${MASON_DIR}/mason install cmake 3.7.1
+    ${MASON_DIR}/mason link cmake 3.7.1
+    ${MASON_DIR}/mason install utfcpp 2.3.4
+    ${MASON_DIR}/mason link utfcpp 2.3.4
+    ${MASON_DIR}/mason install protozero 1.5.1
+    ${MASON_DIR}/mason link protozero 1.5.1
+    ${MASON_DIR}/mason install rapidjson 2016-07-20-369de87
+    ${MASON_DIR}/mason link rapidjson 2016-07-20-369de87
+    ${MASON_DIR}/mason install libosmium 2.12.0
+    ${MASON_DIR}/mason link libosmium 2.12.0
+    BOOST_VERSION=1.63.0
+    ${MASON_DIR}/mason install boost ${BOOST_VERSION}
+    ${MASON_DIR}/mason link boost ${BOOST_VERSION}
+    ${MASON_DIR}/mason install boost_libprogram_options ${BOOST_VERSION}
+    ${MASON_DIR}/mason link boost_libprogram_options ${BOOST_VERSION}
+    ${MASON_DIR}/mason install zlib 1.2.8
+    ${MASON_DIR}/mason link zlib 1.2.8
+    ${MASON_DIR}/mason install expat 2.2.0
+    ${MASON_DIR}/mason link expat 2.2.0
+    ${MASON_DIR}/mason install bzip2 1.0.6
+    ${MASON_DIR}/mason link bzip2 1.0.6
+}
+
+function mason_compile {
+    rm -rf build
+    mkdir -p build
+    cd build
+    CMAKE_PREFIX_PATH=${MASON_ROOT}/.link \
+    ${MASON_ROOT}/.link/bin/cmake \
+        -DCMAKE_INSTALL_PREFIX=${MASON_PREFIX} \
+        -DCMAKE_CXX_COMPILER_LAUNCHER="${MASON_CCACHE}/bin/ccache" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBoost_NO_SYSTEM_PATHS=ON \
+        -DBoost_USE_STATIC_LIBS=ON \
+        ..
+    # limit concurrency on travis to avoid heavy jobs being killed
+    if [[ ${TRAVIS_OS_NAME:-} ]]; then
+        make VERBOSE=1 -j4
+    else
+        make VERBOSE=1 -j${MASON_CONCURRENCY}
+    fi
+    make install
+
+}
+
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
+mason_run "$@"


### PR DESCRIPTION
Added latest libosmium and osmium-tools

Before merging:

  - [x] ~~remove use of `mason link` in these packages - refs #377~~ Too much work, staying with using `link`
  - [x] publish binaries

/cc @joto @freenerd @ingalls @mattficke 