### PR TITLE
Add postgres 10.3 with libedit support enabled

### DIFF
--- a/scripts/postgres/10.3/.travis.yml
+++ b/scripts/postgres/10.3/.travis.yml
@@ -1,0 +1,13 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.2
+      compiler: clang
+    - os: linux
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/postgres/10.3/patch.diff
+++ b/scripts/postgres/10.3/patch.diff
@@ -1,0 +1,11 @@
+--- src/include/pg_config_manual.h	2013-10-07 20:17:38.000000000 -0700
++++ src/include/pg_config_manual.h	2014-03-08 21:29:48.000000000 -0800
+@@ -144,7 +144,7 @@
+  * here's where to twiddle it.  You can also override this at runtime
+  * with the postmaster's -k switch.
+  */
+-#define DEFAULT_PGSOCKET_DIR  "/tmp"
++#define DEFAULT_PGSOCKET_DIR  "/var/run/postgresql"
+ 
+ /*
+  * The random() function is expected to yield values between 0 and

--- a/scripts/postgres/10.3/script.sh
+++ b/scripts/postgres/10.3/script.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
 MASON_NAME=postgres
-MASON_VERSION=9.6.5
-MASON_VERSION2=9.6.5
+MASON_VERSION=10.3
 MASON_LIB_FILE=bin/psql
 MASON_PKGCONFIG_FILE=lib/pkgconfig/libpq.pc
 
@@ -10,18 +9,24 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/libpq.pc
 
 function mason_load_source {
     mason_download \
-        http://ftp.postgresql.org/pub/source/v${MASON_VERSION2}/postgresql-${MASON_VERSION2}.tar.bz2 \
-        de4007bbb8a5869cc3f193ae34b2fbd9e4b876c4
+        http://ftp.postgresql.org/pub/source/v${MASON_VERSION}/postgresql-${MASON_VERSION}.tar.bz2 \
+        e1590a4b2167dcdf164eb887cf83e7da9e155771
 
     mason_extract_tar_bz2
 
-    export MASON_BUILD_PATH=${MASON_ROOT}/.build/postgresql-${MASON_VERSION2}
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/postgresql-${MASON_VERSION}
 }
 
 function mason_prepare_compile {
     LIBEDIT_VERSION="3.1"
+    NCURSES_VERSION="6.1"
+    CCACHE_VERSION=3.3.1
+    ${MASON_DIR}/mason install ccache ${CCACHE_VERSION}
+    MASON_CCACHE=$(${MASON_DIR}/mason prefix ccache ${CCACHE_VERSION})
     ${MASON_DIR}/mason install libedit ${LIBEDIT_VERSION}
     MASON_LIBEDIT=$(${MASON_DIR}/mason prefix libedit ${LIBEDIT_VERSION})
+    ${MASON_DIR}/mason install ncurses ${NCURSES_VERSION}
+    MASON_NCURSES=$(${MASON_DIR}/mason prefix ncurses ${NCURSES_VERSION})
 }
 
 function mason_compile {
@@ -32,6 +37,8 @@ function mason_compile {
 
     # note CFLAGS overrides defaults (-Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -Wno-unused-command-line-argument) so we need to add optimization flags back
     export CFLAGS="${CFLAGS}  -O3 -DNDEBUG -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -Wno-unused-command-line-argument"
+    export CFLAGS="-I${MASON_LIBEDIT}/include -I${MASON_NCURSES}/include ${CFLAGS}"
+    export LDFLAGS="-L${MASON_LIBEDIT}/lib -L${MASON_NCURSES}/lib ${LDFLAGS}"
     ./configure \
         --prefix=${MASON_PREFIX} \
         ${MASON_HOST_ARG} \
@@ -65,8 +72,18 @@ function mason_compile {
     rm -f ${MASON_PREFIX}/lib/libpq{*.so*,*.dylib}
     MASON_LIBPQ_PATH=${MASON_PREFIX}/lib/libpq.a
     MASON_LIBPQ_PATH2=${MASON_LIBPQ_PATH////\\/}
-    perl -i -p -e "s/\-lpq/${MASON_LIBPQ_PATH2} -pthread/g;" src//Makefile.global.in
-    perl -i -p -e "s/\-lpq/${MASON_LIBPQ_PATH2} -pthread/g;" src//Makefile.global
+    MASON_LIBEDIT_PATH=${MASON_LIBEDIT}/lib/libedit.a
+    MASON_LIBEDIT_PATH=${MASON_LIBEDIT_PATH////\\/}
+    MASON_NCURSES_PATH=${MASON_NCURSES}/lib/libncurses.a
+    MASON_NCURSES_PATH=${MASON_NCURSES_PATH////\\/}
+    perl -i -p -e "s/\-lncurses/${MASON_NCURSES_PATH}/g;" src/backend/Makefile
+    perl -i -p -e "s/\-lncurses/${MASON_NCURSES_PATH}/g;" src/Makefile.global
+    perl -i -p -e "s/\-lncurses/${MASON_NCURSES_PATH}/g;" configure
+    perl -i -p -e "s/\-lncurses/${MASON_NCURSES_PATH}/g;" config/programs.m4
+    perl -i -p -e "s/\-ledit/${MASON_LIBEDIT_PATH}/g;" src/Makefile.global.in
+    perl -i -p -e "s/\-ledit/${MASON_LIBEDIT_PATH}/g;" src/Makefile.global
+    perl -i -p -e "s/\-lpq/${MASON_LIBPQ_PATH2} -pthread/g;" src/Makefile.global.in
+    perl -i -p -e "s/\-lpq/${MASON_LIBPQ_PATH2} -pthread/g;" src/Makefile.global
     make -j${MASON_CONCURRENCY} install
     make -j${MASON_CONCURRENCY} -C contrib install
     rm -f ${MASON_PREFIX}/lib/lib{*.so*,*.dylib}


### PR DESCRIPTION
Adds a new postgres 10.3 package that should support autocomplete of SQL in the `psql` interpreter. This is missing in the previous versions because we pass `--without-readline` to avoid the GNU GPL dep. Now we are building against BSD libedit with `--with-readline --with-libedit-preferred`.

The build is working on OS X and Linux: https://travis-ci.org/mapbox/mason/builds/357120940. So this is ready to test. @ingalls would you be up for confirming that autocomplete is now working?