### PR TITLE
Fix webp build for iOS compilation

### DIFF
--- a/scripts/webp/0.6.0/.travis.yml
+++ b/scripts/webp/0.6.0/.travis.yml
@@ -3,17 +3,38 @@ language: generic
 matrix:
   include:
     - os: osx
-      osx_image: xcode8.2
       compiler: clang
-    - os: linux
-      env: MASON_PLATFORM_VERSION=i686
       sudo: false
+    - os: osx
+      env: MASON_PLATFORM=ios
+      compiler: clang
     - os: linux
       env: MASON_PLATFORM_VERSION=cortex_a9
-      sudo: false
+    - os: linux
+      env: MASON_PLATFORM_VERSION=i686
     - os: linux
       compiler: clang
       sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
+    - os: osx
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v5
+    - os: osx
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v7
+    - os: osx
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v8
+    - os: osx
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=x86
+    - os: osx
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=x86-64
+    - os: osx
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=mips
+    - os: osx
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=mips-64
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/webp/0.6.0/script.sh
+++ b/scripts/webp/0.6.0/script.sh
@@ -51,6 +51,9 @@ function mason_compile {
         --disable-wic \
         --disable-dependency-tracking
 
+    # Must do make clean after configure to clear out object files left over
+    # from previous build on different architecture
+    make clean
     make V=1 -j${MASON_CONCURRENCY}
     make install -j${MASON_CONCURRENCY}
 }


### PR DESCRIPTION
Fixes https://github.com/mapbox/mason/issues/450

We were missing a `make clean`, so while we were configuring the project for the next architecture, we weren't actually building the files since they were already in place from a different build from the previous architecture.