### PR TITLE
llvm 6.x / current unreleased HEAD

### DIFF
--- a/scripts/clang++/6.0.0/.travis.yml
+++ b/scripts/clang++/6.0.0/.travis.yml
@@ -1,0 +1,11 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+    - os: linux
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/clang++/6.0.0/script.sh
+++ b/scripts/clang++/6.0.0/script.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# dynamically take name of package from directory
+MASON_NAME=$(basename $(dirname $HERE))
+# dynamically take the version of the package from directory
+MASON_VERSION=$(basename $HERE)
+MASON_LIB_FILE=bin/${MASON_NAME}
+
+. ${MASON_DIR}/mason.sh
+
+# inherit all functions from base
+source ${HERE}/../../${MASON_NAME}/base/common.sh
+
+mason_run "$@"

--- a/scripts/clang-format/6.0.0/.travis.yml
+++ b/scripts/clang-format/6.0.0/.travis.yml
@@ -1,0 +1,11 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+    - os: linux
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/clang-format/6.0.0/script.sh
+++ b/scripts/clang-format/6.0.0/script.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# dynamically take name of package from directory
+MASON_NAME=$(basename $(dirname $HERE))
+# dynamically take the version of the package from directory
+MASON_VERSION=$(basename $HERE)
+MASON_LIB_FILE=bin/${MASON_NAME}
+
+. ${MASON_DIR}/mason.sh
+
+# inherit all functions from base
+source ${HERE}/../../${MASON_NAME}/base/common.sh
+
+mason_run "$@"

--- a/scripts/clang-tidy/6.0.0/.travis.yml
+++ b/scripts/clang-tidy/6.0.0/.travis.yml
@@ -1,0 +1,11 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+    - os: linux
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/clang-tidy/6.0.0/script.sh
+++ b/scripts/clang-tidy/6.0.0/script.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# dynamically take name of package from directory
+MASON_NAME=$(basename $(dirname $HERE))
+# dynamically take the version of the package from directory
+MASON_VERSION=$(basename $HERE)
+MASON_LIB_FILE=bin/${MASON_NAME}
+
+. ${MASON_DIR}/mason.sh
+
+# inherit all functions from base
+source ${HERE}/../../${MASON_NAME}/base/common.sh
+
+mason_run "$@"

--- a/scripts/include-what-you-use/6.0.0/.travis.yml
+++ b/scripts/include-what-you-use/6.0.0/.travis.yml
@@ -1,0 +1,11 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+    - os: linux
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/include-what-you-use/6.0.0/script.sh
+++ b/scripts/include-what-you-use/6.0.0/script.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# dynamically take name of package from directory
+MASON_NAME=$(basename $(dirname $HERE))
+# dynamically take the version of the package from directory
+MASON_VERSION=$(basename $HERE)
+MASON_LIB_FILE=bin/${MASON_NAME}
+
+. ${MASON_DIR}/mason.sh
+
+# inherit all functions from base
+source ${HERE}/../../${MASON_NAME}/base/common.sh
+
+mason_run "$@"

--- a/scripts/lldb/6.0.0/.travis.yml
+++ b/scripts/lldb/6.0.0/.travis.yml
@@ -1,0 +1,11 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+    - os: linux
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/lldb/6.0.0/script.sh
+++ b/scripts/lldb/6.0.0/script.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# dynamically take name of package from directory
+MASON_NAME=$(basename $(dirname $HERE))
+# dynamically take the version of the package from directory
+MASON_VERSION=$(basename $HERE)
+MASON_LIB_FILE=bin/${MASON_NAME}
+
+. ${MASON_DIR}/mason.sh
+
+# inherit all functions from base
+source ${HERE}/../../${MASON_NAME}/base/common.sh
+
+mason_run "$@"

