### PR TITLE
Default to clang++ 5.0.0 as base compiler

### DIFF
--- a/utils/toolchain.sh
+++ b/utils/toolchain.sh
@@ -3,10 +3,10 @@
 set -eu
 set -o pipefail
 
-CLANG_VERSION="3.9.1"
+CLANG_VERSION="5.0.0"
 ./mason install clang++ ${CLANG_VERSION}
 export PATH=$(./mason prefix clang++ ${CLANG_VERSION})/bin:${PATH}
-export CXX=clang++-3.9
-export CC=clang-3.9
+export CXX=clang++
+export CC=clang
 
 set +eu


### PR DESCRIPTION
This upgrades the default compiler we use to build binaries on travis from clang++ 3.9.1 to 5.0.0.

My plan is is to keep incrementing this default as new clang++ versions come out, to ensure our binaries benefit from the latest compiler optimizations and new features.

In particular, clang++ 5 unlocks the ability to target the CXX11 ABI and the ability to compile c++17 code. I'm working on packaging https://build2.org (to be able to experiment with it) and build2 requires c++17 but I also anticipate other tools will begin needing it soon.

Before merging:

 - [x] ensure all tests pass with mason unit tests
 - [x] Test clang 3.9.1 binaries linked against source code compiled with clang++ 5. This should work fine, but want to make sure it works before merging. My testcase will be libmapnik (and all deps) built with clang 3.9.1 and node-mapnik build with clang++ 5.

Known gocha: code compiled with `-flto` is not portable across clang++ major versions. So you cannot have `-flto` code build with clang 3 linked with clang 5 lto code. 