### PR TITLE
Fixed unbounded vars when not compiling png for cortex_a9 or i686

### DIFF
--- a/scripts/libpng/1.6.25/script.sh
+++ b/scripts/libpng/1.6.25/script.sh
@@ -34,8 +34,8 @@ function mason_prepare_compile {
 }
 
 function mason_compile {
-    export CFLAGS="${CFLAGS:-} ${MASON_ZLIB_CFLAGS} -O3"
-    export LDFLAGS="${CFLAGS:-} ${MASON_ZLIB_LDFLAGS}"
+    export CFLAGS="${CFLAGS:-} ${MASON_ZLIB_CFLAGS:-} -O3"
+    export LDFLAGS="${CFLAGS:-} ${MASON_ZLIB_LDFLAGS:-}"
 
     if [ ${MASON_PLATFORM_VERSION} == "cortex_a9" ] || [ ${MASON_PLATFORM_VERSION} == "i686" ]; then
         # XXX: This hack is because libpng does not respect CFLAGS

--- a/scripts/libpng/1.6.28/script.sh
+++ b/scripts/libpng/1.6.28/script.sh
@@ -34,8 +34,8 @@ function mason_prepare_compile {
 }
 
 function mason_compile {
-    export CFLAGS="${CFLAGS:-} ${MASON_ZLIB_CFLAGS} -O3 -DNDEBUG"
-    export LDFLAGS="${CFLAGS:-} ${MASON_ZLIB_LDFLAGS}"
+    export CFLAGS="${CFLAGS:-} ${MASON_ZLIB_CFLAGS:-} -O3 -DNDEBUG"
+    export LDFLAGS="${CFLAGS:-} ${MASON_ZLIB_LDFLAGS:-}"
 
     if [ ${MASON_PLATFORM_VERSION} == "cortex_a9" ] || [ ${MASON_PLATFORM_VERSION} == "i686" ]; then
         # XXX: This hack is because libpng does not respect CFLAGS


### PR DESCRIPTION
If you aren't compiling png for cortex_a9 or i686,  the MASON_ZLIB_* variables are never set, and cause an error. This fixes that case.