### PR TITLE
Remove -Wmissing-declarations from CAIRO_CFLAGS_DEFAULTS

### DIFF
--- a/scripts/cairo/1.14.8/script.sh
+++ b/scripts/cairo/1.14.8/script.sh
@@ -35,7 +35,7 @@ function mason_compile {
     CFLAGS="${CFLAGS} -Wno-enum-conversion -I${MASON_PIXMAN}/include/pixman-1 -I${MASON_FREETYPE}/include/freetype2 -I${MASON_PNG}/include/"
     LDFLAGS="-L${MASON_PIXMAN}/lib -lpixman-1 -L${MASON_FREETYPE}/lib -lfreetype -L${MASON_PNG}/lib -lpng"
     # note CFLAGS overrides defaults
-    CAIRO_CFLAGS_DEFAULTS="-Wall -Wextra -Wmissing-declarations -Werror-implicit-function-declaration -Wpointer-arith -Wwrite-strings -Wsign-compare -Wpacked -Wswitch-enum -Wmissing-format-attribute -Wvolatile-register-var -Wstrict-aliasing=2 -Winit-self -Wno-missing-field-initializers -Wno-unused-parameter -Wno-attributes -Wno-long-long -Winline -fno-strict-aliasing -fno-common -Wp,-D_FORTIFY_SOURCE=2"
+    CAIRO_CFLAGS_DEFAULTS="-Wall -Wextra -Werror-implicit-function-declaration -Wpointer-arith -Wwrite-strings -Wsign-compare -Wpacked -Wswitch-enum -Wmissing-format-attribute -Wvolatile-register-var -Wstrict-aliasing=2 -Winit-self -Wno-missing-field-initializers -Wno-unused-parameter -Wno-attributes -Wno-long-long -Winline -fno-strict-aliasing -fno-common -Wp,-D_FORTIFY_SOURCE=2"
     # so we need to add optimization flags back
     export CFLAGS="${CFLAGS} ${CAIRO_CFLAGS_DEFAULTS} -O3 -DNDEBUG"
     LDFLAGS=${LDFLAGS} ./autogen.sh \


### PR DESCRIPTION
Fixes #490, cairo-1.14.8 build failure on IA32.