### PR TITLE
Mapnik dep updates

### DIFF
--- a/scripts/boost_libregex_icu57/1.63.0/.travis.yml
+++ b/scripts/boost_libregex_icu57/1.63.0/.travis.yml
@@ -1,0 +1,18 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.2
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libregex_icu57/1.63.0/script.sh
+++ b/scripts/boost_libregex_icu57/1.63.0/script.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+# Note: cannot deduce from directory since it is named in a custom way
+#BOOST_LIBRARY=${THIS_DIR#boost_lib}
+BOOST_LIBRARY=regex
+MASON_NAME=boost_lib${BOOST_LIBRARY}_icu57
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+function mason_prepare_compile {
+    ${MASON_DIR}/mason install icu 57.1
+    MASON_ICU=$(${MASON_DIR}/mason prefix icu 57.1)
+}
+
+# custom compile that gets icu working
+function mason_compile {
+    gen_config ${BOOST_TOOLSET} ${BOOST_TOOLSET_CXX}
+    if [[ ! -f ./b2 ]] ; then
+        ./bootstrap.sh
+    fi
+    echo 'int main() { return 0; }' > libs/regex/build/has_icu_test.cpp
+    ./b2 \
+        --with-${BOOST_LIBRARY} \
+        --prefix=${MASON_PREFIX} \
+        -j${MASON_CONCURRENCY} \
+        -sHAVE_ICU=1 -sICU_PATH=${MASON_ICU} --reconfigure --debug-configuration \
+        -d0 -a \
+        --ignore-site-config --user-config=user-config.jam \
+        architecture="${BOOST_ARCH}" \
+        toolset="${BOOST_TOOLSET}" \
+        link=static \
+        variant=release \
+        linkflags="${LDFLAGS:-" "}" \
+        cxxflags="-fvisibility=hidden ${CXXFLAGS:-" "}" \
+        stage
+    mkdir -p $(dirname ${MASON_PREFIX}/${MASON_LIB_FILE})
+    mv stage/${MASON_LIB_FILE} ${MASON_PREFIX}/${MASON_LIB_FILE}
+}
+
+mason_run "$@"

--- a/scripts/gdal/2.1.3/script.sh
+++ b/scripts/gdal/2.1.3/script.sh
@@ -42,8 +42,8 @@ function mason_prepare_compile {
     ${MASON_DIR}/mason install expat 2.2.0
     MASON_EXPAT=$(${MASON_DIR}/mason prefix expat 2.2.0)
     perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_EXPAT}/lib/libexpat.la
-    ${MASON_DIR}/mason install libpq 9.6.1
-    MASON_LIBPQ=$(${MASON_DIR}/mason prefix libpq 9.6.1)
+    ${MASON_DIR}/mason install libpq 9.6.2
+    MASON_LIBPQ=$(${MASON_DIR}/mason prefix libpq 9.6.2)
     # depends on sudo apt-get install zlib1g-dev
     ${MASON_DIR}/mason install zlib system
     MASON_ZLIB=$(${MASON_DIR}/mason prefix zlib system)

--- a/scripts/gdal/2.1.3/script.sh
+++ b/scripts/gdal/2.1.3/script.sh
@@ -50,7 +50,7 @@ function mason_prepare_compile {
     # depends on sudo apt-get install libc6-dev
     #${MASON_DIR}/mason install iconv system
     #MASON_ICONV=$(${MASON_DIR}/mason prefix iconv system)
-    export LIBRARY_PATH=${MASON_LIBPQ}/lib:$LIBRARY_PATH
+    export LIBRARY_PATH=${MASON_LIBPQ}/lib:${LIBRARY_PATH:-}
     ${MASON_DIR}/mason install ccache 3.3.1
     MASON_CCACHE=$(${MASON_DIR}/mason prefix ccache 3.3.1)/bin/ccache
 }
