### PR TITLE
Protobuf 3.5.1 cxx11abi

### DIFF
--- a/scripts/protobuf/3.5.1-cxx11abi/.travis.yml
+++ b/scripts/protobuf/3.5.1-cxx11abi/.travis.yml
@@ -1,0 +1,19 @@
+matrix:
+  include:
+    - os: linux
+      sudo: required
+      dist: xenial
+      addons:
+        apt:
+          packages:
+           - libstdc++-5-dev
+           - g++-5
+
+# override install to prefer g++ instead of clang++
+install:
+- export CXX=g++-5
+- export CC=gcc-5
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/protobuf/3.5.1-cxx11abi/script.sh
+++ b/scripts/protobuf/3.5.1-cxx11abi/script.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+LIB_VERSION=3.5.1
+
+MASON_NAME=protobuf
+MASON_VERSION=${LIB_VERSION}-cxx11abi
+
+if [ "${MASON_PLATFORM}" == "ios" ]; then
+    MASON_LIB_FILE=lib-isim-i386/libprotobuf.a
+    MASON_PKGCONFIG_FILE=lib-isim-i386/pkgconfig/protobuf.pc
+else
+    MASON_LIB_FILE=lib/libprotobuf.a
+    MASON_PKGCONFIG_FILE=lib/pkgconfig/protobuf.pc
+fi
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        https://github.com/google/protobuf/releases/download/v${LIB_VERSION}/protobuf-cpp-${LIB_VERSION}.tar.gz \
+        567b4000dc3666fb9de712beddfcf24a80e857f0
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${LIB_VERSION}
+}
+
+function mason_compile {
+    # note CFLAGS overrides defaults (-O2 -g -DNDEBUG) so we need to add optimization flags back
+    export CFLAGS="${CFLAGS} -O3 -DNDEBUG"
+    export CXXFLAGS="${CXXFLAGS} -O3 -DNDEBUG -D_GLIBCXX_USE_CXX11_ABI=1"
+
+    if [ "${MASON_PLATFORM}" == "android" ]; then
+        export LDFLAGS="${LDFLAGS} -llog"
+    fi
+
+    export PROTOBUF_XC_ARG=""
+    if [ "${MASON_PLATFORM}" == "android" ] || [ "${MASON_PLATFORM}" == "ios" ]; then
+        export PROTOBUF_XC_ARG="${PROTOBUF_XC_ARG} --with-protoc=protoc"
+    fi
+
+    if [ "${MASON_PLATFORM}" == "ios" ]; then
+        export MACOSX_DEPLOYMENT_TARGET="10.8"
+    fi
+
+    if [ -f Makefile ]; then
+        make distclean
+    fi
+
+    ./configure \
+        --prefix=${MASON_PREFIX} \
+        ${MASON_HOST_ARG} \
+        ${PROTOBUF_XC_ARG} \
+        --enable-static --disable-shared \
+        --disable-debug --without-zlib \
+        --disable-dependency-tracking
+
+    make V=1 -j${MASON_CONCURRENCY}
+    make install -j${MASON_CONCURRENCY}
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"

--- a/scripts/protobuf/3.5.1/.travis.yml
+++ b/scripts/protobuf/3.5.1/.travis.yml
@@ -30,8 +30,7 @@ addons:
     sources:
      - ubuntu-toolchain-r-test
     packages:
-     - libstdc++-4.9-dev
-     - libstdc++6
+     - libstdc++-5-dev
 
 script:
 - |

--- a/scripts/protobuf/3.5.1/script.sh
+++ b/scripts/protobuf/3.5.1/script.sh
@@ -1,26 +1,28 @@
 #!/usr/bin/env bash
 
-MASON_NAME=protobuf
-MASON_VERSION=3.5.1
+LIB_VERSION=3.5.1
 
-if [[ ${MASON_PLATFORM} == 'ios' ]]; then
-    MASON_LIB_FILE=lib-isim-i386/libprotobuf-lite.a
-    MASON_PKGCONFIG_FILE=lib-isim-i386/pkgconfig/protobuf-lite.pc
+MASON_NAME=protobuf
+MASON_VERSION=${LIB_VERSION}
+
+if [ "${MASON_PLATFORM}" == "ios" ]; then
+    MASON_LIB_FILE=lib-isim-i386/libprotobuf.a
+    MASON_PKGCONFIG_FILE=lib-isim-i386/pkgconfig/protobuf.pc
 else
-    MASON_LIB_FILE=lib/libprotobuf-lite.a
-    MASON_PKGCONFIG_FILE=lib/pkgconfig/protobuf-lite.pc
+    MASON_LIB_FILE=lib/libprotobuf.a
+    MASON_PKGCONFIG_FILE=lib/pkgconfig/protobuf.pc
 fi
 
 . ${MASON_DIR}/mason.sh
 
 function mason_load_source {
     mason_download \
-        https://github.com/google/protobuf/releases/download/v${MASON_VERSION}/protobuf-cpp-${MASON_VERSION}.tar.gz \
+        https://github.com/google/protobuf/releases/download/v${LIB_VERSION}/protobuf-cpp-${LIB_VERSION}.tar.gz \
         567b4000dc3666fb9de712beddfcf24a80e857f0
 
     mason_extract_tar_gz
 
-    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${LIB_VERSION}
 }
 
 function mason_compile {
@@ -28,16 +30,16 @@ function mason_compile {
     export CFLAGS="${CFLAGS} -O3 -DNDEBUG"
     export CXXFLAGS="${CXXFLAGS} -O3 -DNDEBUG"
 
-    if [ ${MASON_PLATFORM} == 'android' ]; then
+    if [ "${MASON_PLATFORM}" == "android" ]; then
         export LDFLAGS="${LDFLAGS} -llog"
     fi
 
     export PROTOBUF_XC_ARG=""
-    if [ ${MASON_PLATFORM} == 'android' ] || [ ${MASON_PLATFORM} == 'ios' ]; then
+    if [ "${MASON_PLATFORM}" == "android" ] || [ "${MASON_PLATFORM}" == "ios" ]; then
         export PROTOBUF_XC_ARG="${PROTOBUF_XC_ARG} --with-protoc=protoc"
     fi
 
-    if [ ${MASON_PLATFORM} == 'ios' ]; then
+    if [ "${MASON_PLATFORM}" == "ios" ]; then
         export MACOSX_DEPLOYMENT_TARGET="10.8"
     fi
 


### PR DESCRIPTION
Thanks to Travis now _unofficially_ supporting Ubuntu Xenial, we were finally able to compile protobuf 3.5.1 using the new C++11 ABI thanks to a sane GCC 5 environment.