### PR TITLE
redis 3.2.9

### DIFF
--- a/scripts/redis/3.2.9-configurable-malloc/.travis.yml
+++ b/scripts/redis/3.2.9-configurable-malloc/.travis.yml
@@ -1,0 +1,14 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.2
+      compiler: clang
+    - os: linux
+      compiler: clang
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/redis/3.2.9-configurable-malloc/script.sh
+++ b/scripts/redis/3.2.9-configurable-malloc/script.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+MASON_NAME=redis
+RAW_VERSION=3.2.9
+MASON_VERSION=${RAW_VERSION}-configurable-malloc
+MASON_LIB_FILE=bin/redis-server
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        http://download.redis.io/releases/redis-${RAW_VERSION}.tar.gz \
+        6b2cc5a8223d235d1d2673fa8f806baf1847baa9
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${RAW_VERSION}
+}
+
+function mason_compile {
+    # This extra cflags export is to ensure -O3 is passed to deps
+    export CFLAGS="${CFLAGS:-} -O3 -DNDEBUG"
+    make -j${MASON_CONCURRENCY} MALLOC=libc V=1 OPTIMIZATION=-O3
+    make PREFIX=${MASON_PREFIX} install
+}
+
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"

--- a/scripts/redis/3.2.9/.travis.yml
+++ b/scripts/redis/3.2.9/.travis.yml
@@ -1,0 +1,14 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.2
+      compiler: clang
+    - os: linux
+      compiler: clang
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/redis/3.2.9/script.sh
+++ b/scripts/redis/3.2.9/script.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+MASON_NAME=redis
+MASON_VERSION=3.2.9
+MASON_LIB_FILE=bin/redis-server
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        http://download.redis.io/releases/redis-${MASON_VERSION}.tar.gz \
+        6b2cc5a8223d235d1d2673fa8f806baf1847baa9
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
+}
+
+function mason_compile {
+    # This extra cflags export is to ensure -O3 is passed to deps
+    export CFLAGS="${CFLAGS:-} -O3 -DNDEBUG"
+    make -j${MASON_CONCURRENCY} V=1 OPTIMIZATION=-O3
+    make PREFIX=${MASON_PREFIX} install
+}
+
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"


### PR DESCRIPTION
Adds the latest release of redis. This includes 2 packages:

 - `redis 3.2.9` - This will default to using the internal jemalloc on linux (it is 4.0.3-0-ge9192eacf8935e29fc62fddc2701f7942b1cc02c)
 - `redis 3.2.9-configurable-malloc` - This uses the default libc malloc (and therefore can be customized to use a more recent jemalloc using `LD_PRELOAD`)


/cc @xrwang 