### PR TITLE
Llvm 6.0.0 release override

### DIFF
--- a/scripts/clang++/6.0.0/script.sh
+++ b/scripts/clang++/6.0.0/script.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# For context on this file see https://github.com/mapbox/mason/blob/master/scripts/llvm/base/README.md
+
 # dynamically determine the path to this package
 HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
 

--- a/scripts/clang-format/6.0.0/script.sh
+++ b/scripts/clang-format/6.0.0/script.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# For context on this file see https://github.com/mapbox/mason/blob/master/scripts/llvm/base/README.md
+
 # dynamically determine the path to this package
 HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
 

--- a/scripts/clang-tidy/6.0.0/script.sh
+++ b/scripts/clang-tidy/6.0.0/script.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# For context on this file see https://github.com/mapbox/mason/blob/master/scripts/llvm/base/README.md
+
 # dynamically determine the path to this package
 HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
 

--- a/scripts/include-what-you-use/6.0.0/script.sh
+++ b/scripts/include-what-you-use/6.0.0/script.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# For context on this file see https://github.com/mapbox/mason/blob/master/scripts/llvm/base/README.md
+
 # dynamically determine the path to this package
 HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
 

--- a/scripts/lldb/6.0.0/script.sh
+++ b/scripts/lldb/6.0.0/script.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# For context on this file see https://github.com/mapbox/mason/blob/master/scripts/llvm/base/README.md
+
 # dynamically determine the path to this package
 HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
 

--- a/scripts/llvm-cov/6.0.0/script.sh
+++ b/scripts/llvm-cov/6.0.0/script.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# For context on this file see https://github.com/mapbox/mason/blob/master/scripts/llvm/base/README.md
+
 # dynamically determine the path to this package
 HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
 

--- a/scripts/llvm/6.0.0/README.md
+++ b/scripts/llvm/6.0.0/README.md
@@ -1,3 +1,1 @@
-### llvm v4.x
-
-Development package of llvm git head
+For context on this file see https://github.com/mapbox/mason/blob/master/scripts/llvm/base/README.md

--- a/scripts/llvm/6.0.0/script.sh
+++ b/scripts/llvm/6.0.0/script.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# For context on this file see https://github.com/mapbox/mason/blob/master/scripts/llvm/base/README.md
+
 # dynamically determine the path to this package
 HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
 # dynamically take name of package from directory
@@ -9,19 +11,10 @@ MASON_VERSION=$(basename $HERE)
 # inherit all functions from llvm base
 source ${HERE}/../../${MASON_NAME}/base/common.sh
 
-function setup_base_tools() {
-    get_llvm_project "http://llvm.org/git/llvm.git"              ${MASON_BUILD_PATH}
-    get_llvm_project "http://llvm.org/git/clang.git"             ${MASON_BUILD_PATH}/tools/clang
-    get_llvm_project "http://llvm.org/git/compiler-rt.git"       ${MASON_BUILD_PATH}/projects/compiler-rt
-    if [[ ${BUILD_AND_LINK_LIBCXX} == true ]]; then
-        get_llvm_project "http://llvm.org/git/libcxx.git"            ${MASON_BUILD_PATH}/projects/libcxx
-        get_llvm_project "http://llvm.org/git/libcxxabi.git"         ${MASON_BUILD_PATH}/projects/libcxxabi
-        get_llvm_project "http://llvm.org/git/libunwind.git"         ${MASON_BUILD_PATH}/projects/libunwind
-    fi
-    get_llvm_project "http://llvm.org/git/lld.git"               ${MASON_BUILD_PATH}/tools/lld
-    get_llvm_project "http://llvm.org/git/clang-tools-extra.git" ${MASON_BUILD_PATH}/tools/clang/tools/extra
-    get_llvm_project "http://llvm.org/git/lldb.git"              ${MASON_BUILD_PATH}/tools/lldb
-    get_llvm_project "https://github.com/include-what-you-use/include-what-you-use.git"  ${MASON_BUILD_PATH}/tools/clang/tools/include-what-you-use
-}
+# broken with:
+# ../tools/clang/tools/include-what-you-use/iwyu_ast_util.cc:455:3: error: use of undeclared identifier 'printTemplateArgumentList'
+# function setup_release() {
+#     get_llvm_project "https://github.com/include-what-you-use/include-what-you-use.git"  ${MASON_BUILD_PATH}/tools/clang/tools/include-what-you-use "" 5788b34c2e22fa97630c4a5b1153d828698f9ac1
+# }
 
 mason_run "$@"

