### PR TITLE
osmium-tool export branch

### DIFF
--- a/scripts/libosmium/cd8e2ff/.travis.yml
+++ b/scripts/libosmium/cd8e2ff/.travis.yml
@@ -1,0 +1,11 @@
+language: generic
+
+matrix:
+  include:
+    - os: linux
+      compiler: clang
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/libosmium/cd8e2ff/script.sh
+++ b/scripts/libosmium/cd8e2ff/script.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+MASON_NAME=libosmium
+MASON_VERSION=cd8e2ff
+MASON_HEADER_ONLY=true
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        https://github.com/osmcode/${MASON_NAME}/archive/${MASON_VERSION}.tar.gz \
+        1b5750e1bff99779f1ce320d001e3f793d1fcdf1
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-cd8e2ff7ca72f66cd7cadcc1c36f4f0685d0fbb2
+}
+
+function mason_compile {
+    mkdir -p ${MASON_PREFIX}/include/
+    cp -r include/osmium ${MASON_PREFIX}/include/osmium
+}
+
+function mason_cflags {
+    echo "-I${MASON_PREFIX}/include"
+}
+
+function mason_ldflags {
+    :
+}
+
+mason_run "$@"

--- a/scripts/libosmium/d86a054/.travis.yml
+++ b/scripts/libosmium/d86a054/.travis.yml
@@ -1,0 +1,11 @@
+language: generic
+
+matrix:
+  include:
+    - os: linux
+      compiler: clang
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/libosmium/d86a054/script.sh
+++ b/scripts/libosmium/d86a054/script.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+MASON_NAME=libosmium
+MASON_VERSION=d86a054
+MASON_HEADER_ONLY=true
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        https://github.com/osmcode/${MASON_NAME}/archive/${MASON_VERSION}.tar.gz \
+        1b5750e1bff99779f1ce320d001e3f793d1fcdf1
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-d86a05479c60b054f6d9b3b0cb4a71180077d422
+}
+
+function mason_compile {
+    mkdir -p ${MASON_PREFIX}/include/
+    cp -r include/osmium ${MASON_PREFIX}/include/osmium
+}
+
+function mason_cflags {
+    echo "-I${MASON_PREFIX}/include"
+}
+
+function mason_ldflags {
+    :
+}
+
+mason_run "$@"

--- a/scripts/libosmium/d86a054/script.sh
+++ b/scripts/libosmium/d86a054/script.sh
@@ -9,7 +9,7 @@ MASON_HEADER_ONLY=true
 function mason_load_source {
     mason_download \
         https://github.com/osmcode/${MASON_NAME}/archive/${MASON_VERSION}.tar.gz \
-        1b5750e1bff99779f1ce320d001e3f793d1fcdf1
+        5ad392a2ece2e84f61726bfdf85fbeaf84f808e2
 
     mason_extract_tar_gz
 

--- a/scripts/osmium-tool/2e292f3/.travis.yml
+++ b/scripts/osmium-tool/2e292f3/.travis.yml
@@ -1,0 +1,21 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
+           - pandoc
+
+script:
+- if [[ $(uname -s) == 'Darwin' ]]; then brew install pandoc || true; fi;
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/osmium-tool/2e292f3/script.sh
+++ b/scripts/osmium-tool/2e292f3/script.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+MASON_NAME=osmium-tool
+MASON_VERSION=2e292f3
+MASON_LIB_FILE=bin/osmium
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        https://github.com/osmcode/${MASON_NAME}/archive/2e292f3.tar.gz \
+        154ba22c3e2ec71feb479a1f100b592ca92f03d6
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-2e292f3f1114613138f6a52f1c24f94c84f23431
+}
+
+function mason_prepare_compile {
+    CCACHE_VERSION=3.3.1
+    ${MASON_DIR}/mason install ccache ${CCACHE_VERSION}
+    MASON_CCACHE=$(${MASON_DIR}/mason prefix ccache ${CCACHE_VERSION})
+    ${MASON_DIR}/mason install cmake 3.7.1
+    ${MASON_DIR}/mason link cmake 3.7.1
+    ${MASON_DIR}/mason install utfcpp 2.3.4
+    ${MASON_DIR}/mason link utfcpp 2.3.4
+    ${MASON_DIR}/mason install protozero 1.5.1
+    ${MASON_DIR}/mason link protozero 1.5.1
+    ${MASON_DIR}/mason install rapidjson 2016-07-20-369de87
+    ${MASON_DIR}/mason link rapidjson 2016-07-20-369de87
+    ${MASON_DIR}/mason install libosmium cd8e2ff
+    ${MASON_DIR}/mason link libosmium cd8e2ff
+    BOOST_VERSION=1.63.0
+    ${MASON_DIR}/mason install boost ${BOOST_VERSION}
+    ${MASON_DIR}/mason link boost ${BOOST_VERSION}
+    ${MASON_DIR}/mason install boost_libprogram_options ${BOOST_VERSION}
+    ${MASON_DIR}/mason link boost_libprogram_options ${BOOST_VERSION}
+    ${MASON_DIR}/mason install zlib 1.2.8
+    ${MASON_DIR}/mason link zlib 1.2.8
+    ${MASON_DIR}/mason install expat 2.2.0
+    ${MASON_DIR}/mason link expat 2.2.0
+    ${MASON_DIR}/mason install bzip2 1.0.6
+    ${MASON_DIR}/mason link bzip2 1.0.6
+}
+
+function mason_compile {
+    rm -rf build
+    mkdir -p build
+    cd build
+    CMAKE_PREFIX_PATH=${MASON_ROOT}/.link \
+    ${MASON_ROOT}/.link/bin/cmake \
+        -DCMAKE_INSTALL_PREFIX=${MASON_PREFIX} \
+        -DCMAKE_CXX_COMPILER_LAUNCHER="${MASON_CCACHE}/bin/ccache" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBoost_NO_SYSTEM_PATHS=ON \
+        -DBoost_USE_STATIC_LIBS=ON \
+        ..
+    # limit concurrency on travis to avoid heavy jobs being killed
+    if [[ ${TRAVIS_OS_NAME:-} ]]; then
+        make VERBOSE=1 -j4
+    else
+        make VERBOSE=1 -j${MASON_CONCURRENCY}
+    fi
+    make install
+
+}
+
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
+mason_run "$@"

