### PR TITLE
Protobuf updates

### DIFF
--- a/mason.sh
+++ b/mason.sh
@@ -505,13 +505,13 @@ function mason_config {
         echo "platform=${MASON_PLATFORM}"
         echo "platform_version=${MASON_PLATFORM_VERSION}"
     fi
+    mason_config_custom
     for name in include_dirs definitions options ldflags static_libs ; do
         eval value=\$MASON_CONFIG_$(echo ${name} | tr '[:lower:]' '[:upper:]')
         if [ ! -z "${value}" ]; then
             echo "${name}=${value//${MASON_PREFIX}/${MASON_CONFIG_PREFIX}}"
         fi
     done
-    mason_config_custom
 }
 
 function mason_write_config {

--- a/scripts/protobuf/3.4.1/script.sh
+++ b/scripts/protobuf/3.4.1/script.sh
@@ -32,9 +32,12 @@ function mason_compile {
         export LDFLAGS="${LDFLAGS} -llog"
     fi
 
-    export PROTOBUF_XC_ARG=""
     if [ ${MASON_PLATFORM} == 'android' ] || [ ${MASON_PLATFORM} == 'ios' ]; then
-        export PROTOBUF_XC_ARG="${PROTOBUF_XC_ARG} --with-protoc=protoc"
+        local PREFIX=$(MASON_PLATFORM= MASON_PLATFORM_VERSION= ${MASON_DIR}/mason prefix ${MASON_NAME} ${MASON_VERSION})
+        if [ ! -d ${PREFIX} ]; then
+            $(MASON_PLATFORM= MASON_PLATFORM_VERSION= ${MASON_DIR}/mason install ${MASON_NAME} ${MASON_VERSION})
+        fi
+        export PROTOBUF_XC_ARG="--with-protoc=${PREFIX}/bin/protoc"
     fi
 
     if [ ${MASON_PLATFORM} == 'ios' ]; then
@@ -48,7 +51,7 @@ function mason_compile {
     ./configure \
         --prefix=${MASON_PREFIX} \
         ${MASON_HOST_ARG} \
-        ${PROTOBUF_XC_ARG} \
+        ${PROTOBUF_XC_ARG:-} \
         --enable-static --disable-shared \
         --disable-debug --without-zlib \
         --disable-dependency-tracking

--- a/scripts/protobuf/3.4.1/script.sh
+++ b/scripts/protobuf/3.4.1/script.sh
@@ -64,4 +64,10 @@ function mason_clean {
     make clean
 }
 
+function mason_config_custom {
+    if [ ${MASON_PLATFORM} == 'android' ]; then
+        MASON_CONFIG_LDFLAGS="${MASON_CONFIG_LDFLAGS} -llog"
+    fi
+}
+
 mason_run "$@"

--- a/scripts/protobuf/3.5.0/script.sh
+++ b/scripts/protobuf/3.5.0/script.sh
@@ -32,9 +32,12 @@ function mason_compile {
         export LDFLAGS="${LDFLAGS} -llog"
     fi
 
-    export PROTOBUF_XC_ARG=""
     if [ ${MASON_PLATFORM} == 'android' ] || [ ${MASON_PLATFORM} == 'ios' ]; then
-        export PROTOBUF_XC_ARG="${PROTOBUF_XC_ARG} --with-protoc=protoc"
+        local PREFIX=$(MASON_PLATFORM= MASON_PLATFORM_VERSION= ${MASON_DIR}/mason prefix ${MASON_NAME} ${MASON_VERSION})
+        if [ ! -d ${PREFIX} ]; then
+            $(MASON_PLATFORM= MASON_PLATFORM_VERSION= ${MASON_DIR}/mason install ${MASON_NAME} ${MASON_VERSION})
+        fi
+        export PROTOBUF_XC_ARG="--with-protoc=${PREFIX}/bin/protoc"
     fi
 
     if [ ${MASON_PLATFORM} == 'ios' ]; then
@@ -48,7 +51,7 @@ function mason_compile {
     ./configure \
         --prefix=${MASON_PREFIX} \
         ${MASON_HOST_ARG} \
-        ${PROTOBUF_XC_ARG} \
+        ${PROTOBUF_XC_ARG:-} \
         --enable-static --disable-shared \
         --disable-debug --without-zlib \
         --disable-dependency-tracking

--- a/scripts/protobuf/3.5.0/script.sh
+++ b/scripts/protobuf/3.5.0/script.sh
@@ -64,4 +64,10 @@ function mason_clean {
     make clean
 }
 
+function mason_config_custom {
+    if [ ${MASON_PLATFORM} == 'android' ]; then
+        MASON_CONFIG_LDFLAGS="${MASON_CONFIG_LDFLAGS} -llog"
+    fi
+}
+
 mason_run "$@"

--- a/scripts/protobuf/3.5.1-cxx11abi/script.sh
+++ b/scripts/protobuf/3.5.1-cxx11abi/script.sh
@@ -34,9 +34,12 @@ function mason_compile {
         export LDFLAGS="${LDFLAGS} -llog"
     fi
 
-    export PROTOBUF_XC_ARG=""
-    if [ "${MASON_PLATFORM}" == "android" ] || [ "${MASON_PLATFORM}" == "ios" ]; then
-        export PROTOBUF_XC_ARG="${PROTOBUF_XC_ARG} --with-protoc=protoc"
+    if [ ${MASON_PLATFORM} == 'android' ] || [ ${MASON_PLATFORM} == 'ios' ]; then
+        local PREFIX=$(MASON_PLATFORM= MASON_PLATFORM_VERSION= ${MASON_DIR}/mason prefix ${MASON_NAME} ${MASON_VERSION})
+        if [ ! -d ${PREFIX} ]; then
+            $(MASON_PLATFORM= MASON_PLATFORM_VERSION= ${MASON_DIR}/mason install ${MASON_NAME} ${MASON_VERSION})
+        fi
+        export PROTOBUF_XC_ARG="--with-protoc=${PREFIX}/bin/protoc"
     fi
 
     if [ "${MASON_PLATFORM}" == "ios" ]; then
@@ -50,7 +53,7 @@ function mason_compile {
     ./configure \
         --prefix=${MASON_PREFIX} \
         ${MASON_HOST_ARG} \
-        ${PROTOBUF_XC_ARG} \
+        ${PROTOBUF_XC_ARG:-} \
         --enable-static --disable-shared \
         --disable-debug --without-zlib \
         --disable-dependency-tracking

--- a/scripts/protobuf/3.5.1-cxx11abi/script.sh
+++ b/scripts/protobuf/3.5.1-cxx11abi/script.sh
@@ -66,4 +66,10 @@ function mason_clean {
     make clean
 }
 
+function mason_config_custom {
+    if [ ${MASON_PLATFORM} == 'android' ]; then
+        MASON_CONFIG_LDFLAGS="${MASON_CONFIG_LDFLAGS} -llog"
+    fi
+}
+
 mason_run "$@"

--- a/scripts/protobuf/3.5.1/script.sh
+++ b/scripts/protobuf/3.5.1/script.sh
@@ -34,9 +34,12 @@ function mason_compile {
         export LDFLAGS="${LDFLAGS} -llog"
     fi
 
-    export PROTOBUF_XC_ARG=""
-    if [ "${MASON_PLATFORM}" == "android" ] || [ "${MASON_PLATFORM}" == "ios" ]; then
-        export PROTOBUF_XC_ARG="${PROTOBUF_XC_ARG} --with-protoc=protoc"
+    if [ ${MASON_PLATFORM} == 'android' ] || [ ${MASON_PLATFORM} == 'ios' ]; then
+        local PREFIX=$(MASON_PLATFORM= MASON_PLATFORM_VERSION= ${MASON_DIR}/mason prefix ${MASON_NAME} ${MASON_VERSION})
+        if [ ! -d ${PREFIX} ]; then
+            $(MASON_PLATFORM= MASON_PLATFORM_VERSION= ${MASON_DIR}/mason install ${MASON_NAME} ${MASON_VERSION})
+        fi
+        export PROTOBUF_XC_ARG="--with-protoc=${PREFIX}/bin/protoc"
     fi
 
     if [ "${MASON_PLATFORM}" == "ios" ]; then
@@ -50,7 +53,7 @@ function mason_compile {
     ./configure \
         --prefix=${MASON_PREFIX} \
         ${MASON_HOST_ARG} \
-        ${PROTOBUF_XC_ARG} \
+        ${PROTOBUF_XC_ARG:-} \
         --enable-static --disable-shared \
         --disable-debug --without-zlib \
         --disable-dependency-tracking

--- a/scripts/protobuf/3.5.1/script.sh
+++ b/scripts/protobuf/3.5.1/script.sh
@@ -66,4 +66,10 @@ function mason_clean {
     make clean
 }
 
+function mason_config_custom {
+    if [ ${MASON_PLATFORM} == 'android' ]; then
+        MASON_CONFIG_LDFLAGS="${MASON_CONFIG_LDFLAGS} -llog"
+    fi
+}
+
 mason_run "$@"


### PR DESCRIPTION
- Use `mason_config_custom` to append `-llog` ldflag to android builds
- Use build's protoc for executing tests when cross-compiling (iOS, Android)