### PR TITLE
rocksdb: trigger warning if SSE not available

### DIFF
--- a/scripts/rocksdb/5.4.6/script.sh
+++ b/scripts/rocksdb/5.4.6/script.sh
@@ -28,6 +28,10 @@ function mason_compile {
     # we want -O3 for best performance
     perl -i -p -e "s/-O2 -fno-omit-frame-pointer/-O3/g;" Makefile
     export CXX="${MASON_CCACHE}/bin/ccache ${CXX}"
+    # explicitly ask for SSE support, which will trigger a warning if not available
+    # https://github.com/facebook/rocksdb/blob/9b11d4345a0f01fc3de756e01460bf1b0446f326/INSTALL.md#compilation)
+    # https://github.com/facebook/rocksdb/blob/627c9f1abb263ab8d2072a1ac9d30a6e4bc3dde4/build_tools/build_detect_platform#L471
+    export USE_SSE=1
     INSTALL_PATH=${MASON_PREFIX} V=1 make install-static -j${MASON_CONCURRENCY}
     if [[ $(uname -s) == 'Darwin' ]]; then
         export EXTRA_LDFLAGS="-lc++"


### PR DESCRIPTION
This adds `USE_SSE` to the rocksdb build. Adding this:

 - explicitly enabled sse optimizations by adding `-msse -msse4.2` to the compile flags, rather than letting the build set `-march=native`.
 - enables a warning for the build if `-msse -msse4.2` is not supported (note: there is no warning on travis since the Xeon processors support ss4.2)

My assumption is that `-msse -msse4.2` is portable to all CPUs normally used by mason users, so asking for this explicitly will help us have something to refer back to if this assumption if this ever proves untrue (e.g. someone is running a CPU chip older than Xeon).

To be merged into #462 @lukasmartinelli 