--- a/scripts/llvm-cov/6.0.0/.travis.yml
+++ b/scripts/llvm-cov/6.0.0/.travis.yml
@@ -1,0 +1,11 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+    - os: linux
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/llvm-cov/6.0.0/script.sh
+++ b/scripts/llvm-cov/6.0.0/script.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# dynamically take name of package from directory
+MASON_NAME=$(basename $(dirname $HERE))
+# dynamically take the version of the package from directory
+MASON_VERSION=$(basename $HERE)
+MASON_LIB_FILE=bin/${MASON_NAME}
+
+. ${MASON_DIR}/mason.sh
+
+# inherit all functions from base
+source ${HERE}/../../${MASON_NAME}/base/common.sh
+
+mason_run "$@"

--- a/scripts/llvm/6.0.0/.travis.yml
+++ b/scripts/llvm/6.0.0/.travis.yml
@@ -1,0 +1,4 @@
+language: generic
+
+script:
+- echo "nothing to do since travis cannot compile something as large as llvm"

--- a/scripts/llvm/6.0.0/README.md
+++ b/scripts/llvm/6.0.0/README.md
@@ -1,0 +1,3 @@
+### llvm v4.x
+
+Development package of llvm git head

--- a/scripts/llvm/6.0.0/script.sh
+++ b/scripts/llvm/6.0.0/script.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+# dynamically take name of package from directory
+MASON_NAME=$(basename $(dirname $HERE))
+# dynamically take the version of the package from directory
+MASON_VERSION=$(basename $HERE)
+# inherit all functions from llvm base
+source ${HERE}/../../${MASON_NAME}/base/common.sh
+
+function setup_release() {
+    get_llvm_project "http://llvm.org/git/llvm.git"              ${MASON_BUILD_PATH}
+    get_llvm_project "http://llvm.org/git/clang.git"             ${MASON_BUILD_PATH}/tools/clang
+    get_llvm_project "http://llvm.org/git/compiler-rt.git"       ${MASON_BUILD_PATH}/projects/compiler-rt
+    if [[ ${BUILD_AND_LINK_LIBCXX} == true ]]; then
+        get_llvm_project "http://llvm.org/git/libcxx.git"            ${MASON_BUILD_PATH}/projects/libcxx
+        get_llvm_project "http://llvm.org/git/libcxxabi.git"         ${MASON_BUILD_PATH}/projects/libcxxabi
+        get_llvm_project "http://llvm.org/git/libunwind.git"         ${MASON_BUILD_PATH}/projects/libunwind
+    fi
+    get_llvm_project "http://llvm.org/git/lld.git"               ${MASON_BUILD_PATH}/tools/lld
+    get_llvm_project "http://llvm.org/git/clang-tools-extra.git" ${MASON_BUILD_PATH}/tools/clang/tools/extra
+    get_llvm_project "http://llvm.org/git/lldb.git"              ${MASON_BUILD_PATH}/tools/lldb
+    get_llvm_project "https://github.com/include-what-you-use/include-what-you-use.git"  ${MASON_BUILD_PATH}/tools/clang/tools/include-what-you-use
+}
+
+mason_run "$@"

--- a/scripts/llvm/base/README.md
+++ b/scripts/llvm/base/README.md
@@ -161,7 +161,7 @@ We run the docker image to build the package on linux. We map volumes such that 
 ```
 LLVM_VERSION="4.0.2"
 docker run -it --volume $(pwd):/home/travis/build/mapbox/mason mason-llvm \
-  ./mason build llvm ${LLVM_VERSION} && ./utils/llvm.sh build ${LLVM_VERSION}
+  /bin/bash -c "./mason build llvm ${LLVM_VERSION} && ./utils/llvm.sh build ${LLVM_VERSION}"
 ```
 
 C. Authenticate your shell with the mason AWS KEYS

--- a/scripts/llvm/base/README.md
+++ b/scripts/llvm/base/README.md
@@ -49,6 +49,8 @@ They are built locally by a Mason contributor, rather than on https://travis-ci.
 
 On MacOS we build for OS X 10.12 as the minimum target. We link llvm against the apple system libc++.
 
+On OS X you additionally have to set up code signing once on the machine that builds llvm: https://llvm.org/svn/llvm-project/lldb/trunk/docs/code-signing.txt
+
 ### Linux details
 
 On Linux we build using an Ubuntu Precise docker image in order to ensure that binaries can be run on Ubuntu Precise and newer platforms.
