### PR TITLE
openssl: Remove OPENSSL_NO_DEPRECATED define

### DIFF
--- a/scripts/openssl/1.0.2d/script.sh
+++ b/scripts/openssl/1.0.2d/script.sh
@@ -88,7 +88,6 @@ function mason_compile {
         -no-whirlpool \
         -fPIC \
         -DOPENSSL_PIC \
-        -DOPENSSL_NO_DEPRECATED \
         -DOPENSSL_NO_COMP \
         -DOPENSSL_NO_HEARTBEATS \
         --openssldir=${MASON_PREFIX}/etc/openssl \


### PR DESCRIPTION
Qt still makes use of OpenSSL deprecated functions e.g. `CRYPTO_set_id_callback`.