### PR TITLE
Added tidy-related share files to clang-tidy

### DIFF
--- a/scripts/clang-tidy/base/common.sh
+++ b/scripts/clang-tidy/base/common.sh
@@ -7,6 +7,7 @@ function mason_build {
     # copy bin
     mkdir -p "${MASON_PREFIX}/bin"
     cp "${CLANG_PREFIX}/bin/${MASON_NAME}" "${MASON_PREFIX}/bin/"
+    cp "${CLANG_PREFIX}/bin/clang-apply-replacements" "${MASON_PREFIX}/bin/"
 
     # copy include/c++
     mkdir -p "${MASON_PREFIX}/include"
@@ -20,6 +21,13 @@ function mason_build {
     mkdir -p "${MASON_PREFIX}/lib"
     mkdir -p "${MASON_PREFIX}/lib/clang"
     cp -r ${CLANG_PREFIX}/lib/clang/${MASON_VERSION} "${MASON_PREFIX}/lib/clang/"
+
+    # copy tidy-related share files
+    mkdir -p "${MASON_PREFIX}/share"
+    cp -r "${CLANG_PREFIX}/share/clang/run-clang-tidy.py" "${MASON_PREFIX}/share/"
+    cp -r "${CLANG_PREFIX}/share/clang/clang-tidy-diff.py" "${MASON_PREFIX}/share/"
+    cp -r "${CLANG_PREFIX}/share/clang/run-find-all-symbols.py" "${MASON_PREFIX}/share/"
+
 }
 
 function mason_cflags {


### PR DESCRIPTION
Adds clang-tidy related files from clang share folder, in particular `run-clang-tidy.py` which has better support for parallel clang-tidy jobs.