### PR TITLE
Fix android ndk build

### DIFF
--- a/scripts/android-ndk/arm-9-r10e/script.sh
+++ b/scripts/android-ndk/arm-9-r10e/script.sh
@@ -42,4 +42,16 @@ function mason_clean {
     make clean
 }
 
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
 mason_run "$@"

--- a/scripts/android-ndk/arm-9-r11c/script.sh
+++ b/scripts/android-ndk/arm-9-r11c/script.sh
@@ -42,4 +42,16 @@ function mason_clean {
     make clean
 }
 
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
 mason_run "$@"

--- a/scripts/android-ndk/arm-9-r12b/script.sh
+++ b/scripts/android-ndk/arm-9-r12b/script.sh
@@ -44,4 +44,16 @@ function mason_clean {
     make clean
 }
 
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
 mason_run "$@"

--- a/scripts/android-ndk/arm-9-r13b/script.sh
+++ b/scripts/android-ndk/arm-9-r13b/script.sh
@@ -44,4 +44,16 @@ function mason_clean {
     make clean
 }
 
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
 mason_run "$@"

--- a/scripts/android-ndk/arm64-21-r10e-gcc/script.sh
+++ b/scripts/android-ndk/arm64-21-r10e-gcc/script.sh
@@ -40,4 +40,16 @@ function mason_clean {
     make clean
 }
 
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
 mason_run "$@"

--- a/scripts/android-ndk/arm64-21-r10e/script.sh
+++ b/scripts/android-ndk/arm64-21-r10e/script.sh
@@ -42,4 +42,16 @@ function mason_clean {
     make clean
 }
 
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
 mason_run "$@"

--- a/scripts/android-ndk/arm64-21-r11c/script.sh
+++ b/scripts/android-ndk/arm64-21-r11c/script.sh
@@ -42,4 +42,16 @@ function mason_clean {
     make clean
 }
 
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
 mason_run "$@"

--- a/scripts/android-ndk/arm64-21-r12b/script.sh
+++ b/scripts/android-ndk/arm64-21-r12b/script.sh
@@ -44,4 +44,16 @@ function mason_clean {
     make clean
 }
 
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
 mason_run "$@"

--- a/scripts/android-ndk/arm64-21-r13b/script.sh
+++ b/scripts/android-ndk/arm64-21-r13b/script.sh
@@ -44,4 +44,16 @@ function mason_clean {
     make clean
 }
 
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
 mason_run "$@"

--- a/scripts/android-ndk/mips-9-r10e/script.sh
+++ b/scripts/android-ndk/mips-9-r10e/script.sh
@@ -42,4 +42,16 @@ function mason_clean {
     make clean
 }
 
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
 mason_run "$@"

--- a/scripts/android-ndk/mips-9-r11c/script.sh
+++ b/scripts/android-ndk/mips-9-r11c/script.sh
@@ -42,4 +42,16 @@ function mason_clean {
     make clean
 }
 
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
 mason_run "$@"

--- a/scripts/android-ndk/mips-9-r12b/script.sh
+++ b/scripts/android-ndk/mips-9-r12b/script.sh
@@ -44,4 +44,16 @@ function mason_clean {
     make clean
 }
 
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
 mason_run "$@"

--- a/scripts/android-ndk/mips64-21-r10e/script.sh
+++ b/scripts/android-ndk/mips64-21-r10e/script.sh
@@ -42,4 +42,16 @@ function mason_clean {
     make clean
 }
 
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
 mason_run "$@"

--- a/scripts/android-ndk/mips64-21-r11c/script.sh
+++ b/scripts/android-ndk/mips64-21-r11c/script.sh
@@ -42,4 +42,16 @@ function mason_clean {
     make clean
 }
 
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
 mason_run "$@"

--- a/scripts/android-ndk/mips64-21-r12b/script.sh
+++ b/scripts/android-ndk/mips64-21-r12b/script.sh
@@ -44,4 +44,16 @@ function mason_clean {
     make clean
 }
 
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
 mason_run "$@"

--- a/scripts/android-ndk/mips64-21-r13b/script.sh
+++ b/scripts/android-ndk/mips64-21-r13b/script.sh
@@ -44,4 +44,16 @@ function mason_clean {
     make clean
 }
 
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
 mason_run "$@"

--- a/scripts/android-ndk/x86-9-r10e/script.sh
+++ b/scripts/android-ndk/x86-9-r10e/script.sh
@@ -46,4 +46,16 @@ function mason_clean {
     make clean
 }
 
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
 mason_run "$@"

--- a/scripts/android-ndk/x86-9-r11c/script.sh
+++ b/scripts/android-ndk/x86-9-r11c/script.sh
@@ -42,4 +42,16 @@ function mason_clean {
     make clean
 }
 
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
 mason_run "$@"

--- a/scripts/android-ndk/x86-9-r12b/script.sh
+++ b/scripts/android-ndk/x86-9-r12b/script.sh
@@ -44,4 +44,16 @@ function mason_clean {
     make clean
 }
 
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
 mason_run "$@"

--- a/scripts/android-ndk/x86_64-21-r10e/script.sh
+++ b/scripts/android-ndk/x86_64-21-r10e/script.sh
@@ -42,4 +42,16 @@ function mason_clean {
     make clean
 }
 
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
 mason_run "$@"

--- a/scripts/android-ndk/x86_64-21-r11c/script.sh
+++ b/scripts/android-ndk/x86_64-21-r11c/script.sh
@@ -42,4 +42,16 @@ function mason_clean {
     make clean
 }
 
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
 mason_run "$@"

--- a/scripts/android-ndk/x86_64-21-r12b/script.sh
+++ b/scripts/android-ndk/x86_64-21-r12b/script.sh
@@ -44,4 +44,16 @@ function mason_clean {
     make clean
 }
 
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
 mason_run "$@"

--- a/scripts/android-ndk/x86_64-21-r13b/script.sh
+++ b/scripts/android-ndk/x86_64-21-r13b/script.sh
@@ -44,4 +44,16 @@ function mason_clean {
     make clean
 }
 
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
 mason_run "$@"


### PR DESCRIPTION
Fixes this error:

```
The MASON_PKGCONFIG_FILE variable not found in script.sh. Please either provide this variable or override the mason_cflags function hook
```

Noted at #456, which happens when the mason tarball fails to download and the build falls back to a source compile. Really, the core issue should be solved at #456 as well, but this mitigates the confusion.