### PR TITLE
tippecanoe 1.27.7 + libc++

### DIFF
--- a/scripts/tippecanoe/1.27.7-libstdcxx/.travis.yml
+++ b/scripts/tippecanoe/1.27.7-libstdcxx/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+sudo: false
+
+matrix:
+  include:
+    - os: osx
+      compiler: clang
+      osx_image: xcode8.2      
+    - os: linux
+      compiler: clang
+      addons:
+        apt:
+          sources: [ 'ubuntu-toolchain-r-test' ]
+          packages: [ 'libstdc++-5-dev' ]
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/tippecanoe/1.27.7-libstdcxx/script.sh
+++ b/scripts/tippecanoe/1.27.7-libstdcxx/script.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+MASON_NAME=tippecanoe
+MASON_VERSION=1.27.7
+MASON_LIB_FILE=bin/tippecanoe
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        https://github.com/mapbox/tippecanoe/archive/${MASON_VERSION}.tar.gz \
+        46a839d0cd8664b116063002f6008499a2bec963
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
+}
+
+SQLITE_VERSION=3.16.2
+
+function mason_prepare_compile {
+    ${MASON_DIR}/mason install sqlite ${SQLITE_VERSION}
+    MASON_SQLITE=$(${MASON_DIR}/mason prefix sqlite ${SQLITE_VERSION})
+}
+
+function mason_compile {
+    # knock out /usr/local to ensure libsqlite without a doubt that
+    # sqlite from from mason is used
+    perl -i -p -e "s/-L\/usr\/local\/lib//g;" Makefile
+    perl -i -p -e "s/-I\/usr\/local\/include//g;" Makefile
+
+
+    PREFIX=${MASON_PREFIX} \
+    PATH=${MASON_SQLITE}/bin:${PATH} \
+    CXXFLAGS="${CXXFLAGS} -I${MASON_SQLITE}/include" \
+    LDFLAGS="${LDFLAGS} -L${MASON_SQLITE}/lib -ldl -lpthread" make
+
+    PREFIX=${MASON_PREFIX} \
+    PATH=${MASON_SQLITE}/bin:${PATH} \
+    CXXFLAGS="${CXXFLAGS} -I${MASON_SQLITE}/include" \
+    LDFLAGS="${LDFLAGS} -L${MASON_SQLITE}/lib -ldl -lpthread" make install
+}
+
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"

--- a/scripts/tippecanoe/1.27.7-libstdcxx/script.sh
+++ b/scripts/tippecanoe/1.27.7-libstdcxx/script.sh
@@ -1,19 +1,19 @@
 #!/usr/bin/env bash
 
 MASON_NAME=tippecanoe
-MASON_VERSION=1.27.7
+MASON_VERSION=1.27.7-libstdcxx
 MASON_LIB_FILE=bin/tippecanoe
 
 . ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
-        https://github.com/mapbox/tippecanoe/archive/${MASON_VERSION}.tar.gz \
+        https://github.com/mapbox/tippecanoe/archive/1.27.7.tar.gz \
         46a839d0cd8664b116063002f6008499a2bec963
 
     mason_extract_tar_gz
 
-    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-1.27.7
 }
 
 SQLITE_VERSION=3.16.2

--- a/scripts/tippecanoe/1.27.7/.travis.yml
+++ b/scripts/tippecanoe/1.27.7/.travis.yml
@@ -1,0 +1,18 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+    - os: linux
+      compiler: clang
+      sudo: false
+      addons:
+        apt:
+          sources: [ 'ubuntu-toolchain-r-test' ]
+          packages: [ 'libstdc++-4.9-dev' ]
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/tippecanoe/1.27.7/.travis.yml
+++ b/scripts/tippecanoe/1.27.7/.travis.yml
@@ -8,10 +8,6 @@ matrix:
     - os: linux
       compiler: clang
       sudo: false
-      addons:
-        apt:
-          sources: [ 'ubuntu-toolchain-r-test' ]
-          packages: [ 'libstdc++-4.9-dev' ]
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/tippecanoe/1.27.7/script.sh
+++ b/scripts/tippecanoe/1.27.7/script.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+MASON_NAME=tippecanoe
+MASON_VERSION=1.27.7
+MASON_LIB_FILE=bin/tippecanoe
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        https://github.com/mapbox/tippecanoe/archive/${MASON_VERSION}.tar.gz \
+        46a839d0cd8664b116063002f6008499a2bec963
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
+}
+
+SQLITE_VERSION=3.16.2
+
+function mason_prepare_compile {
+    LLVM_VERSION="7.0.0"
+    ${MASON_DIR}/mason install llvm ${LLVM_VERSION}
+    MASON_LLVM=$(${MASON_DIR}/mason prefix llvm ${LLVM_VERSION})
+    ${MASON_DIR}/mason install sqlite ${SQLITE_VERSION}
+    MASON_SQLITE=$(${MASON_DIR}/mason prefix sqlite ${SQLITE_VERSION})
+}
+
+function mason_compile {
+    # Use llvm 7.x to statically link libc++
+    # https://github.com/mapbox/mason/pull/545#issuecomment-367082479
+    export CXX="${MASON_LLVM}/bin/clang++"
+    export CC="${MASON_LLVM}/bin/clang"
+    LDFLAGS="${LDFLAGS} -stdlib=libc++"
+    if [[ $(uname -s) == 'Linux' ]]; then
+        CXXFLAGS="-nostdinc++ -I${MASON_LLVM}/include/c++/v1"
+        LDFLAGS="${LDFLAGS} -nostdlib++ ${MASON_LLVM}/lib/libc++.a"
+        LDFLAGS="${LDFLAGS} ${MASON_LLVM}/lib/libc++abi.a"
+        LDFLAGS="${LDFLAGS} ${MASON_LLVM}/lib/libunwind.a -rtlib=compiler-rt"
+    fi
+
+    # knock out /usr/local to ensure libsqlite without a doubt that
+    # sqlite from from mason is used
+    perl -i -p -e "s/-L\/usr\/local\/lib//g;" Makefile
+    perl -i -p -e "s/-I\/usr\/local\/include//g;" Makefile
+
+
+    PREFIX=${MASON_PREFIX} \
+    PATH=${MASON_SQLITE}/bin:${PATH} \
+    CXXFLAGS="${CXXFLAGS} -I${MASON_SQLITE}/include" \
+    LDFLAGS="${LDFLAGS} -L${MASON_SQLITE}/lib -ldl -lpthread" make
+
+    PREFIX=${MASON_PREFIX} \
+    PATH=${MASON_SQLITE}/bin:${PATH} \
+    CXXFLAGS="${CXXFLAGS} -I${MASON_SQLITE}/include" \
+    LDFLAGS="${LDFLAGS} -L${MASON_SQLITE}/lib -ldl -lpthread" make install
+}
+
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"

