### PR TITLE
libcurl 7.50.2 with openssl 1.0.2d

### DIFF
--- a/scripts/libcurl/7.50.2/script.sh
+++ b/scripts/libcurl/7.50.2/script.sh
@@ -5,7 +5,7 @@ MASON_VERSION=7.50.2
 MASON_LIB_FILE=lib/libcurl.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/libcurl.pc
 
-OPENSSL_VERSION=1.0.2
+OPENSSL_VERSION=1.0.2d
 
 . ${MASON_DIR}/mason.sh
 


### PR DESCRIPTION
Moves from openssl 1.0.2 to 1.0.2d for libcurl 7.50.2