### PR TITLE
Do not assume PKG_CONFIG_PATH to be defined.

### DIFF
--- a/scripts/harfbuzz/0.9.40/script.sh
+++ b/scripts/harfbuzz/0.9.40/script.sh
@@ -23,7 +23,7 @@ function mason_prepare_compile {
     MASON_FREETYPE=$(${MASON_DIR}/mason prefix freetype ${FREETYPE_VERSION})
     MASON_PLATFORM= ${MASON_DIR}/mason install ragel 6.9
     export PATH=$(MASON_PLATFORM= ${MASON_DIR}/mason prefix ragel 6.9)/bin:$PATH
-    export PKG_CONFIG_PATH="$(${MASON_DIR}/mason prefix freetype ${FREETYPE_VERSION})/lib/pkgconfig":$PKG_CONFIG_PATH
+    export PKG_CONFIG_PATH="$(${MASON_DIR}/mason prefix freetype ${FREETYPE_VERSION})/lib/pkgconfig":${PKG_CONFIG_PATH:-}
     export C_INCLUDE_PATH="${MASON_FREETYPE}/include/freetype2"
     export CPLUS_INCLUDE_PATH="${MASON_FREETYPE}/include/freetype2"
     export LIBRARY_PATH="${MASON_FREETYPE}/lib"

--- a/scripts/harfbuzz/0.9.41/script.sh
+++ b/scripts/harfbuzz/0.9.41/script.sh
@@ -23,7 +23,7 @@ function mason_prepare_compile {
     MASON_FREETYPE=$(${MASON_DIR}/mason prefix freetype ${FREETYPE_VERSION})
     MASON_PLATFORM= ${MASON_DIR}/mason install ragel 6.9
     export PATH=$(MASON_PLATFORM= ${MASON_DIR}/mason prefix ragel 6.9)/bin:$PATH
-    export PKG_CONFIG_PATH="$(${MASON_DIR}/mason prefix freetype ${FREETYPE_VERSION})/lib/pkgconfig":$PKG_CONFIG_PATH
+    export PKG_CONFIG_PATH="$(${MASON_DIR}/mason prefix freetype ${FREETYPE_VERSION})/lib/pkgconfig":${PKG_CONFIG_PATH:-}
     export C_INCLUDE_PATH="${MASON_FREETYPE}/include/freetype2"
     export CPLUS_INCLUDE_PATH="${MASON_FREETYPE}/include/freetype2"
     export LIBRARY_PATH="${MASON_FREETYPE}/lib"

--- a/scripts/harfbuzz/1.1.2/script.sh
+++ b/scripts/harfbuzz/1.1.2/script.sh
@@ -23,7 +23,7 @@ function mason_prepare_compile {
     MASON_FREETYPE=$(${MASON_DIR}/mason prefix freetype ${FREETYPE_VERSION})
     MASON_PLATFORM= ${MASON_DIR}/mason install ragel 6.9
     export PATH=$(MASON_PLATFORM= ${MASON_DIR}/mason prefix ragel 6.9)/bin:$PATH
-    export PKG_CONFIG_PATH="$(${MASON_DIR}/mason prefix freetype ${FREETYPE_VERSION})/lib/pkgconfig":$PKG_CONFIG_PATH
+    export PKG_CONFIG_PATH="$(${MASON_DIR}/mason prefix freetype ${FREETYPE_VERSION})/lib/pkgconfig":${PKG_CONFIG_PATH:-}
     export C_INCLUDE_PATH="${MASON_FREETYPE}/include/freetype2"
     export CPLUS_INCLUDE_PATH="${MASON_FREETYPE}/include/freetype2"
     export LIBRARY_PATH="${MASON_FREETYPE}/lib"

--- a/scripts/harfbuzz/1.2.1/script.sh
+++ b/scripts/harfbuzz/1.2.1/script.sh
@@ -23,7 +23,7 @@ function mason_prepare_compile {
     MASON_FREETYPE=$(${MASON_DIR}/mason prefix freetype ${FREETYPE_VERSION})
     MASON_PLATFORM= ${MASON_DIR}/mason install ragel 6.9
     export PATH=$(MASON_PLATFORM= ${MASON_DIR}/mason prefix ragel 6.9)/bin:$PATH
-    export PKG_CONFIG_PATH="$(${MASON_DIR}/mason prefix freetype ${FREETYPE_VERSION})/lib/pkgconfig":$PKG_CONFIG_PATH
+    export PKG_CONFIG_PATH="$(${MASON_DIR}/mason prefix freetype ${FREETYPE_VERSION})/lib/pkgconfig":${PKG_CONFIG_PATH:-}
     export C_INCLUDE_PATH="${MASON_FREETYPE}/include/freetype2"
     export CPLUS_INCLUDE_PATH="${MASON_FREETYPE}/include/freetype2"
     export LIBRARY_PATH="${MASON_FREETYPE}/lib"

--- a/scripts/harfbuzz/1.2.6/script.sh
+++ b/scripts/harfbuzz/1.2.6/script.sh
@@ -23,7 +23,7 @@ function mason_prepare_compile {
     MASON_FREETYPE=$(${MASON_DIR}/mason prefix freetype ${FREETYPE_VERSION})
     MASON_PLATFORM= ${MASON_DIR}/mason install ragel 6.9
     export PATH=$(MASON_PLATFORM= ${MASON_DIR}/mason prefix ragel 6.9)/bin:$PATH
-    export PKG_CONFIG_PATH="$(${MASON_DIR}/mason prefix freetype ${FREETYPE_VERSION})/lib/pkgconfig":$PKG_CONFIG_PATH
+    export PKG_CONFIG_PATH="$(${MASON_DIR}/mason prefix freetype ${FREETYPE_VERSION})/lib/pkgconfig":${PKG_CONFIG_PATH:-}
     export C_INCLUDE_PATH="${MASON_FREETYPE}/include/freetype2"
     export CPLUS_INCLUDE_PATH="${MASON_FREETYPE}/include/freetype2"
     export LIBRARY_PATH="${MASON_FREETYPE}/lib"

--- a/scripts/harfbuzz/1.3.0/script.sh
+++ b/scripts/harfbuzz/1.3.0/script.sh
@@ -23,7 +23,7 @@ function mason_prepare_compile {
     MASON_FREETYPE=$(${MASON_DIR}/mason prefix freetype ${FREETYPE_VERSION})
     MASON_PLATFORM= ${MASON_DIR}/mason install ragel 6.9
     export PATH=$(MASON_PLATFORM= ${MASON_DIR}/mason prefix ragel 6.9)/bin:$PATH
-    export PKG_CONFIG_PATH="$(${MASON_DIR}/mason prefix freetype ${FREETYPE_VERSION})/lib/pkgconfig":$PKG_CONFIG_PATH
+    export PKG_CONFIG_PATH="$(${MASON_DIR}/mason prefix freetype ${FREETYPE_VERSION})/lib/pkgconfig":${PKG_CONFIG_PATH:-}
     export C_INCLUDE_PATH="${MASON_FREETYPE}/include/freetype2"
     export CPLUS_INCLUDE_PATH="${MASON_FREETYPE}/include/freetype2"
     export LIBRARY_PATH="${MASON_FREETYPE}/lib"

--- a/scripts/harfbuzz/1.4.2-ft/script.sh
+++ b/scripts/harfbuzz/1.4.2-ft/script.sh
@@ -23,7 +23,7 @@ function mason_prepare_compile {
     MASON_FREETYPE=$(${MASON_DIR}/mason prefix freetype ${FREETYPE_VERSION})
     MASON_PLATFORM= ${MASON_DIR}/mason install ragel 6.9
     export PATH=$(MASON_PLATFORM= ${MASON_DIR}/mason prefix ragel 6.9)/bin:$PATH
-    export PKG_CONFIG_PATH="$(${MASON_DIR}/mason prefix freetype ${FREETYPE_VERSION})/lib/pkgconfig":$PKG_CONFIG_PATH
+    export PKG_CONFIG_PATH="$(${MASON_DIR}/mason prefix freetype ${FREETYPE_VERSION})/lib/pkgconfig":${PKG_CONFIG_PATH:-}
     export C_INCLUDE_PATH="${MASON_FREETYPE}/include/freetype2"
     export CPLUS_INCLUDE_PATH="${MASON_FREETYPE}/include/freetype2"
     export LIBRARY_PATH="${MASON_FREETYPE}/lib"

--- a/scripts/protobuf_c/1.1.0/script.sh
+++ b/scripts/protobuf_c/1.1.0/script.sh
@@ -21,7 +21,7 @@ function mason_prepare_compile {
     cd $(dirname ${MASON_ROOT})
     ${MASON_DIR}/mason install protobuf 2.6.1
     MASON_PROTOBUF=$(${MASON_DIR}/mason prefix protobuf 2.6.1)
-    export PKG_CONFIG_PATH=${MASON_PROTOBUF}/lib/pkgconfig:${PKG_CONFIG_PATH}
+    export PKG_CONFIG_PATH=${MASON_PROTOBUF}/lib/pkgconfig:${PKG_CONFIG_PATH:-}
 }
 
 function mason_compile {


### PR DESCRIPTION
There are some instances in mason scripts (mostly harfbuzz scripts) where PKG_CONFIG_PATH is extended and exported. This patch fixes the extension when PKG_CONFIG_PATH is empty.