### PR TITLE
fix nunicode 1.7.1 build

### DIFF
--- a/scripts/nunicode/1.7.1/.travis.yml
+++ b/scripts/nunicode/1.7.1/.travis.yml
@@ -31,7 +31,7 @@ addons:
     packages: [ 'libstdc++-5-dev', 'cmake', 'cmake-data' ]
 
 install:
-- if [[ $(uname -s) == 'Darwin' ]]; then brew install cmake; fi
+- if [[ $(uname -s) == 'Darwin' && $(which brew) == '' ]]; then brew install cmake; fi
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/nunicode/1.7.1/script.sh
+++ b/scripts/nunicode/1.7.1/script.sh
@@ -23,11 +23,20 @@ function mason_compile {
     # patch CMakeLists file
     cat ../CMakeLists.txt | sed -e '/find_package.Sqlite3/ s/^/#/' > ../CMakeLists.txt.new && cp ../CMakeLists.txt.new ../CMakeLists.txt
 
-    cmake \
-        -DCMAKE_BUILD_TYPE=RELEASE \
-        -DCMAKE_INSTALL_PREFIX=${MASON_PREFIX} \
-        ${MASON_CMAKE_TOOLCHAIN} \
-        ..
+    if [ ${MASON_PLATFORM} = 'android' ]; then
+        ${MASON_DIR}/utils/android.sh > toolchain.cmake
+
+        cmake \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=${MASON_PREFIX} \
+            -DCMAKE_TOOLCHAIN_FILE=toolchain.cmake \
+            ..
+    else
+        cmake \
+            -DCMAKE_BUILD_TYPE=RELEASE \
+            -DCMAKE_INSTALL_PREFIX=${MASON_PREFIX} \
+            ..
+    fi
 
     make install -j${MASON_CONCURRENCY}
 }


### PR DESCRIPTION
Was using an outdated global `${MASON_CMAKE_TOOLCHAIN}`