### PR TITLE
ragel: Add -std=gnu++98 to CXXFLAGS.

### DIFF
--- a/scripts/ragel/6.9/script.sh
+++ b/scripts/ragel/6.9/script.sh
@@ -17,6 +17,7 @@ function mason_load_source {
 }
 
 function mason_compile {
+    export CXXFLAGS="${CXXFLAGS//-std=c++11} -std=c++03"
     ./configure --prefix=${MASON_PREFIX} \
      --disable-dependency-tracking
 
@@ -27,6 +28,14 @@ function mason_compile {
 
 function mason_clean {
     make clean
+}
+
+function mason_cflags {
+    echo ""
+}
+
+function mason_ldflags {
+    echo ""
 }
 
 mason_run "$@"


### PR DESCRIPTION
On my (linux, IA32) system mason build of ragel-6.9 fails with -Wnarrowing, due to use of -std=c++11. This patch adds -std=gnu++98 to CXXFLAGS, which is enough to make the compiler not to turn this warning into an error.

There is probably a cleaner way to fix this though.