### PR TITLE
build2 0.6.2

### DIFF
--- a/scripts/build2/0.6.2/.travis.yml
+++ b/scripts/build2/0.6.2/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.3
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/build2/0.6.2/script.sh
+++ b/scripts/build2/0.6.2/script.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+MASON_NAME=build2
+MASON_VERSION=0.6.2
+MASON_LIB_FILE=bin/bpkg
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        https://download.build2.org/${MASON_VERSION}/build2-toolchain-${MASON_VERSION}.tar.gz \
+        081d33ae551732c3b9cf6777c1055c1e415af496
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/build2-toolchain-${MASON_VERSION}
+}
+
+function mason_compile {
+    # NOTE: build2 requires a c++17 capable compiler and it uses CXX11_ABI features in libstdc++ (so it must be build with _GLIBCXX_USE_CXX11_ABI=1)
+    # Since we want the binaries to be portable to pre cxx11 abi machines, we statically link against libc++ instead of linking against libstdc++
+    # note with clang 4.x will hit "header 'shared_mutex' not found and cannot be generated" because c++17 support is lacking
+    LDFLAGS=""
+    if [[ $(uname -s) == 'Linux' ]]; then
+        LDFLAGS="-Wl,--start-group -lc++ -lc++abi -pthread -lrt"
+    fi
+    perl -i -p -e "s/pthread/pthread -stdlib=libc++ ${LDFLAGS} /g;" ./build2/bootstrap.sh
+    perl -i -p -e "s/=static/=static config.bin.exe.lib=static config.cxx.coptions=-stdlib=libc++ config.cxx.loptions='${LDFLAGS}' /g;" ./build.sh
+    perl -i -p -e "s/suffix=-stage /suffix=-stage config.bin.lib=static config.bin.exe.lib=static config.cxx.coptions=-stdlib=libc++ config.cxx.loptions='${LDFLAGS}' /g;" ./build.sh
+    perl -i -p -e "s/coptions=-O3 /coptions=-O3 config.bin.lib=static config.bin.exe.lib=static config.cxx.coptions=-stdlib=libc++ config.cxx.loptions='${LDFLAGS}' /g;" ./build.sh
+    ./build.sh --install-dir ${MASON_PREFIX} --sudo "" --trust yes ${CXX:-clang++}
+}
+
+function mason_cflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+mason_run "$@"


### PR DESCRIPTION
Adds the https://build2.org package which includes two command line programs: `b` and `bpkg`. My motivation for packaging this is to be easily able to learn how build2 works, as there are some good ideas in its design. Depends on #504 for c++17 support (which build2 code requires).