@@ -68,6 +70,7 @@ If you would like to create a new llvm package, when a new version is created, y
  - At least 1 hour free to run builds locally
  - A fast internet connection for large uploads (> 1.6 GB)
  - A host machine of either Linux or OS X
+ - If using OS X then the machine needs to be set up for signing (https://llvm.org/svn/llvm-project/lldb/trunk/docs/code-signing.txt)
 
 Here are the steps to create a new llvm version:
 

--- a/scripts/llvm/base/common.sh
+++ b/scripts/llvm/base/common.sh
@@ -46,9 +46,9 @@ function get_llvm_project() {
             git clone --depth ${DEPTH} ${URL} ${local_file_or_checkout}
         else
             mason_substep "already cloned ${URL}, pulling to update"
-            (cd ${local_file_or_checkout} && git pull)
+            (cd ${local_file_or_checkout} && echo "pulling ${local_file_or_checkout}" && git pull)
         fi
-        if [[ ${CUSTOM_GITSHA:-false} == false ]]; then
+        if [[ ${CUSTOM_GITSHA:-false} != false ]]; then
             (cd ${local_file_or_checkout} && git fetch && git checkout ${CUSTOM_GITSHA})
         fi
         mason_step "moving ${local_file_or_checkout} into place at ${TO_DIR}"

--- a/scripts/llvm/base/common.sh
+++ b/scripts/llvm/base/common.sh
@@ -9,21 +9,6 @@ export MASON_BASE_VERSION=${MASON_BASE_VERSION:-${MASON_VERSION}}
 export MAJOR_MINOR=$(echo ${MASON_BASE_VERSION} | cut -d '.' -f1-2)
 
 if [[ $(uname -s) == 'Darwin' ]]; then
-    # ensure codesigning is working before starting
-    # this logic borrowed from homebrew llvm.rb formula
-    TMPDIR=$(mktemp -d)
-    (cd $TMPDIR && \
-        cp /usr/bin/false  llvm_check && \
-        RESULT=0 &&
-        /usr/bin/codesign -f -s lldb_codesign --dryrun llvm_check || RESULT=$? &&
-        if [[ ${RESULT} != 0 ]]; then
-          echo "lldb_codesign identity must be available to build with LLDB."
-          echo "See: https://llvm.org/svn/llvm-project/lldb/trunk/docs/code-signing.txt"
-          exit 1
-        fi
-    )
-
-
     export BUILD_AND_LINK_LIBCXX=false
     # avoids this kind of problem with include-what-you-use
     # because iwyu hardcodes at https://github.com/include-what-you-use/include-what-you-use/blob/da5c9b17fec571e6b2bbca29145463d7eaa3582e/iwyu_driver.cc#L219
@@ -146,6 +131,22 @@ function mason_prepare_compile {
 }
 
 function mason_compile {
+    if [[ $(uname -s) == 'Darwin' ]]; then
+        # ensure codesigning is working before starting
+        # this logic borrowed from homebrew llvm.rb formula
+        TMPDIR=$(mktemp -d)
+        (cd $TMPDIR && \
+            cp /usr/bin/false  llvm_check && \
+            RESULT=0 &&
+            /usr/bin/codesign -f -s lldb_codesign --dryrun llvm_check || RESULT=$? &&
+            if [[ ${RESULT} != 0 ]]; then
+              echo "lldb_codesign identity must be available to build with LLDB."
+              echo "See: https://llvm.org/svn/llvm-project/lldb/trunk/docs/code-signing.txt"
+              exit 1
+            fi
+        )
+    fi
+
     export CXX="${CXX:-${MASON_CLANG}/bin/clang++}"
     export CC="${CC:-${MASON_CLANG}/bin/clang}"
     # knock out lldb doc building, to remove doxygen dependency


### PR DESCRIPTION
Working on packaging HEAD llvm (upcoming 6.x)

Note: all mason packages that pull from head should ping to a specific git revision. However llvm is an exception. So the 6.0.0 will be rebuilt occasionally (by me) and a potential moving target until the official 6.0.0 release comes out. They could likely be reworked to work on a gitsha, but I've not had the time to do such a refactor.