### PR TITLE
[WIP] Add script to run each package to detect unbound vars

### DIFF
--- a/scripts/apitrace/6a30de1/script.sh
+++ b/scripts/apitrace/6a30de1/script.sh
@@ -2,6 +2,7 @@
 
 MASON_NAME=apitrace
 MASON_VERSION=6a30de1
+MASON_LIB_FILE=bin/apitrace
 
 . ${MASON_DIR}/mason.sh
 

--- a/scripts/minjur/a2c9dc871369432c7978718834dac487c0591bd6/script.sh
+++ b/scripts/minjur/a2c9dc871369432c7978718834dac487c0591bd6/script.sh
@@ -2,6 +2,7 @@
 
 MASON_NAME=minjur
 MASON_VERSION=a2c9dc871369432c7978718834dac487c0591bd6
+MASON_LIB_FILE=bin/minjur
 
 . ${MASON_DIR}/mason.sh
 

--- a/scripts/minjur/feac70472f46c3145b6bdf7a02fdc37777828318/script.sh
+++ b/scripts/minjur/feac70472f46c3145b6bdf7a02fdc37777828318/script.sh
@@ -2,6 +2,7 @@
 
 MASON_NAME=minjur
 MASON_VERSION=feac70472f46c3145b6bdf7a02fdc37777828318
+MASON_LIB_FILE=bin/minjur
 
 . ${MASON_DIR}/mason.sh
 

--- a/utils/rebuild-all.py
+++ b/utils/rebuild-all.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+import os
+import glob
+from subprocess import Popen, PIPE
+
+for item in glob.glob('./scripts/*/*/script.sh'):
+   parts = item.split('/')
+   package = parts[2]
+   version = parts[3]
+   stdin, stderr = Popen('./mason cflags %s %s' % (package, version), shell=True, stdout=PIPE, stderr=PIPE).communicate()
+   if stderr and 'unbound' in stderr:
+      print package, version, stderr
+
+


### PR DESCRIPTION
We have some remaining packages with unbound variables that are broken after https://github.com/mapbox/mason/pull/356.

This PR is an attempt to detect and fix them.

Currently seeing:

```
apitrace 6a30de1 /Users/dane/projects/mason/mason.sh: line 297: MASON_LIB_FILE: unbound variable
mesa 11.2.2 /Users/dane/projects/mason/mason.sh: line 297: MASON_LIB_FILE: unbound variable
mesa 13.0.3 /Users/dane/projects/mason/mason.sh: line 297: MASON_LIB_FILE: unbound variable
mesa 13.0.4 /Users/dane/projects/mason/mason.sh: line 297: MASON_LIB_FILE: unbound variable
minjur a2c9dc871369432c7978718834dac487c0591bd6 /Users/dane/projects/mason/mason.sh: line 297: MASON_LIB_FILE: unbound variable
minjur feac70472f46c3145b6bdf7a02fdc37777828318 /Users/dane/projects/mason/mason.sh: line 297: MASON_LIB_FILE: unbound variable
or-tools 5.1 /Users/dane/projects/mason/scripts/or-tools/5.1/script.sh: line 91: DIR: unbound variable
```