### PR TITLE
protozero 1.6.0

### DIFF
--- a/scripts/protozero/1.6.0/.travis.yml
+++ b/scripts/protozero/1.6.0/.travis.yml
@@ -1,0 +1,10 @@
+language: generic
+
+matrix:
+  include:
+    - os: linux
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/protozero/1.6.0/script.sh
+++ b/scripts/protozero/1.6.0/script.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+MASON_NAME=protozero
+MASON_VERSION=1.6.0
+MASON_HEADER_ONLY=true
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        https://github.com/mapbox/protozero/archive/v${MASON_VERSION}.tar.gz \
+        acc010d0e5d8be7ac2223bd5afa9959e4577429f
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/protozero-${MASON_VERSION}
+}
+
+function mason_compile {
+    mkdir -p ${MASON_PREFIX}/include/
+    cp -r include/protozero ${MASON_PREFIX}/include/protozero
+}
+
+function mason_cflags {
+    echo "-I${MASON_PREFIX}/include"
+}
+
+function mason_ldflags {
+    :
+}
+
+mason_run "$@"


### PR DESCRIPTION
Adding v1.6.0 release of protozero: https://github.com/mapbox/protozero/blob/master/CHANGELOG.md#160---2017-10-24

/cc @mapbox/core-tech 
