### PR TITLE
Add ogr2ogr and libgdal 2.2.2

### DIFF
--- a/scripts/libgdal/2.2.2/.travis.yml
+++ b/scripts/libgdal/2.2.2/.travis.yml
@@ -1,0 +1,13 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.3
+      compiler: clang
+    - os: linux
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/libgdal/2.2.2/script.sh
+++ b/scripts/libgdal/2.2.2/script.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+MASON_NAME=libgdal
+MASON_VERSION=2.2.2
+MASON_LIB_FILE=lib/libgdal.a
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
+    mkdir -p ${MASON_BUILD_PATH}
+}
+
+function mason_prepare_compile {
+    ${MASON_DIR}/mason install gdal ${MASON_VERSION}
+    GDAL_PREFIX=$(${MASON_DIR}/mason prefix gdal ${MASON_VERSION})
+}
+
+function mason_compile {
+    mkdir -p ${MASON_PREFIX}/lib
+    mkdir -p ${MASON_PREFIX}/include
+    mkdir -p ${MASON_PREFIX}/share
+    mkdir -p ${MASON_PREFIX}/bin
+    cp -r ${GDAL_PREFIX}/bin/gdal-config ${MASON_PREFIX}/bin/
+    cp -r ${GDAL_PREFIX}/include/* ${MASON_PREFIX}/include/
+    cp -r ${GDAL_PREFIX}/share/* ${MASON_PREFIX}/share/
+    cp -r ${GDAL_PREFIX}/lib/libgdal.a ${MASON_PREFIX}/lib/
+}
+
+function mason_cflags {
+    echo "-I${MASON_PREFIX}/include"
+}
+
+function mason_ldflags {
+    echo $(${MASON_PREFIX}/bin/gdal-config --dep-libs --libs)
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"

--- a/scripts/ogr2ogr/2.2.2/.travis.yml
+++ b/scripts/ogr2ogr/2.2.2/.travis.yml
@@ -1,0 +1,13 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.3
+      compiler: clang
+    - os: linux
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/ogr2ogr/2.2.2/script.sh
+++ b/scripts/ogr2ogr/2.2.2/script.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+MASON_NAME=ogr2ogr
+MASON_VERSION=2.2.2
+MASON_LIB_FILE=bin/ogr2ogr
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
+    mkdir -p ${MASON_BUILD_PATH}
+}
+
+function mason_prepare_compile {
+    ${MASON_DIR}/mason install gdal ${MASON_VERSION}
+    GDAL_PREFIX=$(${MASON_DIR}/mason prefix gdal ${MASON_VERSION})
+}
+
+function mason_compile {
+    mkdir -p ${MASON_PREFIX}/include
+    mkdir -p ${MASON_PREFIX}/share
+    mkdir -p ${MASON_PREFIX}/bin
+    cp -r ${GDAL_PREFIX}/bin/gdal-config ${MASON_PREFIX}/bin/
+    cp -r ${GDAL_PREFIX}/include/* ${MASON_PREFIX}/include/
+    cp -r ${GDAL_PREFIX}/share/* ${MASON_PREFIX}/share/
+    cp -r ${GDAL_PREFIX}/bin/ogr2ogr ${MASON_PREFIX}/bin/
+}
+
+function mason_cflags {
+    echo "-I${MASON_PREFIX}/include"
+}
+
+function mason_ldflags {
+    echo $(${MASON_PREFIX}/bin/gdal-config --dep-libs --libs)
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"


### PR DESCRIPTION
New packages for ogr2ogr and libgdal using binaries from gdal 2.2.2. These packages are very small (< 12 MB) while the `gdal` package is > 325 MB.

refs #500