### PR TITLE
LLVM 7.0.0

### DIFF
--- a/scripts/clang++/7.0.0/.travis.yml
+++ b/scripts/clang++/7.0.0/.travis.yml
@@ -1,0 +1,11 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+    - os: linux
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/clang++/7.0.0/script.sh
+++ b/scripts/clang++/7.0.0/script.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# dynamically take name of package from directory
+MASON_NAME=$(basename $(dirname $HERE))
+# dynamically take the version of the package from directory
+MASON_VERSION=$(basename $HERE)
+MASON_LIB_FILE=bin/${MASON_NAME}
+
+. ${MASON_DIR}/mason.sh
+
+# inherit all functions from base
+source ${HERE}/../../${MASON_NAME}/base/common.sh
+
+mason_run "$@"

--- a/scripts/clang-format/7.0.0/.travis.yml
+++ b/scripts/clang-format/7.0.0/.travis.yml
@@ -1,0 +1,11 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+    - os: linux
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/clang-format/7.0.0/script.sh
+++ b/scripts/clang-format/7.0.0/script.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# dynamically take name of package from directory
+MASON_NAME=$(basename $(dirname $HERE))
+# dynamically take the version of the package from directory
+MASON_VERSION=$(basename $HERE)
+MASON_LIB_FILE=bin/${MASON_NAME}
+
+. ${MASON_DIR}/mason.sh
+
+# inherit all functions from base
+source ${HERE}/../../${MASON_NAME}/base/common.sh
+
+mason_run "$@"

--- a/scripts/clang-tidy/7.0.0/.travis.yml
+++ b/scripts/clang-tidy/7.0.0/.travis.yml
@@ -1,0 +1,11 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+    - os: linux
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/clang-tidy/7.0.0/script.sh
+++ b/scripts/clang-tidy/7.0.0/script.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# dynamically take name of package from directory
+MASON_NAME=$(basename $(dirname $HERE))
+# dynamically take the version of the package from directory
+MASON_VERSION=$(basename $HERE)
+MASON_LIB_FILE=bin/${MASON_NAME}
+
+. ${MASON_DIR}/mason.sh
+
+# inherit all functions from base
+source ${HERE}/../../${MASON_NAME}/base/common.sh
+
+mason_run "$@"

--- a/scripts/include-what-you-use/7.0.0/.travis.yml
+++ b/scripts/include-what-you-use/7.0.0/.travis.yml
@@ -1,0 +1,11 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+    - os: linux
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/include-what-you-use/7.0.0/script.sh
+++ b/scripts/include-what-you-use/7.0.0/script.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# dynamically take name of package from directory
+MASON_NAME=$(basename $(dirname $HERE))
+# dynamically take the version of the package from directory
+MASON_VERSION=$(basename $HERE)
+MASON_LIB_FILE=bin/${MASON_NAME}
+
+. ${MASON_DIR}/mason.sh
+
+# inherit all functions from base
+source ${HERE}/../../${MASON_NAME}/base/common.sh
+
+mason_run "$@"

--- a/scripts/lldb/7.0.0/.travis.yml
+++ b/scripts/lldb/7.0.0/.travis.yml
@@ -1,0 +1,11 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+    - os: linux
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/lldb/7.0.0/script.sh
+++ b/scripts/lldb/7.0.0/script.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# dynamically take name of package from directory
+MASON_NAME=$(basename $(dirname $HERE))
+# dynamically take the version of the package from directory
+MASON_VERSION=$(basename $HERE)
+MASON_LIB_FILE=bin/${MASON_NAME}
+
+. ${MASON_DIR}/mason.sh
+
+# inherit all functions from base
+source ${HERE}/../../${MASON_NAME}/base/common.sh
+
+mason_run "$@"

--- a/scripts/llvm-cov/7.0.0/.travis.yml
+++ b/scripts/llvm-cov/7.0.0/.travis.yml
@@ -1,0 +1,11 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+    - os: linux
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/llvm-cov/7.0.0/script.sh
+++ b/scripts/llvm-cov/7.0.0/script.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# dynamically take name of package from directory
+MASON_NAME=$(basename $(dirname $HERE))
+# dynamically take the version of the package from directory
+MASON_VERSION=$(basename $HERE)
+MASON_LIB_FILE=bin/${MASON_NAME}
+
+. ${MASON_DIR}/mason.sh
+
+# inherit all functions from base
+source ${HERE}/../../${MASON_NAME}/base/common.sh
+
+mason_run "$@"