--- a/scripts/tippecanoe/1.27.9/.travis.yml
+++ b/scripts/tippecanoe/1.27.9/.travis.yml
@@ -1,0 +1,14 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+    - os: linux
+      compiler: clang
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/tippecanoe/1.27.9/script.sh
+++ b/scripts/tippecanoe/1.27.9/script.sh
@@ -9,7 +9,7 @@ MASON_LIB_FILE=bin/tippecanoe
 function mason_load_source {
     mason_download \
         https://github.com/mapbox/tippecanoe/archive/${MASON_VERSION}.tar.gz \
-        36738c3f36495fc6fa0e8b90f6c0010c5d435c7c
+        e2a58d1cf9c033ce0285e8242e35c427ace2ccaa
 
     mason_extract_tar_gz
 

--- a/scripts/tippecanoe/1.27.9/script.sh
+++ b/scripts/tippecanoe/1.27.9/script.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+MASON_NAME=tippecanoe
+MASON_VERSION=1.27.9
+MASON_LIB_FILE=bin/tippecanoe
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        https://github.com/mapbox/tippecanoe/archive/${MASON_VERSION}.tar.gz \
+        36738c3f36495fc6fa0e8b90f6c0010c5d435c7c
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
+}
+
+SQLITE_VERSION=3.16.2
+
+function mason_prepare_compile {
+    LLVM_VERSION="7.0.0"
+    ${MASON_DIR}/mason install llvm ${LLVM_VERSION}
+    MASON_LLVM=$(${MASON_DIR}/mason prefix llvm ${LLVM_VERSION})
+    ${MASON_DIR}/mason install sqlite ${SQLITE_VERSION}
+    MASON_SQLITE=$(${MASON_DIR}/mason prefix sqlite ${SQLITE_VERSION})
+}
+
+function mason_compile {
+    # Use llvm 7.x to statically link libc++
+    # https://github.com/mapbox/mason/pull/545#issuecomment-367082479
+    export CXX="${MASON_LLVM}/bin/clang++"
+    export CC="${MASON_LLVM}/bin/clang"
+    LDFLAGS="${LDFLAGS} -stdlib=libc++"
+    if [[ $(uname -s) == 'Linux' ]]; then
+        CXXFLAGS="-nostdinc++ -I${MASON_LLVM}/include/c++/v1"
+        LDFLAGS="${LDFLAGS} -nostdlib++ ${MASON_LLVM}/lib/libc++.a"
+        LDFLAGS="${LDFLAGS} ${MASON_LLVM}/lib/libc++abi.a"
+        LDFLAGS="${LDFLAGS} ${MASON_LLVM}/lib/libunwind.a -rtlib=compiler-rt"
+    fi
+
+    # knock out /usr/local to ensure libsqlite without a doubt that
+    # sqlite from from mason is used
+    perl -i -p -e "s/-L\/usr\/local\/lib//g;" Makefile
+    perl -i -p -e "s/-I\/usr\/local\/include//g;" Makefile
+
+
+    PREFIX=${MASON_PREFIX} \
+    PATH=${MASON_SQLITE}/bin:${PATH} \
+    CXXFLAGS="${CXXFLAGS} -I${MASON_SQLITE}/include" \
+    LDFLAGS="${LDFLAGS} -L${MASON_SQLITE}/lib -ldl -lpthread" make
+
+    PREFIX=${MASON_PREFIX} \
+    PATH=${MASON_SQLITE}/bin:${PATH} \
+    CXXFLAGS="${CXXFLAGS} -I${MASON_SQLITE}/include" \
+    LDFLAGS="${LDFLAGS} -L${MASON_SQLITE}/lib -ldl -lpthread" make install
+}
+
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"


### PR DESCRIPTION
This adds the latest tippecanoe release in a unique and forward looking way. This switches from building against old libstdc++-4.9 (for some portability to >= ubuntu trusty) to statically linking the latest version of libc++, which enables better performance and fuller portability. These binaries should work against any linux system based on glibc (amazon linux, all debian systems, fedora/rhel, etc).

This uses the new llvm compiler package with supports static linking to libc++: https://github.com/mapbox/mason/pull/545#issuecomment-367082479

/cc @mick @ericfischer 