--- a/scripts/osmium-tool/5196c3c/.travis.yml
+++ b/scripts/osmium-tool/5196c3c/.travis.yml
@@ -1,0 +1,21 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
+           - pandoc
+
+script:
+- if [[ $(uname -s) == 'Darwin' ]]; then brew install pandoc || true; fi;
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/osmium-tool/5196c3c/script.sh
+++ b/scripts/osmium-tool/5196c3c/script.sh
@@ -8,8 +8,8 @@ MASON_LIB_FILE=bin/osmium
 
 function mason_load_source {
     mason_download \
-        https://github.com/osmcode/${MASON_NAME}/archive/2e292f3.tar.gz \
-        154ba22c3e2ec71feb479a1f100b592ca92f03d6
+        https://github.com/osmcode/${MASON_NAME}/archive/${MASON_VERSION}.tar.gz \
+        73a961943b401b9e153c253cd27df1f32ca0a034
 
     mason_extract_tar_gz
 

--- a/scripts/osmium-tool/5196c3c/script.sh
+++ b/scripts/osmium-tool/5196c3c/script.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+MASON_NAME=osmium-tool
+MASON_VERSION=5196c3c
+MASON_LIB_FILE=bin/osmium
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        https://github.com/osmcode/${MASON_NAME}/archive/2e292f3.tar.gz \
+        154ba22c3e2ec71feb479a1f100b592ca92f03d6
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-5196c3cb2ce3b8006aed9227f3483dd7ea1ebd8f
+}
+
+function mason_prepare_compile {
+    CCACHE_VERSION=3.3.1
+    ${MASON_DIR}/mason install ccache ${CCACHE_VERSION}
+    MASON_CCACHE=$(${MASON_DIR}/mason prefix ccache ${CCACHE_VERSION})
+    ${MASON_DIR}/mason install cmake 3.7.1
+    ${MASON_DIR}/mason link cmake 3.7.1
+    ${MASON_DIR}/mason install utfcpp 2.3.4
+    ${MASON_DIR}/mason link utfcpp 2.3.4
+    ${MASON_DIR}/mason install protozero 1.5.1
+    ${MASON_DIR}/mason link protozero 1.5.1
+    ${MASON_DIR}/mason install rapidjson 2016-07-20-369de87
+    ${MASON_DIR}/mason link rapidjson 2016-07-20-369de87
+    ${MASON_DIR}/mason install libosmium d86a054
+    ${MASON_DIR}/mason link libosmium d86a054
+    BOOST_VERSION=1.63.0
+    ${MASON_DIR}/mason install boost ${BOOST_VERSION}
+    ${MASON_DIR}/mason link boost ${BOOST_VERSION}
+    ${MASON_DIR}/mason install boost_libprogram_options ${BOOST_VERSION}
+    ${MASON_DIR}/mason link boost_libprogram_options ${BOOST_VERSION}
+    ${MASON_DIR}/mason install zlib 1.2.8
+    ${MASON_DIR}/mason link zlib 1.2.8
+    ${MASON_DIR}/mason install expat 2.2.0
+    ${MASON_DIR}/mason link expat 2.2.0
+    ${MASON_DIR}/mason install bzip2 1.0.6
+    ${MASON_DIR}/mason link bzip2 1.0.6
+}
+
+function mason_compile {
+    rm -rf build
+    mkdir -p build
+    cd build
+    CMAKE_PREFIX_PATH=${MASON_ROOT}/.link \
+    ${MASON_ROOT}/.link/bin/cmake \
+        -DCMAKE_INSTALL_PREFIX=${MASON_PREFIX} \
+        -DCMAKE_CXX_COMPILER_LAUNCHER="${MASON_CCACHE}/bin/ccache" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBoost_NO_SYSTEM_PATHS=ON \
+        -DBoost_USE_STATIC_LIBS=ON \
+        ..
+    # limit concurrency on travis to avoid heavy jobs being killed
+    if [[ ${TRAVIS_OS_NAME:-} ]]; then
+        make VERBOSE=1 -j4
+    else
+        make VERBOSE=1 -j${MASON_CONCURRENCY}
+    fi
+    make install
+
+}
+
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
+mason_run "$@"


### PR DESCRIPTION
Adds a dev package for osmium-tool at https://github.com/osmcode/osmium-tool/commit/2e292f3f1114613138f6a52f1c24f94c84f23431 and libosmium at https://github.com/osmcode/libosmium/commit/d86a05479c60b054f6d9b3b0cb4a71180077d422

To enable testing of upcoming osmium-tool features per 
https://github.com/mapbox/minjur/issues/28#issuecomment-293600977

To test do:

```bash
mkdir ./mason
curl -sSfL https://github.com/mapbox/mason/archive/3696359.tar.gz | tar --gunzip --extract --strip-components=1 --exclude="*md" --exclude="test*" --directory=./mason
./mason/mason install osmium-tool 5196c3c
```