--- a/scripts/llvm/6.0.0/script.sh
+++ b/scripts/llvm/6.0.0/script.sh
@@ -12,7 +12,7 @@ MASON_VERSION=$(basename $HERE)
 source ${HERE}/../../${MASON_NAME}/base/common.sh
 
 function setup_release() {
-    get_llvm_project "https://github.com/include-what-you-use/include-what-you-use.git"  ${MASON_BUILD_PATH}/tools/clang/tools/include-what-you-use "" f1ec249
+    get_llvm_project "https://github.com/include-what-you-use/include-what-you-use.git"  ${MASON_BUILD_PATH}/tools/clang/tools/include-what-you-use "" 4bfe5d6
     # FIX 6.0.0 specific libcxx bug: https://github.com/llvm-mirror/libcxx/commit/68b20ca4d9c4bee2c2ad5a9240599b3e4b78d0ba
     # This will need to be removed in upcoming releases
     (cd ${MASON_BUILD_PATH}/projects/libcxx &&

--- a/scripts/llvm/6.0.0/script.sh
+++ b/scripts/llvm/6.0.0/script.sh
@@ -11,10 +11,12 @@ MASON_VERSION=$(basename $HERE)
 # inherit all functions from llvm base
 source ${HERE}/../../${MASON_NAME}/base/common.sh
 
-# broken with:
-# ../tools/clang/tools/include-what-you-use/iwyu_ast_util.cc:455:3: error: use of undeclared identifier 'printTemplateArgumentList'
-# function setup_release() {
-#     get_llvm_project "https://github.com/include-what-you-use/include-what-you-use.git"  ${MASON_BUILD_PATH}/tools/clang/tools/include-what-you-use "" 5788b34c2e22fa97630c4a5b1153d828698f9ac1
-# }
+function setup_release() {
+    get_llvm_project "https://github.com/include-what-you-use/include-what-you-use.git"  ${MASON_BUILD_PATH}/tools/clang/tools/include-what-you-use "" f1ec249
+    # FIX 6.0.0 specific libcxx bug: https://github.com/llvm-mirror/libcxx/commit/68b20ca4d9c4bee2c2ad5a9240599b3e4b78d0ba
+    # This will need to be removed in upcoming releases
+    (cd ${MASON_BUILD_PATH}/projects/libcxx &&
+        patch -N -p1 < ${MASON_DIR}/scripts/${MASON_NAME}/${MASON_VERSION}/68b20ca4d9c4bee2c2ad5a9240599b3e4b78d0ba.diff)
+}
 
 mason_run "$@"

--- a/scripts/llvm/base/README.md
+++ b/scripts/llvm/base/README.md
@@ -24,12 +24,12 @@ This llvm/base directory is not a package itself, but two critical building bloc
  - `scripts/llvm/base/README.md`: this document, that explains how to understand, use, and build the llvm package and sub-packages
  - `scripts/llvm/base/common.sh`: a common set of bash functions that are inherited by each llvm package.
 
-A given llvm package version is what users of mason actually request: e.g. llvm 4.0.0. This package lives at `scripts/llvm/4.0.0/script.sh`.
+A given llvm package version is what users of mason actually request. This package lives at `scripts/llvm/6.0.1/script.sh`.
 
 A user can install that version like:
 
 ```
-mason install llvm 4.0.0
+mason install llvm 6.0.1
 ```
 
 However, if they do they will get over 1.6 GB of binaries. See below to learn about the subpackages.
@@ -85,36 +85,46 @@ Here are the steps to create a new llvm version:
 
 #### Step 1: Note the latest release
 
-Go to http://releases.llvm.org to see the latest release. For our walkthrough below we will assume that the new release is `4.0.2`.
+Go to http://releases.llvm.org to see the latest release. For our walkthrough below we will assume that the new release is `6.0.1`.
 
 #### Step 2: Make sure this release of llvm is not already packaged
 
-Check to see if there is not already a `scripts/llvm/4.0.2`.
+Check to see if there is not already a `scripts/llvm/6.0.1`.
 
 #### Step 3: Create a mason branch
 
-Create a new branch called `llvm-4.0.2`.
+Create a new branch called `llvm-6.0.1`.
 
 #### Step 4: Create the new package
 
 Top create new version of the llvm package and sub-packages do:
 
 ```
-./utils/llvm.sh create 4.0.2 4.0.1
+./utils/llvm.sh create 6.0.1 6.0.0
 ```
+
+If you hit an error of `first arg must point to a version of llvm that does not exist` that means the package already exists. This will happen when someone has already packaged it as a dev release, pulling from `git` head. You can identify if this is the case by looking inside the `./scripts/llvm/<version>/script.sh` to see if you see `http://llvm.org/git/llvm.git` use in the `setup_base_tools` function.
+
+In this case, if you want to override the scripts and replace them with a formal release that does not pull from git you can do:
+
+```
+FORCE_LLVM_OVERWRITE=1 ./utils/llvm.sh create 6.0.1 6.0.0
+```
+
+Note: if you overwrite, we recommend creating a new release to track git HEAD that is named for the upcoming llvm version so that we still have a package tracking LLVM head via git. Currently updating this "HEAD tracking package" is manual (@springmeyer does it), but ideally we automate this in the future.
 
 #### Step 5: Push packages to github and create PR
 
 First add the new package and sub-packages to git
 
 ```
-git add scripts/*/4.0.2/
+git add scripts/*/6.0.1/
 ```
 
 Now push to github:
 
 ```
-git push origin llvm-4.0.2
+git push origin llvm-6.0.1
 ```
 
 Then go create a PR.
@@ -132,13 +142,13 @@ If you are on Linux, then you will first build the package in the linux docker c
 A. First build the llvm package. This may take > 30 minutes.
 
 ```
-./mason build llvm 4.0.2
+./mason build llvm 6.0.1
 ```
 
 B. Then build all the sub-packages. This will be fast since they are simply repackaged binaries.
 
 ```
-./utils/llvm.sh build 4.0.2
+./utils/llvm.sh build 6.0.1
 ```
 
 C. Authenticate your shell with the mason AWS KEYS
@@ -151,8 +161,8 @@ export AWS_SECRET_ACCESS_KEY=<>
 D. Then publish the main llvm package and sub-packages. This may take > 20 min depending on the speed of your internet connection.
 
 ```
-./mason publish llvm 4.0.2
-./utils/llvm.sh publish 4.0.2
+./mason publish llvm 6.0.1
+./utils/llvm.sh publish 6.0.1
 ```
 
 ##### Linux
@@ -171,7 +181,7 @@ We run the docker image to build the package on linux. We map volumes such that 
 # first set up ccache sharing
 docker create -v $(pwd)/ccache:/ccache --name ccache mason-llvm
 
-LLVM_VERSION="4.0.2"
+LLVM_VERSION="6.0.1"
 mkdir -p ccache
 time docker run -it \
   -e CCACHE_DIR=/ccache \
@@ -205,8 +215,8 @@ export AWS_SECRET_ACCESS_KEY=<>
 D. Then publish the main llvm package and sub-packages. This may take > 20 min depending on the speed of your internet connection.
 
 ```
-MASON_PLATFORM=linux ./mason publish llvm 4.0.2
-MASON_PLATFORM=linux ./utils/llvm.sh publish 4.0.2
+MASON_PLATFORM=linux ./mason publish llvm 6.0.1
+MASON_PLATFORM=linux ./utils/llvm.sh publish 6.0.1
 ```
 
 Note: `MASON_PLATFORM=linux` is only needed if your host is OS X.
@@ -221,7 +231,7 @@ The binary packages will work on:
 
 ### LTO support
 
-If you want to use `-flto` support with clang++ you also need to install binutils >= 2.27. To see the exact version of binutils that llvm was built against look inside the `scripts/llvm/base/common.sh` (https://github.com/mapbox/mason/blob/llvm-4.0.1/scripts/llvm/base/common.sh#L127).
+If you want to use `-flto` support with clang++ you also need to install binutils >= 2.27. To see the exact version of binutils that llvm was built against look inside the `scripts/llvm/base/common.sh` (https://github.com/mapbox/mason/blob/llvm-6.0.0/scripts/llvm/base/common.sh#L127).
 
 ### Xcode missing
 

--- a/scripts/llvm/base/README.md
+++ b/scripts/llvm/base/README.md
@@ -129,6 +129,12 @@ git push origin llvm-6.0.1
 
 Then go create a PR.
 
+#### Step 5b:
+
+Consider IWYU. This package is often behind LLVM releases and therefore does not compile cleanly. It is, therefore, usually disabled in the `setup_release` section of a given versions `script.sh`. But you can consider enabling and pointing at a given gitsha or new release of IWYU to see if it can be made to work (though the compile not will error until your LLVM has progressed so it will slow down your build experience).
+
+For example, at the time of packaging LLVM 6.0.0 this was unresolved: https://github.com/include-what-you-use/include-what-you-use/issues/521
+
 #### Step 6: Build and publish the new llvm package and sub-packages
 
 This step will vary depending on your host operating system.

--- a/scripts/llvm/base/common.sh
+++ b/scripts/llvm/base/common.sh
@@ -11,8 +11,10 @@ export MAJOR_MINOR=$(echo ${MASON_BASE_VERSION} | cut -d '.' -f1-2)
 if [[ $(uname -s) == 'Darwin' ]]; then
     export BUILD_AND_LINK_LIBCXX=true
 
-    # not installing libcxx avoids this kind of problem with include-what-you-use
-    export INSTALL_LIBCXX=false
+    # not installing libcxx may avoids this kind of problem with include-what-you-use
+    # but currently we do build libcxx headers since iwyu quality has declined and having
+    # a working libc++ is more valuable than a working iwyu on OS X
+    export INSTALL_LIBCXX=true
     # because iwyu hardcodes at https://github.com/include-what-you-use/include-what-you-use/blob/da5c9b17fec571e6b2bbca29145463d7eaa3582e/iwyu_driver.cc#L219
     : '
     /Library/Developer/CommandLineTools/usr/include/c++/v1/cstdlib:167:44: error: declaration conflicts with target of using declaration already in scope

--- a/utils/llvm.sh
+++ b/utils/llvm.sh
@@ -54,11 +54,11 @@ function create() {
         echo "ERROR: please provide first arg of new version"
         exit 1
     fi
-    if [[ -d ./scripts/llvm/${1} ]]; then
+    if [[ -d ./scripts/llvm/${1} ]] && [[ ${FORCE_LLVM_OVERWRITE:-false} != 1 ]]; then
         usage
         echo
         echo
-        echo "ERROR: first arg must point to a version of llvm that does not exist"
+        echo "ERROR: first arg must point to a version of llvm that does not exist (or pass 'FORCE_LLVM_OVERWRITE=1 ./utils/llvm.sh create'"
         exit 1
     fi
     if [[ ! -d ./scripts/llvm/${2} ]]; then


### PR DESCRIPTION
Prep to create an official LLVM 6.0.0 release (previous 6.0.0 package was a dev version).

Should fix #563 before release.