### PR TITLE
0.14.0 mason release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## 0.14.0
 
-https://github.com/mapbox/mason/compare/v0.13.0...702a81e4599f99db1a658d6ab805ac5972d2b6a8
-
  - Added
     - libosmium cd8e2ff
     - osm-area-tools b222e00
@@ -18,6 +16,8 @@ https://github.com/mapbox/mason/compare/v0.13.0...702a81e4599f99db1a658d6ab805ac
 
  - Fixed
     - If mason is executed through a symlink, resolve the link
+
+Changes: https://github.com/mapbox/mason/compare/v0.13.0...v0.14.0
 
 ## 0.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Mason releases
 
+## 0.14.0
+
+https://github.com/mapbox/mason/compare/v0.13.0...702a81e4599f99db1a658d6ab805ac5972d2b6a8
+
+ - Added
+    - libosmium cd8e2ff
+    - osm-area-tools b222e00
+    - geometry 0.9.2
+    - supercluster 0.2.1
+    -	benchmark 1.0.0, 1.1.0
+    -	cheap-ruler 2.5.2, 2.5.3
+    -	TBB to 2017_U7
+    -	llvm 4.0.1
+    -	tippecanoe 1.21.0
+    - catch 1.9.6
+
+ - Fixed
+    - If mason is executed through a symlink, resolve the link
+
 ## 0.13.0
 
  - Added

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To install mason locally:
 
 ```sh
 mkdir ./mason
-curl -sSfL https://github.com/mapbox/mason/archive/v0.13.0.tar.gz | tar --gunzip --extract --strip-components=1 --exclude="*md" --exclude="test*" --directory=./mason
+curl -sSfL https://github.com/mapbox/mason/archive/v0.14.0.tar.gz | tar --gunzip --extract --strip-components=1 --exclude="*md" --exclude="test*" --directory=./mason
 ```
 
 Then you can use the `mason` command like: `./mason/mason install <package> <version>`
@@ -48,7 +48,7 @@ Then you can use the `mason` command like: `./mason/mason install <package> <ver
 To install mason globally (to /tmp):
 
 ```sh
-curl -sSfL https://github.com/mapbox/mason/archive/v0.13.0.tar.gz | tar --gunzip --extract --strip-components=1 --exclude="*md" --exclude="test*" --directory=/tmp
+curl -sSfL https://github.com/mapbox/mason/archive/v0.14.0.tar.gz | tar --gunzip --extract --strip-components=1 --exclude="*md" --exclude="test*" --directory=/tmp
 ```
 
 Then you can use the `mason` command like: `/tmp/mason install <package> <version>`
@@ -62,7 +62,7 @@ Optionally a convention when using submodules, is to place the submodule at a pa
 ```bash
 git submodule add git@github.com:mapbox/mason.git .mason/
 ```
-        
+
 This will append a few lines to your `.gitmodules` file. Make sure to change the `url` parameter to `https` instead of `git@github` ssh protocol.
 
 ```
@@ -70,7 +70,7 @@ This will append a few lines to your `.gitmodules` file. Make sure to change the
     path = .mason
     url = https://github.com/mapbox/mason.git
 ```
-   
+
 Update your `Makefile` to point to the mason scripts and provide an installation script for the necessary dependencies. The following installs two Mason packages with the `make mason_packages` command.
 
 ```Make


### PR DESCRIPTION
Releasing 0.14.0 with updated libraries and versions - using this commit to compare between 0.13.0 and current master (plus #458) https://github.com/mapbox/mason/compare/v0.13.0...702a81e4599f99db1a658d6ab805ac5972d2b6a8

cc @springmeyer 