### PR TITLE
Perf 4.15.15

### DIFF
--- a/scripts/perf/4.15.15/.travis.yml
+++ b/scripts/perf/4.15.15/.travis.yml
@@ -1,0 +1,28 @@
+language: generic
+
+matrix:
+  include:
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          # apt:
+          #  make systemtap-sdt-dev bison flex libperl-dev
+          # yum:
+          #  make flex bison elfutils-libelf-devel elfutils-devel libunwind-devel xz-devel numactl-devel openssl-devel slang-devel gtk2-devel perl-ExtUtils-Embed python-devel binutils-devel audit-libs-devel
+          packages:
+           - bison
+           - flex
+           - g++-4.9
+           - systemtap-sdt-dev
+
+# note: perf must be compiled with gcc (see script.sh)
+install:
+  - export CXX=g++-4.9
+  - export CC=gcc-4.9
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/perf/4.15.15/readme.md
+++ b/scripts/perf/4.15.15/readme.md
@@ -1,0 +1,51 @@
+This is the expected/enabled features of this perf build:
+
+Taken from https://travis-ci.org/mapbox/mason/builds/336964403#L613
+
+...                         dwarf: [ on  ]
+...            dwarf_getlocations: [ on  ]
+...                         glibc: [ on  ]
+...                          gtk2: [ OFF ]
+...                      libaudit: [ OFF ]
+...                        libbfd: [ on  ]
+...                        libelf: [ on  ]
+...                       libnuma: [ OFF ]
+...        numa_num_possible_cpus: [ OFF ]
+...                       libperl: [ OFF ]
+...                     libpython: [ on  ]
+...                      libslang: [ on  ]
+...                     libcrypto: [ on  ]
+...                     libunwind: [ OFF ]
+...            libdw-dwarf-unwind: [ on  ]
+...                          zlib: [ on  ]
+...                          lzma: [ on  ]
+...                     get_cpuid: [ on  ]
+...                           bpf: [ on  ]
+...                     backtrace: [ on  ]
+...                fortify-source: [ on  ]
+...         sync-compare-and-swap: [ on  ]
+...                  gtk2-infobar: [ OFF ]
+...             libelf-getphdrnum: [ on  ]
+...           libelf-gelf_getnote: [ on  ]
+...          libelf-getshdrstrndx: [ on  ]
+...                   libelf-mmap: [ on  ]
+...             libpython-version: [ on  ]
+...                 libunwind-x86: [ OFF ]
+...              libunwind-x86_64: [ OFF ]
+...                 libunwind-arm: [ OFF ]
+...             libunwind-aarch64: [ OFF ]
+...   pthread-attr-setaffinity-np: [ on  ]
+...            stackprotector-all: [ on  ]
+...                       timerfd: [ on  ]
+...                  sched_getcpu: [ on  ]
+...                           sdt: [ on  ]
+...                         setns: [ on  ]
+Makefile.config:613: Python support disabled by user
+...                        prefix: /home/travis/build/mapbox/mason/mason_packages/linux-x86_64/perf/4.15
+...                        bindir: /home/travis/build/mapbox/mason/mason_packages/linux-x86_64/perf/4.15/bin
+...                        libdir: /home/travis/build/mapbox/mason/mason_packages/linux-x86_64/perf/4.15/lib64
+...                    sysconfdir: /home/travis/build/mapbox/mason/mason_packages/linux-x86_64/perf/4.15/etc
+...                 LIBUNWIND_DIR: 
+...                     LIBDW_DIR: 
+...                          JDIR: /usr/lib/jvm/java-1.7.0-openjdk-amd64
+...     DWARF post unwind library: libdw

--- a/scripts/perf/4.15.15/readme.md
+++ b/scripts/perf/4.15.15/readme.md
@@ -2,10 +2,11 @@ This is the expected/enabled features of this perf build:
 
 Taken from https://travis-ci.org/mapbox/mason/builds/336964403#L613
 
+Auto-detecting system features:
 ...                         dwarf: [ on  ]
 ...            dwarf_getlocations: [ on  ]
 ...                         glibc: [ on  ]
-...                          gtk2: [ OFF ]
+...                          gtk2: [ on  ]
 ...                      libaudit: [ OFF ]
 ...                        libbfd: [ on  ]
 ...                        libelf: [ on  ]
@@ -24,7 +25,7 @@ Taken from https://travis-ci.org/mapbox/mason/builds/336964403#L613
 ...                     backtrace: [ on  ]
 ...                fortify-source: [ on  ]
 ...         sync-compare-and-swap: [ on  ]
-...                  gtk2-infobar: [ OFF ]
+...                  gtk2-infobar: [ on  ]
 ...             libelf-getphdrnum: [ on  ]
 ...           libelf-gelf_getnote: [ on  ]
 ...          libelf-getshdrstrndx: [ on  ]
@@ -41,11 +42,11 @@ Taken from https://travis-ci.org/mapbox/mason/builds/336964403#L613
 ...                           sdt: [ on  ]
 ...                         setns: [ on  ]
 Makefile.config:613: Python support disabled by user