--- a/scripts/llvm/7.0.0/.travis.yml
+++ b/scripts/llvm/7.0.0/.travis.yml
@@ -1,0 +1,4 @@
+language: generic
+
+script:
+- echo "nothing to do since travis cannot compile something as large as llvm"

--- a/scripts/llvm/7.0.0/README.md
+++ b/scripts/llvm/7.0.0/README.md
@@ -1,0 +1,3 @@
+### llvm v7.x
+
+Development package of llvm git head

--- a/scripts/llvm/7.0.0/script.sh
+++ b/scripts/llvm/7.0.0/script.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+# dynamically take name of package from directory
+MASON_NAME=$(basename $(dirname $HERE))
+# dynamically take the version of the package from directory
+MASON_VERSION=$(basename $HERE)
+# inherit all functions from llvm base
+source ${HERE}/../../${MASON_NAME}/base/common.sh
+
+function setup_base_tools() {
+    get_llvm_project "http://llvm.org/git/llvm.git"              ${MASON_BUILD_PATH}
+    get_llvm_project "http://llvm.org/git/clang.git"             ${MASON_BUILD_PATH}/tools/clang
+    get_llvm_project "http://llvm.org/git/compiler-rt.git"       ${MASON_BUILD_PATH}/projects/compiler-rt
+    if [[ ${BUILD_AND_LINK_LIBCXX} == true ]]; then
+        get_llvm_project "http://llvm.org/git/libcxx.git"            ${MASON_BUILD_PATH}/projects/libcxx
+        get_llvm_project "http://llvm.org/git/libcxxabi.git"         ${MASON_BUILD_PATH}/projects/libcxxabi
+        get_llvm_project "http://llvm.org/git/libunwind.git"         ${MASON_BUILD_PATH}/projects/libunwind
+    fi
+    get_llvm_project "http://llvm.org/git/openmp.git"            ${MASON_BUILD_PATH}/projects/openmp
+    get_llvm_project "http://llvm.org/git/lld.git"               ${MASON_BUILD_PATH}/tools/lld
+    get_llvm_project "http://llvm.org/git/clang-tools-extra.git" ${MASON_BUILD_PATH}/tools/clang/tools/extra
+    get_llvm_project "http://llvm.org/git/lldb.git"              ${MASON_BUILD_PATH}/tools/lldb
+    get_llvm_project "http://llvm.org/git/polly.git"             ${MASON_BUILD_PATH}/tools/polly
+    get_llvm_project "https://github.com/include-what-you-use/include-what-you-use.git"  ${MASON_BUILD_PATH}/tools/clang/tools/include-what-you-use
+}
+
+mason_run "$@"

--- a/scripts/llvm/base/README.md
+++ b/scripts/llvm/base/README.md
@@ -172,7 +172,7 @@ We run the docker image to build the package on linux. We map volumes such that 
 docker create -v $(pwd)/ccache:/ccache --name ccache mason-llvm
 
 LLVM_VERSION="4.0.2"
-mkdir ccache
+mkdir -p ccache
 time docker run -it \
   -e CCACHE_DIR=/ccache \
   -e LLVM_VERSION="${LLVM_VERSION}" \


### PR DESCRIPTION
This adds a new package+sub packages for LLVM 7.x (current HEAD master).

In addition it applies advances to the build script shared by all versions which unlocks:

 - The ability to compile a C++ binary that does not depend on libgcc_s (uses compiler RT instead when `-rtlib=compiler-rt` is passed)
 - The ability to compile a C++ binary against a fully static libc++.a, libc++abi.a, and libunwind.a
 - The ability to support WASM as a target.

Specific changes are:

 - Now also building `openmp` and `polly` support
 - Adds support for building web assembly `-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=WebAssembly`
 - Now correctly disabling assertions for more sub-projects:
    - LIBUNWIND_ENABLE_ASSERTIONS=OFF
    - LIBCXXABI_ENABLE_ASSERTIONS=OFF
 - Now correctly requesting compiler-rt be used in place of libgcc
    - LIBUNWIND_USE_COMPILER_RT=ON
    - LIBCXXABI_USE_COMPILER_RT=ON
    - SANITIZER_USE_COMPILER_RT=ON
    - LIBUNWIND_USE_COMPILER_RT=ON
 - Now setting `LLDB_CODESIGN_IDENTITY=''` to avoid error on OS X with missing `debugserver`
 - Turned off `-DLLVM_CREATE_XCODE_TOOLCHAIN=OFF` since we are no longer running `install-xcode-toolchain` target
 - Fix to properly symlink clang++-MAJOR.MINOR even when upstream head is different than
   the directory version name (likely when building from HEAD)

refs https://github.com/mapbox/mason/pull/545#issuecomment-367082479