@@ -63,6 +63,7 @@ function mason_compile {
 
     # note CFLAGS overrides defaults so we need to add optimization flags back
     export CFLAGS="${CFLAGS} -O3 -DNDEBUG"
+    export CXXFLAGS="${CXXFLAGS} -O3 -DNDEBUG"
 
     CUSTOM_LIBS="-L${MASON_TIFF}/lib -ltiff -L${MASON_JPEG}/lib -ljpeg -L${MASON_PROJ}/lib -lproj -L${MASON_PNG}/lib -lpng -L${MASON_EXPAT}/lib -lexpat"
     CUSTOM_CFLAGS="${CFLAGS} -I${MASON_LIBPQ}/include -I${MASON_TIFF}/include -I${MASON_JPEG}/include -I${MASON_PROJ}/include -I${MASON_PNG}/include -I${MASON_EXPAT}/include"
@@ -179,7 +180,7 @@ function mason_cflags {
 }
 
 function mason_ldflags {
-    echo $(${MASON_PREFIX}/bin/gdal-config --static --libs)
+    echo $(${MASON_PREFIX}/bin/gdal-config --dep-libs --libs)
 }
 
 function mason_clean {

--- a/scripts/geos/3.6.1/.travis.yml
+++ b/scripts/geos/3.6.1/.travis.yml
@@ -1,0 +1,12 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.2
+    - os: linux
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/geos/3.6.1/patch.diff
+++ b/scripts/geos/3.6.1/patch.diff
@@ -1,0 +1,13 @@
+diff --git a/configure b/configure
+index eee34f8..808c020 100755
+--- a/configure
++++ b/configure
+@@ -17611,7 +17611,7 @@
+ $as_echo "$dummy_cv_ansi" >&6; }
+ 
+ if test yes = "$dummy_cv_ansi"; then
+-    WARNFLAGS="$WARNFLAGS -ansi"
++    WARNFLAGS="$WARNFLAGS"
+ else
+     :
+ fi

--- a/scripts/geos/3.6.1/script.sh
+++ b/scripts/geos/3.6.1/script.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+MASON_NAME=geos
+MASON_VERSION=3.6.1
+MASON_LIB_FILE=lib/libgeos.a
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        http://download.osgeo.org/geos/${MASON_NAME}-${MASON_VERSION}.tar.bz2 \
+        c23fa59e6ab8a4e8df634773fb1ac9794fc5d88a
+
+    mason_extract_tar_bz2
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
+}
+
+function mason_compile {
+    #if [ "$MASON_PLATFORM" == "linux" ]; then
+        mason_step "Loading patch ${MASON_DIR}/scripts/${MASON_NAME}/${MASON_VERSION}/patch.diff"
+        patch -N -p1 < ${MASON_DIR}/scripts/${MASON_NAME}/${MASON_VERSION}/patch.diff
+    #fi
+
+    # note: we put ${STDLIB_CXXFLAGS} into CXX instead of LDFLAGS due to libtool oddity:
+    # http://stackoverflow.com/questions/16248360/autotools-libtool-link-library-with-libstdc-despite-stdlib-libc-option-pass
+    if [[ $(uname -s) == 'Darwin' ]]; then
+        CXX="${CXX} -stdlib=libc++ -std=c++11"
+    fi
+    export CFLAGS="${CFLAGS} -O3 -DNDEBUG"
+    export CXXFLAGS="${CXXFLAGS} -O3 -DNDEBUG"
+    ./configure \
+        --prefix=${MASON_PREFIX} \
+        ${MASON_HOST_ARG} \
+        --disable-shared --enable-static \
+        --disable-dependency-tracking
+    make -j${MASON_CONCURRENCY} install
+}
+
+function mason_cflags {
+    echo $(${MASON_PREFIX}/bin/geos-config --cflags)
+}
+
+function mason_ldflags {
+    echo $(${MASON_PREFIX}/bin/geos-config  --static-clibs)
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"

--- a/scripts/icu/57.1/.travis.yml
+++ b/scripts/icu/57.1/.travis.yml
@@ -1,0 +1,38 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.2
+    - os: osx
+      env: MASON_PLATFORM=ios
+      osx_image: xcode8.2
+    - os: linux
+      env: MASON_PLATFORM_VERSION=cortex_a9
+    - os: linux
+      env: MASON_PLATFORM_VERSION=i686
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
+    - os: osx
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v5
+    - os: osx
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v7
+    - os: osx
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v8
+    - os: osx
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=x86
+    - os: osx
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=x86-64
+    - os: osx
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=mips
+    - os: osx
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=mips-64
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/icu/57.1/.travis.yml
+++ b/scripts/icu/57.1/.travis.yml
@@ -36,3 +36,4 @@ matrix:
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/icu/57.1/script.sh
+++ b/scripts/icu/57.1/script.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+
+# Build ICU common package (libicuuc.a) with data file separate and with support for legacy conversion and break iteration turned off in order to minimize size
+
+MASON_NAME=icu
+MASON_VERSION=57.1
+MASON_LIB_FILE=lib/libicuuc.a
+#MASON_PKGCONFIG_FILE=lib/pkgconfig/icu-uc.pc
+
+. ${MASON_DIR}/mason.sh
+
+MASON_BUILD_DEBUG=0 # Enable to build library with debug symbols
+MASON_CROSS_BUILD=0
+
+function mason_load_source {
+    mason_download \
+        http://download.icu-project.org/files/icu4c/57.1/icu4c-57_1-src.tgz \
+        c40f6ec922e10a50812157eae28969c528982196
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}
+}
+
+function mason_prepare_compile {
+    if [[ ${MASON_PLATFORM} == 'ios' || ${MASON_PLATFORM} == 'android' || ${MASON_PLATFORM_VERSION} != `uname -m` ]]; then
+        mason_substep "Cross-compiling ICU. Starting with host build of ICU to generate tools."
+
+        pushd ${MASON_ROOT}/..
+        env -i HOME="$HOME" PATH="$PATH" USER="$USER" ${MASON_DIR}/mason build icu ${MASON_VERSION}
+        popd
+
+        # TODO: Copies a bunch of files to a kind of orphaned place, do we need to do something to clean up after the build?
+        #  Copying the whole build directory is the easiest way to do a cross build, but we could limit this to a small subset of files (icucross.mk, the tools directory, probably a few others...)
+        #  Also instead of using the regular build steps, we could use a dedicated built target that just builds the tools
+        mason_substep "Moving host ICU build directory to ${MASON_ROOT}/.build/icu-host"
+        rm -rf ${MASON_ROOT}/.build/icu-host
+        cp -R ${MASON_BUILD_PATH}/source ${MASON_ROOT}/.build/icu-host
+    fi
+}
+
+function mason_compile {
+    if [[ ${MASON_PLATFORM} == 'ios' || ${MASON_PLATFORM} == 'android' || ${MASON_PLATFORM_VERSION} != `uname -m` ]]; then
+        MASON_CROSS_BUILD=1
+    fi
+    mason_compile_base
+}
+
+function mason_compile_base {
+    pushd  ${MASON_BUILD_PATH}/source
+
+    # Using uint_least16_t instead of char16_t because Android Clang doesn't recognize char16_t
+    # I'm being shady and telling users of the library to use char16_t, so there's an implicit raw cast
+    ICU_CORE_CPP_FLAGS="-DU_CHARSET_IS_UTF8=1 -DUCHAR_TYPE=uint_least16_t -DU_STATIC_IMPLEMENTATION"
+    ICU_MODULE_CPP_FLAGS="${ICU_CORE_CPP_FLAGS} -DU_USING_ICU_NAMESPACE=0 -DUNISTR_FROM_CHAR_EXPLICIT=explicit -DUCONFIG_NO_LEGACY_CONVERSION=1 -DUCONFIG_NO_FORMATTING -DUCONFIG_NO_TRANSLITERATION -DUCONFIG_NO_REGULAR_EXPRESSIONS"
+    
+    export CPPFLAGS="${CPPFLAGS:-} ${ICU_CORE_CPP_FLAGS} ${ICU_MODULE_CPP_FLAGS} -fvisibility=hidden"
+
+    echo "Configuring with ${MASON_HOST_ARG}"
+
+    if [[ ${MASON_BUILD_DEBUG} == 1 ]]; then
+        export CFLAGS="${CFLAGS} -O0 -DDEBUG -g"
+        export CXXFLAGS="${CXXFLAGS} -O0 -DDEBUG -g"
+        ICU_BUILDTYPE_FLAGS="--enable-debug --disable-release"
+    else
+        # note CFLAGS overrides defaults (-O2) so we need to add optimization flags back
+        export CFLAGS="${CFLAGS} -O3 -DNDEBUG"
+        export CXXFLAGS="${CXXFLAGS} -O3 -DNDEBUG"
+        ICU_BUILDTYPE_FLAGS="--enable-release --disable-debug"
+    fi
+
+    if [[ -f ./data/in/icudt${MASON_VERSION/.*}l.dat ]]; then
+        # This was created via the data customizer https://ssl.icu-project.org/datacustom/
+        # The customizer has been deprecated so hopefully in future icu version we can do this
+        # automatically as part of the build
+        # Method was:
+        # 1. Download customized .dat from the datacustom with just Break Iterators, Collators, and Base data
+        # aws s3 cp --acl public-read icudt57l.dat s3://mason-binaries/prebuilt/icudt57l.dat
+        # should evaluate to https://mason-binaries.s3.amazonaws.com/prebuilt/icudt57l.dat
+        curl -sSfL https://${MASON_BUCKET}.s3.amazonaws.com/prebuilt/icudt${MASON_VERSION/.*}l.dat -o ./data/in/icudt${MASON_VERSION/.*}l.dat
+    else
+        echo "could not find ./data/in/icudt${MASON_VERSION/.*}l.dat"
+        exit 1
+    fi
+    ./configure ${MASON_HOST_ARG} --prefix=${MASON_PREFIX} \
+    ${ICU_BUILDTYPE_FLAGS} \
+    $(cross_build_configure) \
+    --with-data-packaging=archive \
+    --enable-renaming \
+    --enable-strict \
+    --enable-static \
+    --enable-draft \
+    --disable-rpath \
+    --disable-shared \
+    --disable-tests \
+    --disable-extras \
+    --disable-tracing \
+    --disable-layout \
+    --disable-icuio \
+    --disable-samples \
+    --disable-dyload || cat config.log
+
+
+    # Must do make clean after configure to clear out object files left over from previous build on different architecture
+    make clean
+    make VERBOSE=1 -j${MASON_CONCURRENCY}
+    make install
+    popd
+}
+
+function cross_build_configure {
+    # Building tools is disabled in cross-build mode. Using the host-built version of the tools is the whole point of the --with-cross-build flag
+    if [ ${MASON_CROSS_BUILD} == 1 ]; then
+        echo "--with-cross-build=${MASON_ROOT}/.build/icu-host --disable-tools"
+    else
+        echo "--enable-tools"
+    fi
+}
+
+function mason_cflags {
+    echo "-I${MASON_PREFIX}/include ${CPPFLAGS}"
+}
+
+function mason_ldflags {
+    echo ""
+}
+
+mason_run "$@"

