### PR TITLE
openfst 1.6.3

### DIFF
--- a/scripts/openfst/1.6.3/.travis.yml
+++ b/scripts/openfst/1.6.3/.travis.yml
@@ -1,0 +1,45 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.2
+      compiler: clang
+    - os: linux
+      env: MASON_PLATFORM_VERSION=cortex_a9
+      sudo: false
+    - os: linux
+      env: MASON_PLATFORM_VERSION=i686
+      sudo: false
+      addons:
+        apt:
+          packages: [ 'zlib1g-dev:i386' ]
+    - os: linux
+      env: MASON_PLATFORM=linux
+      compiler: clang
+      sudo: false
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v5
+      sudo: false
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v7
+      sudo: false
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v8
+      sudo: false
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=x86
+      sudo: false
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=x86-64
+      sudo: false
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=mips
+      sudo: false
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=mips-64
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/openfst/1.6.3/.travis.yml
+++ b/scripts/openfst/1.6.3/.travis.yml
@@ -6,38 +6,8 @@ matrix:
       osx_image: xcode8.2
       compiler: clang
     - os: linux
-      env: MASON_PLATFORM_VERSION=cortex_a9
-      sudo: false
-    - os: linux
-      env: MASON_PLATFORM_VERSION=i686
-      sudo: false
-      addons:
-        apt:
-          packages: [ 'zlib1g-dev:i386' ]
-    - os: linux
       env: MASON_PLATFORM=linux
       compiler: clang
-      sudo: false
-    - os: linux
-      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v5
-      sudo: false
-    - os: linux
-      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v7
-      sudo: false
-    - os: linux
-      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v8
-      sudo: false
-    - os: linux
-      env: MASON_PLATFORM=android MASON_ANDROID_ABI=x86
-      sudo: false
-    - os: linux
-      env: MASON_PLATFORM=android MASON_ANDROID_ABI=x86-64
-      sudo: false
-    - os: linux
-      env: MASON_PLATFORM=android MASON_ANDROID_ABI=mips
-      sudo: false
-    - os: linux
-      env: MASON_PLATFORM=android MASON_ANDROID_ABI=mips-64
       sudo: false
 
 script:

--- a/scripts/openfst/1.6.3/script.sh
+++ b/scripts/openfst/1.6.3/script.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+MASON_NAME=openfst
+MASON_VERSION=1.6.3
+MASON_LIB_FILE=lib/libre2.a
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        http://www.openfst.org/twiki/pub/FST/FstDownload/${MASON_NAME}-${MASON_VERSION}.tar.gz \
+        9e144c56ea477038d14583376b6414170f0e1b1d
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
+}
+
+function mason_compile {
+    export CFLAGS="${CFLAGS:-} -O3 -DNDEBUG"
+    export CXXFLAGS="${CXXFLAGS:-} -O3 -DNDEBUG"
+    if [[ $(uname -s) == 'Darwin' ]]; then
+        export LDFLAGS="${LDFLAGS:-} -stdlib=libc++"
+    fi
+
+    ./configure \
+        --prefix=${MASON_PREFIX} \
+        ${MASON_HOST_ARG} \
+        --enable-static \
+        --with-pic \
+        --disable-shared \
+        --disable-dependency-tracking \
+        --enable-compact-fsts \
+        --enable-compress \
+        --enable-const-fsts \
+        --enable-far \
+        --enable-linear-fsts \
+        --enable-lookahead-fsts \
+        --enable-mpdt \
+        --enable-ngram-fsts \
+        --enable-pdt \
+        --enable-special \
+        --enable-python \
+        --enable-bin
+
+
+    make -j${MASON_CONCURRENCY}
+    make install
+}
+
+function mason_cflags {
+    echo "-I${MASON_PREFIX}/include"
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    echo ${MASON_PREFIX}/${MASON_LIB_FILE}
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"

--- a/scripts/openfst/1.6.3/script.sh
+++ b/scripts/openfst/1.6.3/script.sh
@@ -2,7 +2,7 @@
 
 MASON_NAME=openfst
 MASON_VERSION=1.6.3
-MASON_LIB_FILE=lib/libre2.a
+MASON_LIB_FILE=lib/libfst.a
 
 . ${MASON_DIR}/mason.sh
 

--- a/scripts/re2/2017-08-01/.travis.yml
+++ b/scripts/re2/2017-08-01/.travis.yml
@@ -1,0 +1,45 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.2
+      compiler: clang
+    - os: linux
+      env: MASON_PLATFORM_VERSION=cortex_a9
+      sudo: false
+    - os: linux
+      env: MASON_PLATFORM_VERSION=i686
+      sudo: false
+      addons:
+        apt:
+          packages: [ 'zlib1g-dev:i386' ]
+    - os: linux
+      env: MASON_PLATFORM=linux
+      compiler: clang
+      sudo: false
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v5
+      sudo: false
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v7
+      sudo: false
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v8
+      sudo: false
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=x86
+      sudo: false
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=x86-64
+      sudo: false
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=mips
+      sudo: false
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=mips-64
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/re2/2017-08-01/script.sh
+++ b/scripts/re2/2017-08-01/script.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+MASON_NAME=re2
+MASON_VERSION=2017-08-01
+MASON_LIB_FILE=lib/libre2.a
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        https://github.com/google/${MASON_NAME}/archive/${MASON_VERSION}.tar.gz \
+        adf5ed0ddae54ec984790b714b3efdbcdb41fe6c
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
+}
+
+function mason_compile {
+    export CFLAGS="${CFLAGS:-} -O3 -DNDEBUG"
+    export CXXFLAGS="${CXXFLAGS:-} -O3 -DNDEBUG"
+    if [[ $(uname -s) == 'Darwin' ]]; then
+        export LDFLAGS="${LDFLAGS:-} -stdlib=libc++"
+    fi
+
+    make obj/libre2.a -j${MASON_CONCURRENCY}
+    # re2's install script is janky (hardcoded - as far as I can tell - to /usr/local) and hardcoded
+    # to also install the shared library (we only what the static one) and simple enough to re-invent
+    # so install of calling `make install` we instead just manually install the library and headers
+    mkdir -p ${MASON_PREFIX}/lib/
+    cp obj/libre2.a ${MASON_PREFIX}/lib/
+    mkdir -p ${MASON_PREFIX}/include/re2/
+    cp -r re2/*h ${MASON_PREFIX}/include/re2/
+}
+
+function mason_cflags {
+    echo "-I${MASON_PREFIX}/include"
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    echo ${MASON_PREFIX}/${MASON_LIB_FILE}
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"


### PR DESCRIPTION
Adds openfst and the re2 dependency. The goal is to provide these libraries in a way that you could (outside of mason, since we don't do python) build pynini against them.

This seems to work:

Install openfst and re2 with mason:

```bash
cd mason # on this PR branch
./mason install openfst 1.6.3
./mason install re2 2017-08-01
```

```bash
wget http://www.openfst.org/twiki/pub/GRM/PyniniDownload/pynini-1.7.tar.gz
tar -xf pynini-1.7.tar.gz
cd pynini-1.7
```

Patch one pynini header to add a missing include:

```diff
diff --git a/src/gtl.cc b/src/gtl.cc
index 0fed4d6..cfbcb6f 100644
--- a/src/gtl.cc
+++ b/src/gtl.cc
@@ -16,6 +16,7 @@
 // pynini.opengrm.org.
 
 #include <algorithm>
+#include <numeric>
 
 #include "gtl.h"

```

Build pynini against mason packages:

```bash
CFLAGS="-Wno-unused-variable -I$(pwd)/../mason_packages/osx-x86_64/re2/2017-08-01/include -I$(pwd)/../mason_packages/osx-x86_64/openfst/1.6.3/include" \
LDFLAGS="-L$(pwd)/../mason_packages/osx-x86_64/re2/2017-08-01/lib -L$(pwd)/../mason_packages/osx-x86_64/openfst/1.6.3/lib" \
python setup.py develop
```

@boblannon @mapbox/geocoding-gang 