### PR TITLE
Removes unbound var in or-tools script

### DIFF
--- a/scripts/or-tools/5.1/script.sh
+++ b/scripts/or-tools/5.1/script.sh
@@ -88,6 +88,5 @@ function mason_static_libs {
 }
 
 
-echo $DIR
 
 mason_run "$@"


### PR DESCRIPTION
Downstream builds are failing because of bash unbound var errors.

Not sure when exactly this changed, all I could find in the changelog is

```
Fixed
    Unbound variables in sparsehash, bzip2, and harfbuzz packages
```

Can we automatically check all packages?

cc @springmeyer 