-...                        prefix: /home/travis/build/mapbox/mason/mason_packages/linux-x86_64/perf/4.15
-...                        bindir: /home/travis/build/mapbox/mason/mason_packages/linux-x86_64/perf/4.15/bin
-...                        libdir: /home/travis/build/mapbox/mason/mason_packages/linux-x86_64/perf/4.15/lib64
-...                    sysconfdir: /home/travis/build/mapbox/mason/mason_packages/linux-x86_64/perf/4.15/etc
+...                        prefix: /home/travis/build/mapbox/mason/mason_packages/linux-x86_64/perf/4.15.15
+...                        bindir: /home/travis/build/mapbox/mason/mason_packages/linux-x86_64/perf/4.15.15/bin
+...                        libdir: /home/travis/build/mapbox/mason/mason_packages/linux-x86_64/perf/4.15.15/lib64
+...                    sysconfdir: /home/travis/build/mapbox/mason/mason_packages/linux-x86_64/perf/4.15.15/etc
 ...                 LIBUNWIND_DIR: 
 ...                     LIBDW_DIR: 
-...                          JDIR: /usr/lib/jvm/java-1.7.0-openjdk-amd64
+...                          JDIR: /usr/lib/jvm/java-1.6.0-openjdk-amd64
 ...     DWARF post unwind library: libdw

--- a/scripts/perf/4.15.15/script.sh
+++ b/scripts/perf/4.15.15/script.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+MASON_NAME=perf
+MASON_VERSION=4.15.15
+MASON_LIB_FILE=bin/perf
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    # https://www.kernel.org/
+    # https://git.kernel.org/cgit/linux/kernel/git/stable/linux-stable.git/log/tools/perf
+    mason_download \
+        https://cdn.kernel.org/pub/linux/kernel/v4.x/linux-${MASON_VERSION}.tar.xz \
+        49e83b508ceb634f20d2663ed5028c41d0a5f39a
+
+    mason_extract_tar_xz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/linux-${MASON_VERSION}
+}
+
+function mason_prepare_compile {
+    ${MASON_DIR}/mason install zlib 1.2.8
+    MASON_ZLIB=$(${MASON_DIR}/mason prefix zlib 1.2.8)
+    ${MASON_DIR}/mason install xz 5.2.3
+    MASON_XZ=$(${MASON_DIR}/mason prefix xz 5.2.3)
+    ${MASON_DIR}/mason install binutils 2.30
+    MASON_BINUTILS=$(${MASON_DIR}/mason prefix binutils 2.30)
+    ${MASON_DIR}/mason install slang 2.3.1
+    MASON_SLANG=$(${MASON_DIR}/mason prefix slang 2.3.1)
+    ${MASON_DIR}/mason install bzip2 1.0.6
+    MASON_BZIP2=$(${MASON_DIR}/mason prefix bzip2 1.0.6)
+    ${MASON_DIR}/mason install elfutils 0.170
+    MASON_ELFUTILS=$(${MASON_DIR}/mason prefix elfutils 0.170)
+    EXTRA_CFLAGS="-m64 -I${MASON_SLANG}/include -I${MASON_ZLIB}/include -I${MASON_XZ}/include -I${MASON_BINUTILS}/include -I${MASON_BZIP2}/include -I${MASON_ELFUTILS}/include"
+    EXTRA_LDFLAGS="-L${MASON_BZIP2}/lib -L${MASON_ZLIB}/lib -L${MASON_XZ}/lib -L${MASON_SLANG}/lib -L${MASON_ELFUTILS}/lib -L${MASON_BINUTILS}/lib"
+}
+
+# https://perf.wiki.kernel.org/index.php/Jolsa_Howto_Install_Sources
+# https://askubuntu.com/questions/50145/how-to-install-perf-monitoring-tool/306683
+# https://www.spinics.net/lists/linux-perf-users/msg03040.html
+# https://software.intel.com/en-us/articles/linux-perf-for-intel-vtune-Amplifier-XE
+# see the readme.md in this directory for a log of what perf features are enabled
+function mason_compile {
+    cd tools/perf
+    # we set NO_LIBUNWIND since libdw is used from elfutils which is faster: https://lwn.net/Articles/579508/
+    # note: LIBELF is needed for symbols + node --perf_basic_prof_only_functions
+    mkdir -p output-dir
+    rm -rf output-dir/*
+    make \
+      O=output-dir \
+      LIBDW_LDFLAGS="-L${MASON_ELFUTILS}/lib -Wl,--start-group -ldw -lelf -lebl -llzma -lz -lbz2 -ldl -L${MASON_BZIP2}/lib -L${MASON_XZ}/lib" \
+      LIBDW_CFLAGS="-I${MASON_ELFUTILS}/include/" \
+      V=1 VF=1 \
+      prefix=${MASON_PREFIX} \
+      NO_LIBNUMA=1 \
+      NO_LIBAUDIT=1 \
+      NO_LIBUNWIND=1 \
+      NO_BIONIC=1 \
+      NO_BACKTRACE=1 \
+      NO_LIBCRYPTO=1 \
+      NO_LIBPERL=1 \
+      NO_GTK2=1 \
+      LDFLAGS="${EXTRA_LDFLAGS} -Wl,--start-group -L${MASON_BINUTILS}/lib -lbfd -lopcodes -lelf -lz" \
+      NO_LIBPYTHON=1 \
+      WERROR=0 \
+      EXTRA_CFLAGS="${EXTRA_CFLAGS}" \
+      install
+}
+
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
+mason_run "$@"


### PR DESCRIPTION
This adds a new Perf 4.15.15 package. The previous one, `4.15.0`, is segfaulting occasionally when running `perf top` on a machine under heavy load. Hoping that might be fixed by this more recent stable version.