--- a/scripts/icu/57.1/script.sh
+++ b/scripts/icu/57.1/script.sh
@@ -49,9 +49,7 @@ function mason_compile {
 function mason_compile_base {
     pushd  ${MASON_BUILD_PATH}/source
 
-    # Using uint_least16_t instead of char16_t because Android Clang doesn't recognize char16_t
-    # I'm being shady and telling users of the library to use char16_t, so there's an implicit raw cast
-    ICU_CORE_CPP_FLAGS="-DU_CHARSET_IS_UTF8=1 -DUCHAR_TYPE=uint_least16_t -DU_STATIC_IMPLEMENTATION"
+    ICU_CORE_CPP_FLAGS="-DU_CHARSET_IS_UTF8=1 -DU_STATIC_IMPLEMENTATION"
     ICU_MODULE_CPP_FLAGS="${ICU_CORE_CPP_FLAGS} -DU_USING_ICU_NAMESPACE=0 -DUNISTR_FROM_CHAR_EXPLICIT=explicit -DUCONFIG_NO_LEGACY_CONVERSION=1 -DUCONFIG_NO_FORMATTING -DUCONFIG_NO_TRANSLITERATION -DUCONFIG_NO_REGULAR_EXPRESSIONS"
     
     export CPPFLAGS="${CPPFLAGS:-} ${ICU_CORE_CPP_FLAGS} ${ICU_MODULE_CPP_FLAGS} -fvisibility=hidden"

--- a/scripts/libgdal/2.1.3/script.sh
+++ b/scripts/libgdal/2.1.3/script.sh
@@ -32,7 +32,7 @@ function mason_cflags {
 }
 
 function mason_ldflags {
-    echo $(${MASON_PREFIX}/bin/gdal-config --static --libs)
+    echo $(${MASON_PREFIX}/bin/gdal-config --dep-libs --libs)
 }
 
 function mason_clean {

--- a/scripts/libpq/9.6.2/.travis.yml
+++ b/scripts/libpq/9.6.2/.travis.yml
@@ -1,0 +1,13 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.2
+      compiler: clang
+    - os: linux
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/libpq/9.6.2/patch.diff
+++ b/scripts/libpq/9.6.2/patch.diff
@@ -1,0 +1,11 @@
+--- src/include/pg_config_manual.h	2013-10-07 20:17:38.000000000 -0700
++++ src/include/pg_config_manual.h	2014-03-08 21:29:48.000000000 -0800
+@@ -144,7 +144,7 @@
+  * here's where to twiddle it.  You can also override this at runtime
+  * with the postmaster's -k switch.
+  */
+-#define DEFAULT_PGSOCKET_DIR  "/tmp"
++#define DEFAULT_PGSOCKET_DIR  "/var/run/postgresql"
+ 
+ /*
+  * The random() function is expected to yield values between 0 and

--- a/scripts/libpq/9.6.2/script.sh
+++ b/scripts/libpq/9.6.2/script.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+MASON_NAME=libpq
+MASON_VERSION=9.6.2
+MASON_LIB_FILE=lib/libpq.a
+MASON_PKGCONFIG_FILE=lib/pkgconfig/libpq.pc
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        http://ftp.postgresql.org/pub/source/v${MASON_VERSION}/postgresql-${MASON_VERSION}.tar.bz2 \
+        183f73527051430934a20bf08646b16373cddcca
+
+    mason_extract_tar_bz2
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/postgresql-${MASON_VERSION}
+}
+
+function mason_compile {
+    if [[ ${MASON_PLATFORM} == 'linux' ]]; then
+        mason_step "Loading patch"
+        patch src/include/pg_config_manual.h ${MASON_DIR}/scripts/${MASON_NAME}/${MASON_VERSION}/patch.diff
+    fi
+
+    # note CFLAGS overrides defaults (-Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -Wno-unused-command-line-argument) so we need to add optimization flags back
+    export CFLAGS="${CFLAGS}  -O3 -DNDEBUG -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -Wno-unused-command-line-argument"
+    ./configure \
+        --prefix=${MASON_PREFIX} \
+        ${MASON_HOST_ARG} \
+        --enable-thread-safety \
+        --enable-largefile \
+        --without-bonjour \
+        --without-openssl \
+        --without-pam \
+        --without-krb5 \
+        --without-gssapi \
+        --without-ossp-uuid \
+        --without-readline \
+        --without-ldap \
+        --without-zlib \
+        --without-libxml \
+        --without-libxslt \
+        --without-selinux \
+        --without-python \
+        --without-perl \
+        --without-tcl \
+        --disable-rpath \
+        --disable-debug \
+        --disable-profiling \
+        --disable-coverage \
+        --disable-dtrace \
+        --disable-depend \
+        --disable-cassert
+
+    make -j${MASON_CONCURRENCY} -C src/bin/pg_config install
+    make -j${MASON_CONCURRENCY} -C src/interfaces/libpq/ install
+    cp src/include/postgres_ext.h ${MASON_PREFIX}/include/
+    cp src/include/pg_config_ext.h ${MASON_PREFIX}/include/
+    rm -f ${MASON_PREFIX}/lib/libpq{*.so*,*.dylib}
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"

--- a/scripts/libxml2/2.9.4/.travis.yml
+++ b/scripts/libxml2/2.9.4/.travis.yml
@@ -1,0 +1,12 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.2
+    - os: linux
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/libxml2/2.9.4/script.sh
+++ b/scripts/libxml2/2.9.4/script.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+MASON_NAME=libxml2
+MASON_VERSION=2.9.3
+MASON_LIB_FILE=lib/libxml2.a
+MASON_PKGCONFIG_FILE=lib/pkgconfig/libxml-2.0.pc
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        ftp://xmlsoft.org/libxml2/libxml2-${MASON_VERSION}.tar.gz \
+        5b5ff1b6cc9b5aa292a3748a45fc22fa9b46dc8e
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
+}
+
+function mason_compile {
+    # note --with-writer for osmium
+    export CFLAGS="${CFLAGS} -O3 -DNDEBUG"
+    ./configure --prefix=${MASON_PREFIX} \
+        --enable-static --disable-shared ${MASON_HOST_ARG} \
+        --with-writer \
+        --with-xptr \
+        --with-xpath \
+        --with-xinclude \
+        --with-threads \
+        --with-tree \
+        --with-catalog \
+        --without-icu \
+        --without-zlib \
+        --without-python \
+        --without-legacy \
+        --without-iconv \
+        --without-debug \
+        --without-docbook \
+        --without-ftp \
+        --without-html \
+        --without-http \
+        --without-sax1 \
+        --without-schemas \
+        --without-schematron \
+        --without-valid \
+        --without-modules \
+        --without-lzma \
+        --without-readline \
+        --without-regexps \
+        --without-c14n
+    make install -j${MASON_CONCURRENCY}
+}
+
+function mason_cflags {
+    echo "-I${MASON_PREFIX}/include/libxml2"
+}
+
+function mason_ldflags {
+    echo "-L${MASON_PREFIX}/lib -lxml2 -lpthread -lm"
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"

--- a/scripts/mapnik/3.0.13/script.sh
+++ b/scripts/mapnik/3.0.13/script.sh
@@ -38,7 +38,7 @@ function install() {
     ${MASON_DIR}/mason link $1 $2
 }
 
-ICU_VERSION="55.1"
+ICU_VERSION="57.1"
 
 function mason_prepare_compile {
     install jpeg_turbo 1.5.1 libjpeg
@@ -57,7 +57,7 @@ function mason_prepare_compile {
     install boost_libsystem 1.63.0
     install boost_libfilesystem 1.63.0
     install boost_libprogram_options 1.63.0
-    install boost_libregex_icu 1.63.0
+    install boost_libregex_icu57 1.63.0
     install freetype 2.7.1 libfreetype
     install harfbuzz 1.4.2-ft libharfbuzz
 }

--- a/scripts/mapnik/3.0.13/script.sh
+++ b/scripts/mapnik/3.0.13/script.sh
@@ -45,7 +45,7 @@ function mason_prepare_compile {
     install libpng 1.6.28 libpng
     install libtiff 4.0.7 libtiff
     install libpq 9.6.2
-    install sqlite 3.16.2 libsqlite3
+    install sqlite 3.17.0 libsqlite3
     install expat 2.2.0 libexpat
     install icu ${ICU_VERSION}
     install proj 4.9.3 libproj

--- a/scripts/mapnik/3.0.13/script.sh
+++ b/scripts/mapnik/3.0.13/script.sh
@@ -44,7 +44,7 @@ function mason_prepare_compile {
     install jpeg_turbo 1.5.1 libjpeg
     install libpng 1.6.28 libpng
     install libtiff 4.0.7 libtiff
-    install libpq 9.6.1
+    install libpq 9.6.2
     install sqlite 3.16.2 libsqlite3
     install expat 2.2.0 libexpat
     install icu ${ICU_VERSION}

--- a/scripts/postgis/2.3.2/.travis.yml
+++ b/scripts/postgis/2.3.2/.travis.yml
@@ -1,0 +1,13 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.2
+      compiler: clang
+    - os: linux
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/postgis/2.3.2/script.sh
+++ b/scripts/postgis/2.3.2/script.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+
+MASON_NAME=postgis
+MASON_VERSION=2.3.2
+MASON_LIB_FILE=bin/shp2pgsql
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        http://download.osgeo.org/postgis/source/postgis-${MASON_VERSION}.tar.gz \
+        1afe92b14c9329f5ce5cc6a5dbe42575449d508e
+
+    mason_extract_tar_gz
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/postgis-${MASON_VERSION}
+}
+
+function mason_prepare_compile {
+    cd $(dirname ${MASON_ROOT})
+    ${MASON_DIR}/mason install postgres 9.6.2
+    MASON_POSTGRES=$(${MASON_DIR}/mason prefix postgres 9.6.2)
+    ${MASON_DIR}/mason install proj 4.9.3
+    MASON_PROJ=$(${MASON_DIR}/mason prefix proj 4.9.3)
+    ${MASON_DIR}/mason install libxml2 2.9.4
+    MASON_XML2=$(${MASON_DIR}/mason prefix libxml2 2.9.4)
+    ${MASON_DIR}/mason install geos 3.6.1
+    MASON_GEOS=$(${MASON_DIR}/mason prefix geos 3.6.1)
+    if [[ $(uname -s) == 'Darwin' ]]; then
+        FIND="\/Users\/travis\/build\/mapbox\/mason"
+    else
+        FIND="\/home\/travis\/build\/mapbox\/mason"
+    fi
+    REPLACE="$(pwd)"
+    REPLACE=${REPLACE////\\/}
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_PROJ}/lib/libproj.la
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_XML2}/lib/libxml2.la
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_XML2}/bin/xml2-config
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_GEOS}/lib/libgeos.la
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_GEOS}/lib/libgeos_c.la
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_GEOS}/bin/geos-config
+
+    ${MASON_DIR}/mason install gdal 2.1.3
+    MASON_GDAL=$(${MASON_DIR}/mason prefix gdal 2.1.3)
+    ln -sf ${MASON_GDAL}/include ${MASON_GDAL}/include/gdal
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_GDAL}/lib/libgdal.la
+    ${MASON_DIR}/mason install libtiff 4.0.7
+    MASON_TIFF=$(${MASON_DIR}/mason prefix libtiff 4.0.7)
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_TIFF}/lib/libtiff.la
+    ${MASON_DIR}/mason install jpeg_turbo 1.5.1
+    MASON_JPEG=$(${MASON_DIR}/mason prefix jpeg_turbo 1.5.1)
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_JPEG}/lib/libjpeg.la
+    ${MASON_DIR}/mason install libpng 1.6.28
+    MASON_PNG=$(${MASON_DIR}/mason prefix libpng 1.6.28)
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_PNG}/lib/libpng.la
+    ${MASON_DIR}/mason install expat 2.2.0
+    MASON_EXPAT=$(${MASON_DIR}/mason prefix expat 2.2.0)
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_EXPAT}/lib/libexpat.la
+    ${MASON_DIR}/mason install zlib system
+    MASON_ZLIB=$(${MASON_DIR}/mason prefix zlib system)
+    #${MASON_DIR}/mason install iconv system
+    #MASON_ICONV=$(${MASON_DIR}/mason prefix iconv system)
+}
+
+function mason_compile {
+    export LDFLAGS="${LDFLAGS} \
+      -L${MASON_GDAL}/lib -lgdal \
+      -L${MASON_GEOS}/lib -lgeos_c -lgeos\
+      -L${MASON_ZLIB}/lib -lz \
+      -L${MASON_TIFF}/lib -ltiff \
+      -L${MASON_JPEG}/lib -ljpeg \
+      -L${MASON_PROJ}/lib -lproj \
+      -L${MASON_PNG}/lib -lpng \
+      -L${MASON_EXPAT}/lib -lexpat \
+      -L${MASON_PROJ}/lib -lproj \
+      -L${MASON_XML2}/lib -lxml2"
+    export CFLAGS="${CFLAGS} -O3 -DNDEBUG -I$(pwd)/liblwgeom/ \
+      -I$(pwd)/raster/ -I$(pwd)/raster/rt_core/ \
+      -I${MASON_TIFF}/include \
+      -I${MASON_JPEG}/include \
+      -I${MASON_PROJ}/include \
+      -I${MASON_PNG}/include \
+      -I${MASON_EXPAT}/include \
+      -I${MASON_GDAL}/include \
+      -I${MASON_POSTGRES}/include/server \
+      -I${MASON_GEOS}/include \
+      -I${MASON_PROJ}/include \
+      -I${MASON_XML2}/include/libxml2"
+
+    if [[ $(uname -s) == 'Darwin' ]]; then
+        export LDFLAGS="${LDFLAGS} -Wl,-lc++ -Wl,${MASON_GDAL}/lib/libgdal.a -Wl,${MASON_POSTGRES}/lib/libpq.a -liconv"
+    else
+        export LDFLAGS="${LDFLAGS} ${MASON_GDAL}/lib/libgdal.a -lgeos_c -lgeos -lxml2 -lproj -lexpat -lpng -ltiff -ljpeg ${MASON_POSTGRES}/lib/libpq.a -pthread -ldl -lz -lstdc++ -lm"
+    fi
+
+
+    MASON_LIBPQ_PATH=${MASON_POSTGRES}/lib/libpq.a
+    MASON_LIBPQ_PATH2=${MASON_LIBPQ_PATH////\\/}
+    perl -i -p -e "s/\-lpq/${MASON_LIBPQ_PATH2} -pthread/g;" configure
+    perl -i -p -e "s/librtcore\.a/librtcore\.a \.\.\/\.\.\/liblwgeom\/\.libs\/liblwgeom\.a/g;" raster/loader/Makefile.in
+
+    if [[ $(uname -s) == 'Linux' ]]; then
+      # help initGEOS configure check
+      perl -i -p -e "s/\-lgeos_c  /\-lgeos_c \-lgeos \-lstdc++ \-lm /g;" configure
+      # help GDALAllRegister configure check
+      CMD="data=open('./configure','r').read();open('./configure','w')"
+      CMD="${CMD}.write(data.replace('\`\$GDAL_CONFIG --libs\`','\"-lgdal -lgeos_c -lgeos -lxml2 -lproj -lexpat -lpng -ltiff -ljpeg ${MASON_POSTGRES}/lib/libpq.a -pthread -ldl -lz -lstdc++ -lm\"'))"
+      python -c "${CMD}"
+    fi
+
+    ./configure \
+        --enable-static --disable-shared \
+        --prefix=$(mktemp -d) \
+        ${MASON_HOST_ARG} \
+        --with-projdir=${MASON_PROJ} \
+        --with-geosconfig=${MASON_GEOS}/bin/geos-config \
+        --with-pgconfig=${MASON_POSTGRES}/bin/pg_config \
+        --with-xml2config=${MASON_XML2}/bin/xml2-config \
+        --with-gdalconfig=${MASON_GDAL}/bin/gdal-config \
+        --without-json \
+        --without-gui \
+        --with-topology \
+        --with-raster \
+        --with-sfcgal=no \
+        --without-sfcgal \
+        --disable-nls || (cat config.log && exit 1)
+    # -j${MASON_CONCURRENCY} disabled due to https://trac.osgeo.org/postgis/ticket/3345
+    make LDFLAGS="$LDFLAGS" CFLAGS="$CFLAGS"
+    make install LDFLAGS="$LDFLAGS" CFLAGS="$CFLAGS"
+    # the meat of postgis installs into postgres directory
+    # so we actually want to package postgres with the postgis stuff
+    # inside, so here we symlink it
+    mkdir -p $(dirname $MASON_PREFIX)
+    ln -sf ${MASON_POSTGRES} ${MASON_PREFIX}
+}
+
+function mason_cflags {
+  :
+}
+
+function mason_ldflags {
+  :
+}
+
+function mason_static_libs {
+  :
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"

--- a/scripts/postgis/2.3.2/test.sh
+++ b/scripts/postgis/2.3.2/test.sh
@@ -40,10 +40,6 @@ function finish {
   cleanup
 }
 
-function pause(){
-   read -p "$*"
-}
-
 trap finish EXIT
 
 cleanup

--- a/scripts/postgis/2.3.2/test.sh
+++ b/scripts/postgis/2.3.2/test.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -ue
+
+: '
+Assumes gdal and postgis have been linked
+
+'
+
+if [[ ${PGDATA:-unset} != "unset" ]] || [[ ${PGHOST:-unset} != "unset" ]] || [[ ${PGTEMP_DIR:-unset} != "unset" ]]; then
+    echo "ERROR: this script deletes \${PGDATA}, \${PGHOST}, and \${PGTEMP_DIR}."
+    echo "So it will not run if you have these set in your environment"
+    exit 1
+fi
+
+# make sure we can init, start, create db, and stop
+export PGDATA=./local-postgres
+# PGHOST must start with / so therefore must be absolute path
+export PGHOST=$(pwd)/local-unix-socket
+export PGTEMP_DIR=$(pwd)/local-tmp
+export PGPORT=1111
+
+# cleanup
+function cleanup() {
+    if [[ -d ${PGDATA} ]]; then rm -r ${PGDATA}; fi
+    if [[ -d ${PGTEMP_DIR} ]]; then rm -r ${PGTEMP_DIR}; fi
+    if [[ -d ${PGHOST} ]]; then rm -r ${PGHOST}; fi
+    rm -f postgres.log
+    rm -f seattle_washington_water_coast*
+    rm -f seattle_washington.water.coast*
+}
+
+function setup() {
+    mkdir ${PGTEMP_DIR}
+    mkdir ${PGHOST}
+}
+
+function finish {
+  ./mason_packages/.link/bin/pg_ctl -w stop
+  cleanup
+}
+
+function pause(){
+   read -p "$*"
+}
+
+trap finish EXIT
+
+cleanup
+setup
+
+./mason_packages/.link/bin/initdb
+export PATH=./mason_packages/.link/bin/:${PATH}
+# must be absolute
+export GDAL_DATA=$(pwd)/mason_packages/.link/share/gdal
+postgres -k $PGHOST > postgres.log &
+sleep 2
+cat postgres.log
+createdb template_postgis
+psql -l
+psql template_postgis -c "CREATE TABLESPACE temp_disk LOCATION '${PGTEMP_DIR}';"
+psql template_postgis -c "SET temp_tablespaces TO 'temp_disk';"
+psql template_postgis -c "CREATE EXTENSION postgis;"
+psql template_postgis -c "SELECT PostGIS_Full_Version();"
+curl -OL "https://s3.amazonaws.com/metro-extracts.mapzen.com/seattle_washington.water.coastline.zip"
+unzip -o seattle_washington.water.coastline.zip
+createdb test-osm -T template_postgis
+shp2pgsql -s 4326 seattle_washington_water_coast.shp coast | psql test-osm
+psql test-osm -c "SELECT count(*) from coast;"

--- a/scripts/postgres/9.6.2/.travis.yml
+++ b/scripts/postgres/9.6.2/.travis.yml
@@ -1,0 +1,13 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.2
+      compiler: clang
+    - os: linux
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/postgres/9.6.2/patch.diff
+++ b/scripts/postgres/9.6.2/patch.diff
@@ -1,0 +1,11 @@
+--- src/include/pg_config_manual.h	2013-10-07 20:17:38.000000000 -0700
++++ src/include/pg_config_manual.h	2014-03-08 21:29:48.000000000 -0800
+@@ -144,7 +144,7 @@
+  * here's where to twiddle it.  You can also override this at runtime
+  * with the postmaster's -k switch.
+  */
+-#define DEFAULT_PGSOCKET_DIR  "/tmp"
++#define DEFAULT_PGSOCKET_DIR  "/var/run/postgresql"
+ 
+ /*
+  * The random() function is expected to yield values between 0 and

--- a/scripts/postgres/9.6.2/script.sh
+++ b/scripts/postgres/9.6.2/script.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+MASON_NAME=postgres
+MASON_VERSION=9.6.2
+MASON_LIB_FILE=bin/psql
+MASON_PKGCONFIG_FILE=lib/pkgconfig/libpq.pc
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        http://ftp.postgresql.org/pub/source/v${MASON_VERSION}/postgresql-${MASON_VERSION}.tar.bz2 \
+        183f73527051430934a20bf08646b16373cddcca
+
+    mason_extract_tar_bz2
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/postgresql-${MASON_VERSION}
+}
+
+function mason_compile {
+    if [[ ${MASON_PLATFORM} == 'linux' ]]; then
+        mason_step "Loading patch"
+        patch src/include/pg_config_manual.h ${MASON_DIR}/scripts/${MASON_NAME}/${MASON_VERSION}/patch.diff
+    fi
+
+    # note CFLAGS overrides defaults (-Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -Wno-unused-command-line-argument) so we need to add optimization flags back
+    export CFLAGS="${CFLAGS}  -O3 -DNDEBUG -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -Wno-unused-command-line-argument"
+    ./configure \
+        --prefix=${MASON_PREFIX} \
+        ${MASON_HOST_ARG} \
+        --enable-thread-safety \
+        --enable-largefile \
+        --with-python \
+        --with-zlib \
+        --without-bonjour \
+        --without-openssl \
+        --without-pam \
+        --without-gssapi \
+        --without-ossp-uuid \
+        --without-readline \
+        --without-ldap \
+        --without-libxml \
+        --without-libxslt \
+        --without-selinux \
+        --without-perl \
+        --without-tcl \
+        --disable-rpath \
+        --disable-debug \
+        --disable-profiling \
+        --disable-coverage \
+        --disable-dtrace \
+        --disable-depend \
+        --disable-cassert
+
+    make -j${MASON_CONCURRENCY} -C src/interfaces/libpq/ install
+    rm -f src/interfaces/libpq{*.so*,*.dylib}
+    rm -f ${MASON_PREFIX}/lib/libpq{*.so*,*.dylib}
+    MASON_LIBPQ_PATH=${MASON_PREFIX}/lib/libpq.a
+    MASON_LIBPQ_PATH2=${MASON_LIBPQ_PATH////\\/}
+    perl -i -p -e "s/\-lpq/${MASON_LIBPQ_PATH2} -pthread/g;" src//Makefile.global.in
+    perl -i -p -e "s/\-lpq/${MASON_LIBPQ_PATH2} -pthread/g;" src//Makefile.global
+    make -j${MASON_CONCURRENCY} install
+    make -j${MASON_CONCURRENCY} -C contrib/hstore install
+    rm -f ${MASON_PREFIX}/lib/lib{*.so*,*.dylib}
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"

--- a/scripts/zlib/system/script.sh
+++ b/scripts/zlib/system/script.sh
@@ -15,16 +15,16 @@ else
     MASON_LDFLAGS="-L${MASON_PREFIX}/lib"
 
     if [[ ${MASON_PLATFORM} = 'osx' || ${MASON_PLATFORM} = 'android' ]]; then
-        ZLIB_INCLUDE_PREFIX="${MASON_SDK_PATH}/usr/include"
-        if [[ -d "${MASON_SDK_PATH}/usr/lib64" ]]; then
-            ZLIB_LIBRARY="${MASON_SDK_PATH}/usr/lib64/libz.${MASON_DYNLIB_SUFFIX}"
+        ZLIB_INCLUDE_PREFIX="${MASON_SDK_PATH:-}/usr/include"
+        if [[ -d "${MASON_SDK_PATH:-}/usr/lib64" ]]; then
+            ZLIB_LIBRARY="${MASON_SDK_PATH:-}/usr/lib64/libz.${MASON_DYNLIB_SUFFIX}"
         else
-            ZLIB_LIBRARY="${MASON_SDK_PATH}/usr/lib/libz.${MASON_DYNLIB_SUFFIX}"
+            ZLIB_LIBRARY="${MASON_SDK_PATH:-}/usr/lib/libz.${MASON_DYNLIB_SUFFIX}"
         fi
         MASON_LDFLAGS="${MASON_LDFLAGS} -lz"
     else
-        ZLIB_INCLUDE_PREFIX="${MASON_SDK_PATH}`pkg-config zlib --variable=includedir`"
-        ZLIB_LIBRARY="${MASON_SDK_PATH}`pkg-config zlib --variable=libdir`/libz.${MASON_DYNLIB_SUFFIX}"
+        ZLIB_INCLUDE_PREFIX="${MASON_SDK_PATH:-}`pkg-config zlib --variable=includedir`"
+        ZLIB_LIBRARY="${MASON_SDK_PATH:-}`pkg-config zlib --variable=libdir`/libz.${MASON_DYNLIB_SUFFIX}"
         MASON_CFLAGS="${MASON_CFLAGS} `pkg-config zlib --cflags-only-other`"
         MASON_LDFLAGS="${MASON_LDFLAGS} `pkg-config zlib --libs-only-other --libs-only-l`"
     fi
@@ -42,7 +42,7 @@ fi
 
 function mason_system_version {
     if [[ ${MASON_PLATFORM} = 'ios' ]]; then
-        FLAGS="-I${MASON_SDK_PATH}/usr/include"
+        FLAGS="-I${MASON_SDK_PATH:-}/usr/include"
     else
         FLAGS=$(mason_cflags)
     fi

--- a/utils/new_boost.sh
+++ b/utils/new_boost.sh
@@ -8,7 +8,7 @@ NEW_VERSION="1.63.0"
 
 manual intervention:
 
-  - change/upgrade icu version used by boost_regex
+  - change/upgrade icu version used by boost_regex_icu* variants
   - new libraries available to build?
 
 '


### PR DESCRIPTION
Adds:

  - icu 57.1 package
      - reduced .dat file size via https://ssl.icu-project.org/datacustom/)
      - fixed optimization flags
  - boost_libregex_icu57 1.63.0 (built against icu 57)
  - geos 3.6.1
  - postgres 9.6.2
  - libpq 9.6.2
  - postgis 2.3.2
  - libxml2 2.9.4

Fixes:
  - optimization flags for gdal
  - ldflags for gdal 2.1.3 package
  - zlib system package unbound var on linux