### PR TITLE
Set BOOST_TOOLSET* from CC and CXX env variables.

### DIFF
--- a/scripts/boost/1.61.0/base.sh
+++ b/scripts/boost/1.61.0/base.sh
@@ -4,7 +4,7 @@
 
 export MASON_VERSION=1.61.0
 export BOOST_VERSION=${MASON_VERSION//./_}
-export BOOST_TOOLSET="clang"
-export BOOST_TOOLSET_CXX="clang++"
+export BOOST_TOOLSET=$(basename ${CC})
+export BOOST_TOOLSET_CXX=$(basename ${CXX})
 export BOOST_ARCH="x86"
 export BOOST_SHASUM=0a72c541e468d76a957adc14e54688dd695d566f

--- a/scripts/boost/1.62.0/base.sh
+++ b/scripts/boost/1.62.0/base.sh
@@ -4,8 +4,8 @@
 
 export MASON_VERSION=1.62.0
 export BOOST_VERSION=${MASON_VERSION//./_}
-export BOOST_TOOLSET="clang"
-export BOOST_TOOLSET_CXX="clang++"
+export BOOST_TOOLSET=$(basename ${CC})
+export BOOST_TOOLSET_CXX=$(basename ${CXX})
 export BOOST_ARCH="x86"
 export BOOST_SHASUM=f4151eec3e9394146b7bebcb17b83149de0a6c23
 # special override to ensure each library shares the cached download

--- a/scripts/boost/1.63.0/base.sh
+++ b/scripts/boost/1.63.0/base.sh
@@ -4,8 +4,8 @@
 
 export MASON_VERSION=1.63.0
 export BOOST_VERSION=${MASON_VERSION//./_}
-export BOOST_TOOLSET="clang"
-export BOOST_TOOLSET_CXX="clang++"
+export BOOST_TOOLSET=$(basename ${CC})
+export BOOST_TOOLSET_CXX=$(basename ${CXX})
 export BOOST_ARCH="x86"
 export BOOST_SHASUM=5c5cf0fd35a5950ed9e00ba54153df47747803f9
 # special override to ensure each library shares the cached download

--- a/scripts/boost/1.64.0/base.sh
+++ b/scripts/boost/1.64.0/base.sh
@@ -4,8 +4,8 @@
 
 export MASON_VERSION=1.64.0
 export BOOST_VERSION=${MASON_VERSION//./_}
-export BOOST_TOOLSET="clang"
-export BOOST_TOOLSET_CXX="clang++"
+export BOOST_TOOLSET=$(basename ${CC})
+export BOOST_TOOLSET_CXX=$(basename ${CXX})
 export BOOST_ARCH="x86"
 export BOOST_SHASUM=6e4dad39f14937af73ace20d2279e2468aad14d8
 # special override to ensure each library shares the cached download

--- a/scripts/boost/1.65.1/base.sh
+++ b/scripts/boost/1.65.1/base.sh
@@ -4,8 +4,8 @@
 
 export MASON_VERSION=1.65.1
 export BOOST_VERSION=${MASON_VERSION//./_}
-export BOOST_TOOLSET="clang"
-export BOOST_TOOLSET_CXX="clang++"
+export BOOST_TOOLSET=$(basename ${CC})
+export BOOST_TOOLSET_CXX=$(basename ${CXX})
 export BOOST_ARCH="x86"
 export BOOST_SHASUM=094a03dd6f07e740719b944cfe01a278f5326315
 # special override to ensure each library shares the cached download


### PR DESCRIPTION
Build scripts for boost currently have the toolset hardcoded to clang. Most linux systems have gcc as the default compiler, which makes the build fail without installing an additional compiler. This patch sets the BOOST_TOOLSET* variables from the CC and CXX environment variables, which should be set to reasonable defaults in mason.sh.