### PR TITLE
[WIP] building select C++ packages against libstdc++-4.8-dev

### DIFF
--- a/scripts/boost/1.64.0/.travis.yml
+++ b/scripts/boost/1.64.0/.travis.yml
@@ -1,0 +1,10 @@
+language: generic
+
+matrix:
+  include:
+    - os: linux
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost/1.64.0/base.sh
+++ b/scripts/boost/1.64.0/base.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# NOTE: use the ./utils/new_boost.sh script to create new versions
+
+export MASON_VERSION=1.64.0
+export BOOST_VERSION=${MASON_VERSION//./_}
+export BOOST_TOOLSET="clang"
+export BOOST_TOOLSET_CXX="clang++"
+export BOOST_ARCH="x86"
+export BOOST_SHASUM=6e4dad39f14937af73ace20d2279e2468aad14d8
+# special override to ensure each library shares the cached download
+export MASON_DOWNLOAD_SLUG="boost-${MASON_VERSION}"

--- a/scripts/boost/1.64.0/common.sh
+++ b/scripts/boost/1.64.0/common.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+function mason_load_source {
+    mason_download \
+        http://downloads.sourceforge.net/project/boost/boost/${MASON_VERSION}/boost_${BOOST_VERSION}.tar.bz2 \
+        ${BOOST_SHASUM}
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/boost_${BOOST_VERSION}
+
+    mason_extract_tar_bz2
+}
+
+function gen_config() {
+  echo "using $1 : : $(which $2)" > user-config.jam
+  if [[ "${AR:-false}" != false ]] || [[ "${RANLIB:-false}" != false ]]; then
+      echo ' : ' >> user-config.jam
+      if [[ "${AR:-false}" != false ]]; then
+          echo "<archiver>${AR} " >> user-config.jam
+      fi
+      if [[ "${RANLIB:-false}" != false ]]; then
+          echo "<ranlib>${RANLIB} " >> user-config.jam
+      fi
+  fi
+  echo ' ;' >> user-config.jam
+}
+
+function mason_compile {
+    gen_config ${BOOST_TOOLSET} ${BOOST_TOOLSET_CXX}
+    if [[ ! -f ./b2 ]] ; then
+        ./bootstrap.sh
+    fi
+    ./b2 \
+        --with-${BOOST_LIBRARY} \
+        --prefix=${MASON_PREFIX} \
+        -j${MASON_CONCURRENCY} \
+        -d0 \
+        --ignore-site-config --user-config=user-config.jam \
+        architecture="${BOOST_ARCH}" \
+        toolset="${BOOST_TOOLSET}" \
+        link=static \
+        variant=release \
+        linkflags="${LDFLAGS:-" "}" \
+        cxxflags="${CXXFLAGS:-" "}" \
+        stage
+    mkdir -p $(dirname ${MASON_PREFIX}/${MASON_LIB_FILE})
+    mv stage/${MASON_LIB_FILE} ${MASON_PREFIX}/${MASON_LIB_FILE}
+}
+
+function mason_prefix {
+    echo "${MASON_PREFIX}"
+}
+
+function mason_cflags {
+    echo "-I${MASON_PREFIX}/include"
+}
+
+function mason_ldflags {
+    local LOCAL_LDFLAGS
+    LOCAL_LDFLAGS="-L${MASON_PREFIX}/lib"
+    if [[ ${BOOST_LIBRARY:-false} != false ]]; then
+        LOCAL_LDFLAGS="${LOCAL_LDFLAGS} -lboost_${BOOST_LIBRARY}"
+    fi
+    echo $LOCAL_LDFLAGS
+}

--- a/scripts/boost/1.64.0/script.sh
+++ b/scripts/boost/1.64.0/script.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# inherit from boost base (used for all boost library packages)
+source ${HERE}/base.sh
+
+# this package is the one that is header-only
+MASON_NAME=boost
+MASON_HEADER_ONLY=true
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${HERE}/common.sh
+
+# override default unpacking to just unpack headers
+function mason_load_source {
+    mason_download \
+        http://downloads.sourceforge.net/project/boost/boost/${MASON_VERSION}/boost_${BOOST_VERSION}.tar.bz2 \
+        ${BOOST_SHASUM}
+
+    mason_extract_tar_bz2 boost_${BOOST_VERSION}/boost
+
+    MASON_BUILD_PATH=${MASON_ROOT}/.build/boost_${BOOST_VERSION}
+}
+
+# override default "compile" target for just the header install
+function mason_compile {
+    mkdir -p ${MASON_PREFIX}/include
+    cp -r ${MASON_ROOT}/.build/boost_${BOOST_VERSION}/boost ${MASON_PREFIX}/include
+    
+    # work around NDK bug https://code.google.com/p/android/issues/detail?id=79483
+    
+    patch ${MASON_PREFIX}/include/boost/core/demangle.hpp <<< "19a20,21
+> #if !defined(__ANDROID__)
+> 
+25a28,29
+> #endif
+> 
+"
+
+    # work around https://github.com/Project-OSRM/node-osrm/issues/191
+    patch ${MASON_PREFIX}/include/boost/interprocess/detail/os_file_functions.hpp <<< "471c471
+<    return ::open(name, (int)mode);
+---
+>    return ::open(name, (int)mode,S_IRUSR|S_IWUSR);
+"
+
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
+mason_run "$@"

--- a/scripts/boost_libatomic/1.64.0/.travis.yml
+++ b/scripts/boost_libatomic/1.64.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-4.8-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libatomic/1.64.0/script.sh
+++ b/scripts/boost_libatomic/1.64.0/script.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+BOOST_LIBRARY=${THIS_DIR#boost_lib}
+MASON_NAME=boost_lib${BOOST_LIBRARY}
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+mason_run "$@"

--- a/scripts/boost_libchrono/1.64.0/.travis.yml
+++ b/scripts/boost_libchrono/1.64.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-4.8-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libchrono/1.64.0/script.sh
+++ b/scripts/boost_libchrono/1.64.0/script.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+BOOST_LIBRARY=${THIS_DIR#boost_lib}
+MASON_NAME=boost_lib${BOOST_LIBRARY}
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+mason_run "$@"

--- a/scripts/boost_libdate_time/1.64.0/.travis.yml
+++ b/scripts/boost_libdate_time/1.64.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-4.8-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libdate_time/1.64.0/script.sh
+++ b/scripts/boost_libdate_time/1.64.0/script.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+BOOST_LIBRARY=${THIS_DIR#boost_lib}
+MASON_NAME=boost_lib${BOOST_LIBRARY}
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+mason_run "$@"

--- a/scripts/boost_libfilesystem/1.64.0/.travis.yml
+++ b/scripts/boost_libfilesystem/1.64.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-4.8-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libfilesystem/1.64.0/script.sh
+++ b/scripts/boost_libfilesystem/1.64.0/script.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+BOOST_LIBRARY=${THIS_DIR#boost_lib}
+MASON_NAME=boost_lib${BOOST_LIBRARY}
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+mason_run "$@"

--- a/scripts/boost_libiostreams/1.64.0/.travis.yml
+++ b/scripts/boost_libiostreams/1.64.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-4.8-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libiostreams/1.64.0/script.sh
+++ b/scripts/boost_libiostreams/1.64.0/script.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+BOOST_LIBRARY=${THIS_DIR#boost_lib}
+MASON_NAME=boost_lib${BOOST_LIBRARY}
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+mason_run "$@"

--- a/scripts/boost_libprogram_options/1.64.0/.travis.yml
+++ b/scripts/boost_libprogram_options/1.64.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-4.8-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libprogram_options/1.64.0/script.sh
+++ b/scripts/boost_libprogram_options/1.64.0/script.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+BOOST_LIBRARY=${THIS_DIR#boost_lib}
+MASON_NAME=boost_lib${BOOST_LIBRARY}
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+mason_run "$@"

--- a/scripts/boost_libpython/1.64.0/.travis.yml
+++ b/scripts/boost_libpython/1.64.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-4.8-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libpython/1.64.0/patch.diff
+++ b/scripts/boost_libpython/1.64.0/patch.diff
@@ -1,0 +1,12 @@
+--- libs/python/src/converter/builtin_converters.cpp	2012-12-07 11:51:06.000000000 -0800
++++ libs/python/src/converter/builtin_converters.cpp	2014-04-01 17:24:37.000000000 -0700
+@@ -32,7 +32,9 @@
+ 
+ void shared_ptr_deleter::operator()(void const*)
+ {
++    PyGILState_STATE gil = PyGILState_Ensure();
+     owner.reset();
++    PyGILState_Release(gil);
+ }
+ 
+ namespace

--- a/scripts/boost_libpython/1.64.0/script.sh
+++ b/scripts/boost_libpython/1.64.0/script.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+BOOST_LIBRARY=${THIS_DIR#boost_lib}
+MASON_NAME=boost_lib${BOOST_LIBRARY}
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+function write_python_config() {
+# usage:
+# write_python_config <user-config.jam> <version> <base> <variant>
+PYTHON_VERSION=$2
+# note: apple pythons need '/System'
+PYTHON_BASE=$3
+# note: python 3 uses 'm'
+PYTHON_VARIANT=$4
+if [[ ${UNAME} == 'Darwin' ]]; then
+    echo "
+      using python
+           : ${PYTHON_VERSION} # version
+           : ${PYTHON_BASE}/Library/Frameworks/Python.framework/Versions/${PYTHON_VERSION}/bin/python${PYTHON_VERSION}${PYTHON_VARIANT} # cmd-or-prefix
+           : ${PYTHON_BASE}/Library/Frameworks/Python.framework/Versions/${PYTHON_VERSION}/include/python${PYTHON_VERSION}${PYTHON_VARIANT} # includes
+           : ${PYTHON_BASE}/Library/Frameworks/Python.framework/Versions/${PYTHON_VERSION}/lib/python${PYTHON_VERSION}/config${PYTHON_VARIANT} # a lib actually symlink
+           : <toolset>${BOOST_TOOLSET} # condition
+           ;
+    " >> $1
+else
+  if [[ ${UNAME} == 'FreeBSD' ]]; then
+      echo "
+        using python
+             : ${PYTHON_VERSION} # version
+             : /usr/local/bin/python${PYTHON_VERSION}${PYTHON_VARIANT} # cmd-or-prefix
+             : /usr/local/include/python${PYTHON_VERSION} # includes
+             : /usr/local/lib/python${PYTHON_VERSION}/config${PYTHON_VARIANT}
+             : <toolset>${BOOST_TOOLSET} # condition
+             ;
+      " >> $1
+  else
+      echo "
+        using python
+             : ${PYTHON_VERSION} # version
+             : /usr/bin/python${PYTHON_VERSION}${PYTHON_VARIANT} # cmd-or-prefix
+             : /usr/include/python${PYTHON_VERSION} # includes
+             : /usr/lib/python${PYTHON_VERSION}/config${PYTHON_VARIANT}
+             : <toolset>${BOOST_TOOLSET} # condition
+             ;
+      " >> $1
+  fi
+fi
+}
+
+function mason_compile {
+    # patch to workaround crashes in python.input
+    # https://github.com/mapnik/mapnik/issues/1968
+    mason_step "Loading patch ${MASON_DIR}/scripts/${MASON_NAME}/${MASON_VERSION}/patch.diff"
+    patch -N -p0 < ${MASON_DIR}/scripts/${MASON_NAME}/${MASON_VERSION}/patch.diff
+    write_python_config user-config.jam "2.7" "/System" ""
+    gen_config ${BOOST_TOOLSET} ${BOOST_TOOLSET_CXX}
+    if [[ ! -f ./b2 ]] ; then
+        ./bootstrap.sh
+    fi
+    ./b2 \
+        --with-${BOOST_LIBRARY} \
+        --prefix=${MASON_PREFIX} \
+        -j${MASON_CONCURRENCY} \
+        -d0 \
+        --ignore-site-config --user-config=user-config.jam \
+        architecture="${BOOST_ARCH}" \
+        toolset="${BOOST_TOOLSET}" \
+        link=static \
+        variant=release \
+        linkflags="${LDFLAGS:-" "}" \
+        cxxflags="${CXXFLAGS:-" "}" \
+        stage
+    mkdir -p $(dirname ${MASON_PREFIX}/${MASON_LIB_FILE})
+    mv stage/${MASON_LIB_FILE} ${MASON_PREFIX}/${MASON_LIB_FILE}
+}
+
+mason_run "$@"

--- a/scripts/boost_libpython/1.64.0/script.sh
+++ b/scripts/boost_libpython/1.64.0/script.sh
@@ -31,7 +31,7 @@ PYTHON_VERSION=$2
 PYTHON_BASE=$3
 # note: python 3 uses 'm'
 PYTHON_VARIANT=$4
-if [[ ${UNAME} == 'Darwin' ]]; then
+if [[ $(uname -s) == 'Darwin' ]]; then
     echo "
       using python
            : ${PYTHON_VERSION} # version
@@ -42,7 +42,7 @@ if [[ ${UNAME} == 'Darwin' ]]; then
            ;
     " >> $1
 else
-  if [[ ${UNAME} == 'FreeBSD' ]]; then
+  if [[ $(uname -s) == 'FreeBSD' ]]; then
       echo "
         using python
              : ${PYTHON_VERSION} # version

--- a/scripts/boost_libregex/1.64.0/.travis.yml
+++ b/scripts/boost_libregex/1.64.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-4.8-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libregex/1.64.0/script.sh
+++ b/scripts/boost_libregex/1.64.0/script.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+BOOST_LIBRARY=${THIS_DIR#boost_lib}
+MASON_NAME=boost_lib${BOOST_LIBRARY}
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+mason_run "$@"

--- a/scripts/boost_libregex_icu/1.64.0/.travis.yml
+++ b/scripts/boost_libregex_icu/1.64.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-4.8-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libregex_icu/1.64.0/script.sh
+++ b/scripts/boost_libregex_icu/1.64.0/script.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+# Note: cannot deduce from directory since it is named in a custom way
+#BOOST_LIBRARY=${THIS_DIR#boost_lib}
+BOOST_LIBRARY=regex
+MASON_NAME=boost_lib${BOOST_LIBRARY}_icu
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+function mason_prepare_compile {
+    ${MASON_DIR}/mason install icu 55.1
+    MASON_ICU=$(${MASON_DIR}/mason prefix icu 55.1)
+}
+
+# custom compile that gets icu working
+function mason_compile {
+    gen_config ${BOOST_TOOLSET} ${BOOST_TOOLSET_CXX}
+    if [[ ! -f ./b2 ]] ; then
+        ./bootstrap.sh
+    fi
+    echo 'int main() { return 0; }' > libs/regex/build/has_icu_test.cpp
+    ./b2 \
+        --with-${BOOST_LIBRARY} \
+        --prefix=${MASON_PREFIX} \
+        -j${MASON_CONCURRENCY} \
+        -sHAVE_ICU=1 -sICU_PATH=${MASON_ICU} --reconfigure --debug-configuration \
+        -d0 \
+        --ignore-site-config --user-config=user-config.jam \
+        architecture="${BOOST_ARCH}" \
+        toolset="${BOOST_TOOLSET}" \
+        link=static \
+        variant=release \
+        linkflags="${LDFLAGS:-" "}" \
+        cxxflags="${CXXFLAGS:-" "}" \
+        stage
+    mkdir -p $(dirname ${MASON_PREFIX}/${MASON_LIB_FILE})
+    mv stage/${MASON_LIB_FILE} ${MASON_PREFIX}/${MASON_LIB_FILE}
+}
+
+mason_run "$@"

--- a/scripts/boost_libregex_icu57/1.64.0/.travis.yml
+++ b/scripts/boost_libregex_icu57/1.64.0/.travis.yml
@@ -1,0 +1,18 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.2
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-4.8-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libregex_icu57/1.64.0/script.sh
+++ b/scripts/boost_libregex_icu57/1.64.0/script.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+# Note: cannot deduce from directory since it is named in a custom way
+#BOOST_LIBRARY=${THIS_DIR#boost_lib}
+BOOST_LIBRARY=regex
+MASON_NAME=boost_lib${BOOST_LIBRARY}_icu57
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+function mason_prepare_compile {
+    ${MASON_DIR}/mason install icu 57.1
+    MASON_ICU=$(${MASON_DIR}/mason prefix icu 57.1)
+}
+
+# custom compile that gets icu working
+function mason_compile {
+    gen_config ${BOOST_TOOLSET} ${BOOST_TOOLSET_CXX}
+    if [[ ! -f ./b2 ]] ; then
+        ./bootstrap.sh
+    fi
+    echo 'int main() { return 0; }' > libs/regex/build/has_icu_test.cpp
+    ./b2 \
+        --with-${BOOST_LIBRARY} \
+        --prefix=${MASON_PREFIX} \
+        -j${MASON_CONCURRENCY} \
+        -sHAVE_ICU=1 -sICU_PATH=${MASON_ICU} --reconfigure --debug-configuration \
+        -d0 -a \
+        --ignore-site-config --user-config=user-config.jam \
+        architecture="${BOOST_ARCH}" \
+        toolset="${BOOST_TOOLSET}" \
+        link=static \
+        variant=release \
+        linkflags="${LDFLAGS:-" "}" \
+        cxxflags="-fvisibility=hidden ${CXXFLAGS:-" "}" \
+        stage
+    mkdir -p $(dirname ${MASON_PREFIX}/${MASON_LIB_FILE})
+    mv stage/${MASON_LIB_FILE} ${MASON_PREFIX}/${MASON_LIB_FILE}
+}
+
+mason_run "$@"

--- a/scripts/boost_libsystem/1.64.0/.travis.yml
+++ b/scripts/boost_libsystem/1.64.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-4.8-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libsystem/1.64.0/script.sh
+++ b/scripts/boost_libsystem/1.64.0/script.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+BOOST_LIBRARY=${THIS_DIR#boost_lib}
+MASON_NAME=boost_lib${BOOST_LIBRARY}
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+mason_run "$@"

--- a/scripts/boost_libtest/1.64.0/.travis.yml
+++ b/scripts/boost_libtest/1.64.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-4.8-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libtest/1.64.0/script.sh
+++ b/scripts/boost_libtest/1.64.0/script.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+BOOST_LIBRARY=${THIS_DIR#boost_lib}
+MASON_NAME=boost_lib${BOOST_LIBRARY}
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+mason_run "$@"

--- a/scripts/boost_libthread/1.64.0/.travis.yml
+++ b/scripts/boost_libthread/1.64.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-4.8-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libthread/1.64.0/script.sh
+++ b/scripts/boost_libthread/1.64.0/script.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+BOOST_LIBRARY=${THIS_DIR#boost_lib}
+MASON_NAME=boost_lib${BOOST_LIBRARY}
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+mason_run "$@"

--- a/scripts/icu/57.1/.travis.yml
+++ b/scripts/icu/57.1/.travis.yml
@@ -18,7 +18,7 @@ matrix:
           sources:
            - ubuntu-toolchain-r-test
           packages:
-           - libstdc++-5-dev
+           - libstdc++-4.9-dev
     - os: osx
       env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v5
     - os: osx

--- a/scripts/mapnik/3.0.13-3/.travis.yml
+++ b/scripts/mapnik/3.0.13-3/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.2
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-4.9-dev
+           - xutils-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/mapnik/3.0.13-3/.travis.yml
+++ b/scripts/mapnik/3.0.13-3/.travis.yml
@@ -11,7 +11,7 @@ matrix:
           sources:
            - ubuntu-toolchain-r-test
           packages:
-           - libstdc++-4.9-dev
+           - libstdc++-4.8-dev
            - xutils-dev
 
 script:

--- a/scripts/mapnik/3.0.13-3/patch.diff
+++ b/scripts/mapnik/3.0.13-3/patch.diff
@@ -1,0 +1,51 @@
+diff --git a/utils/pgsql2sqlite/build.py b/utils/pgsql2sqlite/build.py
+index 45d9003..3dac900 100644
+--- a/utils/pgsql2sqlite/build.py
++++ b/utils/pgsql2sqlite/build.py
+@@ -39,6 +39,20 @@ source = Split(
+ program_env['CXXFLAGS'] = copy(env['LIBMAPNIK_CXXFLAGS'])
+ program_env['LINKFLAGS'] = copy(env['LIBMAPNIK_LINKFLAGS'])
+ program_env.Append(CPPDEFINES = env['LIBMAPNIK_DEFINES'])
++program_env['LIBS'] = []
++
++if env['RUNTIME_LINK'] == 'static':
++    # pkg-config is more reliable than pg_config across platforms
++    cmd = 'pkg-config libpq --libs --static'
++    try:
++        program_env.ParseConfig(cmd)
++    except OSError, e:
++        program_env.Append(LIBS='pq')
++else:
++    program_env.Append(LIBS='pq')
++
++# Link Library to Dependencies
++libraries = copy(program_env['LIBS'])
+ 
+ if env['HAS_CAIRO']:
+     program_env.PrependUnique(CPPPATH=env['CAIRO_CPPPATHS'])
+@@ -46,9 +60,8 @@ if env['HAS_CAIRO']:
+ 
+ program_env.PrependUnique(CPPPATH=['#plugins/input/postgis'])
+ 
+-libraries = []
+ boost_program_options = 'boost_program_options%s' % env['BOOST_APPEND']
+-libraries.extend([boost_program_options,'sqlite3','pq',env['MAPNIK_NAME'],'icuuc'])
++libraries.extend([boost_program_options,'sqlite3',env['MAPNIK_NAME'],'icuuc'])
+ 
+ if env.get('BOOST_LIB_VERSION_FROM_HEADER'):
+     boost_version_from_header = int(env['BOOST_LIB_VERSION_FROM_HEADER'].split('_')[1])
+@@ -59,14 +72,6 @@ if env.get('BOOST_LIB_VERSION_FROM_HEADER'):
+ if env['SQLITE_LINKFLAGS']:
+     program_env.Append(LINKFLAGS=env['SQLITE_LINKFLAGS'])
+ 
+-if env['RUNTIME_LINK'] == 'static':
+-    if env['PLATFORM'] == 'Darwin':
+-        libraries.extend(['ldap', 'pam', 'ssl', 'crypto', 'krb5'])
+-    else:
+-        # TODO - parse back into libraries variable
+-        program_env.ParseConfig('pg_config --libs')
+-        libraries.append('dl')
+-
+ pgsql2sqlite = program_env.Program('pgsql2sqlite', source, LIBS=libraries)
+ Depends(pgsql2sqlite, env.subst('../../src/%s' % env['MAPNIK_LIB_NAME']))
+ 

--- a/scripts/mapnik/3.0.13-3/patch.diff
+++ b/scripts/mapnik/3.0.13-3/patch.diff
@@ -1,8 +1,26 @@
+diff --git a/src/expression_grammar.cpp b/src/expression_grammar.cpp
+index 09234a0..23aa90b 100644
+--- a/src/expression_grammar.cpp
++++ b/src/expression_grammar.cpp
+@@ -26,3 +26,12 @@
+ #include <string>
+ 
+ template struct mapnik::expression_grammar<std::string::const_iterator>;
++
++// Prevent linking to libstdc++'s __throw_out_of_range_fmt
++// https://github.com/springmeyer/glibcxx-symbol-versioning/blob/master/test_out_of_range.cpp
++void  __throw_out_of_range_fmt(const char*, ...) __attribute__((__noreturn__));
++void  __throw_out_of_range_fmt(const char* err, ...)
++{
++    // Safe and over-simplified version. Ignore the format and print it as-is.
++    __throw_out_of_range(err);
++}
+\ No newline at end of file
 diff --git a/utils/pgsql2sqlite/build.py b/utils/pgsql2sqlite/build.py
-index 45d9003..55c7f3f 100644
+index 45d9003..9d909df 100644
 --- a/utils/pgsql2sqlite/build.py
 +++ b/utils/pgsql2sqlite/build.py
-@@ -39,6 +39,23 @@ source = Split(
+@@ -39,6 +39,20 @@ source = Split(
  program_env['CXXFLAGS'] = copy(env['LIBMAPNIK_CXXFLAGS'])
  program_env['LINKFLAGS'] = copy(env['LIBMAPNIK_LINKFLAGS'])
  program_env.Append(CPPDEFINES = env['LIBMAPNIK_DEFINES'])
@@ -20,13 +38,10 @@ index 45d9003..55c7f3f 100644
 +
 +# Link Library to Dependencies
 +libraries = copy(program_env['LIBS'])
-+
-+if env['RUNTIME_LINK'] == 'static' and env['PLATFORM'] == 'Linux':
-+    libraries.append('dl')
  
  if env['HAS_CAIRO']:
      program_env.PrependUnique(CPPPATH=env['CAIRO_CPPPATHS'])
-@@ -46,9 +63,8 @@ if env['HAS_CAIRO']:
+@@ -46,9 +60,8 @@ if env['HAS_CAIRO']:
  
  program_env.PrependUnique(CPPPATH=['#plugins/input/postgis'])
  
@@ -37,7 +52,7 @@ index 45d9003..55c7f3f 100644
  
  if env.get('BOOST_LIB_VERSION_FROM_HEADER'):
      boost_version_from_header = int(env['BOOST_LIB_VERSION_FROM_HEADER'].split('_')[1])
-@@ -59,14 +75,6 @@ if env.get('BOOST_LIB_VERSION_FROM_HEADER'):
+@@ -59,13 +72,8 @@ if env.get('BOOST_LIB_VERSION_FROM_HEADER'):
  if env['SQLITE_LINKFLAGS']:
      program_env.Append(LINKFLAGS=env['SQLITE_LINKFLAGS'])
  
@@ -48,7 +63,8 @@ index 45d9003..55c7f3f 100644
 -        # TODO - parse back into libraries variable
 -        program_env.ParseConfig('pg_config --libs')
 -        libraries.append('dl')
--
++if env['RUNTIME_LINK'] == 'static' and env['PLATFORM'] == 'Linux':
++    libraries.append('dl')
+ 
  pgsql2sqlite = program_env.Program('pgsql2sqlite', source, LIBS=libraries)
  Depends(pgsql2sqlite, env.subst('../../src/%s' % env['MAPNIK_LIB_NAME']))
- 

--- a/scripts/mapnik/3.0.13-3/patch.diff
+++ b/scripts/mapnik/3.0.13-3/patch.diff
@@ -1,8 +1,8 @@
 diff --git a/utils/pgsql2sqlite/build.py b/utils/pgsql2sqlite/build.py
-index 45d9003..3dac900 100644
+index 45d9003..55c7f3f 100644
 --- a/utils/pgsql2sqlite/build.py
 +++ b/utils/pgsql2sqlite/build.py
-@@ -39,6 +39,20 @@ source = Split(
+@@ -39,6 +39,23 @@ source = Split(
  program_env['CXXFLAGS'] = copy(env['LIBMAPNIK_CXXFLAGS'])
  program_env['LINKFLAGS'] = copy(env['LIBMAPNIK_LINKFLAGS'])
  program_env.Append(CPPDEFINES = env['LIBMAPNIK_DEFINES'])
@@ -20,10 +20,13 @@ index 45d9003..3dac900 100644
 +
 +# Link Library to Dependencies
 +libraries = copy(program_env['LIBS'])
++
++if env['RUNTIME_LINK'] == 'static' and env['PLATFORM'] == 'Linux':
++    libraries.append('dl')
  
  if env['HAS_CAIRO']:
      program_env.PrependUnique(CPPPATH=env['CAIRO_CPPPATHS'])
-@@ -46,9 +60,8 @@ if env['HAS_CAIRO']:
+@@ -46,9 +63,8 @@ if env['HAS_CAIRO']:
  
  program_env.PrependUnique(CPPPATH=['#plugins/input/postgis'])
  
@@ -34,7 +37,7 @@ index 45d9003..3dac900 100644
  
  if env.get('BOOST_LIB_VERSION_FROM_HEADER'):
      boost_version_from_header = int(env['BOOST_LIB_VERSION_FROM_HEADER'].split('_')[1])
-@@ -59,14 +72,6 @@ if env.get('BOOST_LIB_VERSION_FROM_HEADER'):
+@@ -59,14 +75,6 @@ if env.get('BOOST_LIB_VERSION_FROM_HEADER'):
  if env['SQLITE_LINKFLAGS']:
      program_env.Append(LINKFLAGS=env['SQLITE_LINKFLAGS'])
  

--- a/scripts/mapnik/3.0.13-3/patch.diff
+++ b/scripts/mapnik/3.0.13-3/patch.diff
@@ -1,9 +1,12 @@
 diff --git a/src/expression_grammar.cpp b/src/expression_grammar.cpp
-index 09234a0..23aa90b 100644
+index 09234a0..309205b 100644
 --- a/src/expression_grammar.cpp
 +++ b/src/expression_grammar.cpp
-@@ -26,3 +26,12 @@
+@@ -24,5 +24,15 @@
+ // once by src/expression.cpp and once by mapnik/transform_expression_grammar_impl.hpp
+ #include <mapnik/expression_grammar_impl.hpp>
  #include <string>
++#include <stdexcept>
  
  template struct mapnik::expression_grammar<std::string::const_iterator>;
 +
@@ -13,7 +16,7 @@ index 09234a0..23aa90b 100644
 +void  __throw_out_of_range_fmt(const char* err, ...)
 +{
 +    // Safe and over-simplified version. Ignore the format and print it as-is.
-+    __throw_out_of_range(err);
++    std::__throw_out_of_range(err);
 +}
 \ No newline at end of file
 diff --git a/utils/pgsql2sqlite/build.py b/utils/pgsql2sqlite/build.py

--- a/scripts/mapnik/3.0.13-3/script.sh
+++ b/scripts/mapnik/3.0.13-3/script.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+
+MASON_NAME=mapnik
+MASON_VERSION=3.0.13-1
+MASON_LIB_FILE=lib/libmapnik.${MASON_DYNLIB_SUFFIX}
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        https://github.com/mapnik/mapnik/releases/download/v3.0.13/mapnik-v3.0.13.tar.bz2 \
+        1e892e849cc7b81e08f3ec8c39a49e07efb4a018
+
+    mason_extract_tar_bz2
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/mapnik-v3.0.13
+
+    #mkdir -p $(dirname ${MASON_BUILD_PATH})
+    #if [[ ! -d ${MASON_BUILD_PATH} ]]; then
+    #    git clone -b 3.0.x-mason-upgrades --single-branch http://github.com/mapnik/mapnik ${MASON_BUILD_PATH}
+    #    (cd ${MASON_BUILD_PATH} && git submodule update --init deps/mapbox/variant/)
+    #fi
+}
+
+function install() {
+    ${MASON_DIR}/mason install $1 $2
+    MASON_PLATFORM_ID=$(${MASON_DIR}/mason env MASON_PLATFORM_ID)
+    if [[ ! -d ${MASON_ROOT}/${MASON_PLATFORM_ID}/${1}/${2} ]]; then
+        if [[ ${3:-false} != false ]]; then
+            LA_FILE=$(${MASON_DIR}/mason prefix $1 $2)/lib/$3.la
+            if [[ -f ${LA_FILE} ]]; then
+                perl -i -p -e 's:\Q$ENV{HOME}/build/mapbox/mason\E:$ENV{PWD}:g' ${LA_FILE}
+            else
+                echo "$LA_FILE not found"
+            fi
+        fi
+    fi
+    ${MASON_DIR}/mason link $1 $2
+}
+
+ICU_VERSION="57.1"
+
+function mason_prepare_compile {
+    install jpeg_turbo 1.5.1 libjpeg
+    install libpng 1.6.28 libpng
+    install libtiff 4.0.7 libtiff
+    install libpq 9.6.2
+    install sqlite 3.17.0 libsqlite3
+    install expat 2.2.0 libexpat
+    install icu ${ICU_VERSION}
+    install proj 4.9.3 libproj
+    install pixman 0.34.0 libpixman-1
+    install cairo 1.14.8 libcairo
+    install webp 0.6.0 libwebp
+    install libgdal 2.1.3 libgdal
+    install boost 1.64.0
+    install boost_libsystem 1.64.0
+    install boost_libfilesystem 1.64.0
+    install boost_libprogram_options 1.64.0
+    install boost_libregex_icu57 1.64.0
+    install freetype 2.7.1 libfreetype
+    install harfbuzz 1.4.2-ft libharfbuzz
+}
+
+function mason_compile {
+    patch -N -p1 < ${MASON_DIR}/scripts/${MASON_NAME}/${MASON_VERSION}/patch.diff
+    export PATH="${MASON_ROOT}/.link/bin:${PATH}"
+    MASON_LINKED_REL="${MASON_ROOT}/.link"
+    MASON_LINKED_ABS="${MASON_ROOT}/.link"
+    if [[ $(uname -s) == 'Linux' ]]; then
+        echo "CUSTOM_LDFLAGS = '${LDFLAGS} -Wl,-z,origin -Wl,-rpath=\\\$\$ORIGIN/../lib/ -Wl,-rpath=\\\$\$ORIGIN/../../'" > config.py
+        echo "CUSTOM_CXXFLAGS = '${CXXFLAGS} -D_GLIBCXX_USE_CXX11_ABI=0'" >> config.py
+    else
+        echo "CUSTOM_LDFLAGS = '${LDFLAGS}'" > config.py
+        echo "CUSTOM_CXXFLAGS = '${CXXFLAGS}'" >> config.py
+    fi
+
+    ./configure \
+        CXX="${CXX}" \
+        CC="${CC}" \
+        PREFIX="${MASON_PREFIX}" \
+        RUNTIME_LINK="static" \
+        INPUT_PLUGINS="all" \
+        ENABLE_SONAME=False \
+        PKG_CONFIG_PATH="${MASON_LINKED_REL}/lib/pkgconfig" \
+        PATH_REMOVE="/usr:/usr/local" \
+        BOOST_INCLUDES="${MASON_LINKED_REL}/include" \
+        BOOST_LIBS="${MASON_LINKED_REL}/lib" \
+        ICU_INCLUDES="${MASON_LINKED_REL}/include" \
+        ICU_LIBS="${MASON_LINKED_REL}/lib" \
+        HB_INCLUDES="${MASON_LINKED_REL}/include" \
+        HB_LIBS="${MASON_LINKED_REL}/lib" \
+        PNG_INCLUDES="${MASON_LINKED_REL}/include/libpng16" \
+        PNG_LIBS="${MASON_LINKED_REL}/lib" \
+        JPEG_INCLUDES="${MASON_LINKED_REL}/include" \
+        JPEG_LIBS="${MASON_LINKED_REL}/lib" \
+        TIFF_INCLUDES="${MASON_LINKED_REL}/include" \
+        TIFF_LIBS="${MASON_LINKED_REL}/lib" \
+        WEBP_INCLUDES="${MASON_LINKED_REL}/include" \
+        WEBP_LIBS="${MASON_LINKED_REL}/lib" \
+        PROJ_INCLUDES="${MASON_LINKED_REL}/include" \
+        PROJ_LIBS="${MASON_LINKED_REL}/lib" \
+        PG_INCLUDES="${MASON_LINKED_REL}/include" \
+        PG_LIBS="${MASON_LINKED_REL}/lib" \
+        FREETYPE_INCLUDES="${MASON_LINKED_REL}/include/freetype2" \
+        FREETYPE_LIBS="${MASON_LINKED_REL}/lib" \
+        SVG_RENDERER=True \
+        CAIRO_INCLUDES="${MASON_LINKED_REL}/include" \
+        CAIRO_LIBS="${MASON_LINKED_REL}/lib" \
+        SQLITE_INCLUDES="${MASON_LINKED_REL}/include" \
+        SQLITE_LIBS="${MASON_LINKED_REL}/lib" \
+        GDAL_CONFIG="${MASON_LINKED_REL}/bin/gdal-config" \
+        PG_CONFIG="${MASON_LINKED_REL}/bin/pg_config" \
+        BENCHMARK=False \
+        CPP_TESTS=False \
+        PGSQL2SQLITE=True \
+        SAMPLE_INPUT_PLUGINS=False \
+        DEMO=False \
+        XMLPARSER="ptree" \
+        NO_ATEXIT=True \
+        SVG2PNG=True || cat ${MASON_BUILD_PATH}"/config.log"
+
+    cat config.py
+
+    # limit concurrency on travis to avoid heavy jobs being killed
+    if [[ ${TRAVIS_OS_NAME:-} ]]; then
+        JOBS=4 make
+    else
+        JOBS=${MASON_CONCURRENCY} make
+    fi
+
+    make install
+    if [[ $(uname -s) == 'Darwin' ]]; then
+        install_name_tool -id @loader_path/lib/libmapnik.dylib ${MASON_PREFIX}"/lib/libmapnik.dylib";
+        PLUGINDIRS=${MASON_PREFIX}"/lib/mapnik/input/*.input";
+        for f in $PLUGINDIRS; do
+            echo $f;
+            echo `basename $f`;
+            install_name_tool -id plugins/input/`basename $f` $f;
+            install_name_tool -change ${MASON_PREFIX}"/lib/libmapnik.dylib" @loader_path/../../../lib/libmapnik.dylib $f;
+        done;
+        # command line tools
+        install_name_tool -change ${MASON_PREFIX}"/lib/libmapnik.dylib" @loader_path/../lib/libmapnik.dylib ${MASON_PREFIX}"/bin/mapnik-index"
+        install_name_tool -change ${MASON_PREFIX}"/lib/libmapnik.dylib" @loader_path/../lib/libmapnik.dylib ${MASON_PREFIX}"/bin/mapnik-render"
+        install_name_tool -change ${MASON_PREFIX}"/lib/libmapnik.dylib" @loader_path/../lib/libmapnik.dylib ${MASON_PREFIX}"/bin/shapeindex"
+    fi
+    # fix mapnik-config entries for deps
+    HERE=$(pwd)
+    python -c "data=open('$MASON_PREFIX/bin/mapnik-config','r').read();open('$MASON_PREFIX/bin/mapnik-config','w').write(data.replace('$HERE','.').replace('${MASON_ROOT}','./mason_packages'))"
+    cat $MASON_PREFIX/bin/mapnik-config
+}
+
+function mason_cflags {
+    ${MASON_PREFIX}/bin/mapnik-config --cflags
+}
+
+function mason_ldflags {
+    ${MASON_PREFIX}/bin/mapnik-config --ldflags
+}
+
+function mason_static_libs {
+    ${MASON_PREFIX}/bin/mapnik-config --dep-libs
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"

--- a/scripts/mapnik/3.0.13-3/script.sh
+++ b/scripts/mapnik/3.0.13-3/script.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 MASON_NAME=mapnik
-MASON_VERSION=3.0.13-1
+MASON_VERSION=3.0.13-3
 MASON_LIB_FILE=lib/libmapnik.${MASON_DYNLIB_SUFFIX}
 
 . ${MASON_DIR}/mason.sh

--- a/scripts/wagyu/0.4.2-gcc/.travis.yml
+++ b/scripts/wagyu/0.4.2-gcc/.travis.yml
@@ -1,0 +1,10 @@
+language: generic
+
+matrix:
+  include:
+    - os: linux
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/wagyu/0.4.2-gcc/script.sh
+++ b/scripts/wagyu/0.4.2-gcc/script.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+MASON_NAME=wagyu
+MASON_VERSION=0.4.2-gcc
+MASON_HEADER_ONLY=true
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        https://github.com/mapbox/wagyu/archive/22c2fe6.tar.gz \
+        1c61ffe6651dfd8f91587f8b35d8622bfbc4b634
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/wagyu-22c2fe6a09b8b662eb993a804b2a3ea37c1d09f0
+}
+
+function mason_compile {
+    mkdir -p ${MASON_PREFIX}/include/
+    cp -r include/mapbox ${MASON_PREFIX}/include/mapbox
+}
+
+function mason_cflags {
+    echo "-I${MASON_PREFIX}/include"
+}
+
+function mason_ldflags {
+    :
+}
+
+
+mason_run "$@"

--- a/utils/new_boost.sh
+++ b/utils/new_boost.sh
@@ -1,8 +1,8 @@
 set -eu
 set -o pipefail
 
-LAST_VERSION="1.62.0"
-NEW_VERSION="1.63.0"
+LAST_VERSION="1.63.0"
+NEW_VERSION="1.64.0"
 
 : ' 
 
@@ -46,9 +46,12 @@ for lib in $(find scripts/ -maxdepth 1 -type dir -name 'boost_lib*' -print); do
     fi
 done
 
+# run this after pushing branch:
+# TODO: in the past this would get rate limited at 10 but @kkaefer convinced travis to increase our limit to 50
+: '
 ./mason trigger boost ${NEW_VERSION}
-# TODO: this is rate limited so it needs to be run over many hours to avoid travis blocking
 for lib in $(find scripts/ -maxdepth 1 -type dir -name 'boost_lib*' -print); do
-    echo ./mason trigger $(basename $lib) ${NEW_VERSION}
+    #echo ./mason trigger $(basename $lib) ${NEW_VERSION}
 done
+'
 


### PR DESCRIPTION
This is a WIP branch testing the building of a few C++ packages against libstdc++-4.8-dev to prototype the approach outlined at https://github.com/mapbox/mason/issues/267.

The context is that boost built against libstdc++-5-dev will link these new symbols not available in older libstdc++ (and prevents binaries from working on older linux systems unless libstdc++ is upgraded)

```
U std::logic_error::logic_error(char const*)@@GLIBCXX_3.4.21
U std::runtime_error::runtime_error(char const*)@@GLIBCXX_3.4.21
U std::runtime_error::runtime_error(char const*)@@GLIBCXX_3.4.21
U std::invalid_argument::invalid_argument(char const*)@@GLIBCXX_3.4.21
U std::__throw_out_of_range_fmt(char const*, ...)@@GLIBCXX_3.4.20
```

If Boost is built against libstdc++-4.9-dev then the only remaining symbol is:

```
U std::__throw_out_of_range_fmt(char const*, ...)@@GLIBCXX_3.4.20
```

And building against libstdc++-4.8-dev leads to no symbols newer than `GLIBCXX_3.4.19` being needed. Because `GLIBCXX_3.4.19` is generally available in most recent debian and centos systems this is a good minimum target.

See also https://github.com/springmeyer/glibcxx-symbol-versioning for other symbols that some libraries might pull in if linked with libstdc++-5-dev.

