### PR TITLE
Boost 1.67.0

### DIFF
--- a/scripts/boost/1.67.0/.travis.yml
+++ b/scripts/boost/1.67.0/.travis.yml
@@ -1,0 +1,10 @@
+language: generic
+
+matrix:
+  include:
+    - os: linux
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost/1.67.0/base.sh
+++ b/scripts/boost/1.67.0/base.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# NOTE: use the ./utils/new_boost.sh script to create new versions
+
+export MASON_VERSION=1.67.0
+export BOOST_VERSION=${MASON_VERSION//./_}
+export BOOST_TOOLSET=$(basename ${CC})
+export BOOST_TOOLSET_CXX=$(basename ${CXX})
+export BOOST_ARCH="x86"
+export BOOST_SHASUM=6dde6a5f874a5dfa75865e4430ff9248a43cab07
+# special override to ensure each library shares the cached download
+export MASON_DOWNLOAD_SLUG="boost-${MASON_VERSION}"

--- a/scripts/boost/1.67.0/common.sh
+++ b/scripts/boost/1.67.0/common.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+function mason_load_source {
+    mason_download \
+        http://downloads.sourceforge.net/project/boost/boost/${MASON_VERSION}/boost_${BOOST_VERSION}.tar.bz2 \
+        ${BOOST_SHASUM}
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/boost_${BOOST_VERSION}
+
+    mason_extract_tar_bz2
+}
+
+function gen_config() {
+  echo "using $1 : : $(which $2)" > user-config.jam
+  if [[ "${AR:-false}" != false ]] || [[ "${RANLIB:-false}" != false ]]; then
+      echo ' : ' >> user-config.jam
+      if [[ "${AR:-false}" != false ]]; then
+          echo "<archiver>${AR} " >> user-config.jam
+      fi
+      if [[ "${RANLIB:-false}" != false ]]; then
+          echo "<ranlib>${RANLIB} " >> user-config.jam
+      fi
+  fi
+  echo ' ;' >> user-config.jam
+}
+
+function mason_compile {
+    gen_config ${BOOST_TOOLSET} ${BOOST_TOOLSET_CXX}
+    if [[ ! -f ./b2 ]] ; then
+        ./bootstrap.sh
+    fi
+    ./b2 \
+        --with-${BOOST_LIBRARY} \
+        --prefix=${MASON_PREFIX} \
+        -j${MASON_CONCURRENCY} \
+        -d0 \
+        --ignore-site-config --user-config=user-config.jam \
+        architecture="${BOOST_ARCH}" \
+        toolset="${BOOST_TOOLSET}" \
+        link=static \
+        variant=release \
+        linkflags="${LDFLAGS:-" "}" \
+        cxxflags="${CXXFLAGS:-" "}" \
+        stage
+    mkdir -p $(dirname ${MASON_PREFIX}/${MASON_LIB_FILE})
+    mv stage/${MASON_LIB_FILE} ${MASON_PREFIX}/${MASON_LIB_FILE}
+}
+
+function mason_prefix {
+    echo "${MASON_PREFIX}"
+}
+
+function mason_cflags {
+    echo "-I${MASON_PREFIX}/include"
+}
+
+function mason_ldflags {
+    local LOCAL_LDFLAGS
+    LOCAL_LDFLAGS="-L${MASON_PREFIX}/lib"
+    if [[ ${BOOST_LIBRARY:-false} != false ]]; then
+        LOCAL_LDFLAGS="${LOCAL_LDFLAGS} -lboost_${BOOST_LIBRARY}"
+    fi
+    echo $LOCAL_LDFLAGS
+}

--- a/scripts/boost/1.67.0/script.sh
+++ b/scripts/boost/1.67.0/script.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# inherit from boost base (used for all boost library packages)
+source ${HERE}/base.sh
+
+# this package is the one that is header-only
+MASON_NAME=boost
+MASON_HEADER_ONLY=true
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${HERE}/common.sh
+
+# override default unpacking to just unpack headers
+function mason_load_source {
+    mason_download \
+        http://downloads.sourceforge.net/project/boost/boost/${MASON_VERSION}/boost_${BOOST_VERSION}.tar.bz2 \
+        ${BOOST_SHASUM}
+
+    mason_extract_tar_bz2 boost_${BOOST_VERSION}/boost
+
+    MASON_BUILD_PATH=${MASON_ROOT}/.build/boost_${BOOST_VERSION}
+}
+
+# override default "compile" target for just the header install
+function mason_compile {
+    mkdir -p ${MASON_PREFIX}/include
+    cp -r ${MASON_ROOT}/.build/boost_${BOOST_VERSION}/boost ${MASON_PREFIX}/include
+    
+    # work around NDK bug https://code.google.com/p/android/issues/detail?id=79483
+    
+    patch ${MASON_PREFIX}/include/boost/core/demangle.hpp <<< "19a20,21
+> #if !defined(__ANDROID__)
+> 
+25a28,29
+> #endif
+> 
+"
+
+    # work around https://github.com/Project-OSRM/node-osrm/issues/191
+    patch ${MASON_PREFIX}/include/boost/interprocess/detail/os_file_functions.hpp <<< "471c471
+<    return ::open(name, (int)mode);
+---
+>    return ::open(name, (int)mode,S_IRUSR|S_IWUSR);
+"
+
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
+mason_run "$@"

--- a/scripts/boost_libatomic/1.67.0/.travis.yml
+++ b/scripts/boost_libatomic/1.67.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-4.8-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libatomic/1.67.0/script.sh
+++ b/scripts/boost_libatomic/1.67.0/script.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+BOOST_LIBRARY=${THIS_DIR#boost_lib}
+MASON_NAME=boost_lib${BOOST_LIBRARY}
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+mason_run "$@"

--- a/scripts/boost_libchrono/1.67.0/.travis.yml
+++ b/scripts/boost_libchrono/1.67.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-4.8-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libchrono/1.67.0/script.sh
+++ b/scripts/boost_libchrono/1.67.0/script.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+BOOST_LIBRARY=${THIS_DIR#boost_lib}
+MASON_NAME=boost_lib${BOOST_LIBRARY}
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+mason_run "$@"

--- a/scripts/boost_libdate_time/1.67.0/.travis.yml
+++ b/scripts/boost_libdate_time/1.67.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-4.8-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libdate_time/1.67.0/script.sh
+++ b/scripts/boost_libdate_time/1.67.0/script.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+BOOST_LIBRARY=${THIS_DIR#boost_lib}
+MASON_NAME=boost_lib${BOOST_LIBRARY}
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+mason_run "$@"

--- a/scripts/boost_libfilesystem/1.67.0/.travis.yml
+++ b/scripts/boost_libfilesystem/1.67.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-4.8-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libfilesystem/1.67.0/script.sh
+++ b/scripts/boost_libfilesystem/1.67.0/script.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+BOOST_LIBRARY=${THIS_DIR#boost_lib}
+MASON_NAME=boost_lib${BOOST_LIBRARY}
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+mason_run "$@"

--- a/scripts/boost_libiostreams/1.67.0/.travis.yml
+++ b/scripts/boost_libiostreams/1.67.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-4.8-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libiostreams/1.67.0/script.sh
+++ b/scripts/boost_libiostreams/1.67.0/script.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+BOOST_LIBRARY=${THIS_DIR#boost_lib}
+MASON_NAME=boost_lib${BOOST_LIBRARY}
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+mason_run "$@"

--- a/scripts/boost_libprogram_options/1.67.0/.travis.yml
+++ b/scripts/boost_libprogram_options/1.67.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-4.8-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libprogram_options/1.67.0/script.sh
+++ b/scripts/boost_libprogram_options/1.67.0/script.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+BOOST_LIBRARY=${THIS_DIR#boost_lib}
+MASON_NAME=boost_lib${BOOST_LIBRARY}
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+mason_run "$@"

--- a/scripts/boost_libpython/1.67.0/.travis.yml
+++ b/scripts/boost_libpython/1.67.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-4.8-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libpython/1.67.0/patch.diff
+++ b/scripts/boost_libpython/1.67.0/patch.diff
@@ -1,0 +1,12 @@
+--- libs/python/src/converter/builtin_converters.cpp	2012-12-07 11:51:06.000000000 -0800
++++ libs/python/src/converter/builtin_converters.cpp	2014-04-01 17:24:37.000000000 -0700
+@@ -32,7 +32,9 @@
+ 
+ void shared_ptr_deleter::operator()(void const*)
+ {
++    PyGILState_STATE gil = PyGILState_Ensure();
+     owner.reset();
++    PyGILState_Release(gil);
+ }
+ 
+ namespace

--- a/scripts/boost_libpython/1.67.0/script.sh
+++ b/scripts/boost_libpython/1.67.0/script.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+BOOST_LIBRARY=${THIS_DIR#boost_lib}
+MASON_NAME=boost_lib${BOOST_LIBRARY}
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+function write_python_config() {
+# usage:
+# write_python_config <user-config.jam> <version> <base> <variant>
+PYTHON_VERSION=$2
+# note: apple pythons need '/System'
+PYTHON_BASE=$3
+# note: python 3 uses 'm'
+PYTHON_VARIANT=$4
+if [[ $(uname -s) == 'Darwin' ]]; then
+    echo "
+      using python
+           : ${PYTHON_VERSION} # version
+           : ${PYTHON_BASE}/Library/Frameworks/Python.framework/Versions/${PYTHON_VERSION}/bin/python${PYTHON_VERSION}${PYTHON_VARIANT} # cmd-or-prefix
+           : ${PYTHON_BASE}/Library/Frameworks/Python.framework/Versions/${PYTHON_VERSION}/include/python${PYTHON_VERSION}${PYTHON_VARIANT} # includes
+           : ${PYTHON_BASE}/Library/Frameworks/Python.framework/Versions/${PYTHON_VERSION}/lib/python${PYTHON_VERSION}/config${PYTHON_VARIANT} # a lib actually symlink
+           : <toolset>${BOOST_TOOLSET} # condition
+           ;
+    " >> $1
+else
+  if [[ $(uname -s) == 'FreeBSD' ]]; then
+      echo "
+        using python
+             : ${PYTHON_VERSION} # version
+             : /usr/local/bin/python${PYTHON_VERSION}${PYTHON_VARIANT} # cmd-or-prefix
+             : /usr/local/include/python${PYTHON_VERSION} # includes
+             : /usr/local/lib/python${PYTHON_VERSION}/config${PYTHON_VARIANT}
+             : <toolset>${BOOST_TOOLSET} # condition
+             ;
+      " >> $1
+  else
+      echo "
+        using python
+             : ${PYTHON_VERSION} # version
+             : /usr/bin/python${PYTHON_VERSION}${PYTHON_VARIANT} # cmd-or-prefix
+             : /usr/include/python${PYTHON_VERSION} # includes
+             : /usr/lib/python${PYTHON_VERSION}/config${PYTHON_VARIANT}
+             : <toolset>${BOOST_TOOLSET} # condition
+             ;
+      " >> $1
+  fi
+fi
+}
+
+function mason_compile {
+    # patch to workaround crashes in python.input
+    # https://github.com/mapnik/mapnik/issues/1968
+    mason_step "Loading patch ${MASON_DIR}/scripts/${MASON_NAME}/${MASON_VERSION}/patch.diff"
+    patch -N -p0 < ${MASON_DIR}/scripts/${MASON_NAME}/${MASON_VERSION}/patch.diff
+    write_python_config user-config.jam "2.7" "/System" ""
+    gen_config ${BOOST_TOOLSET} ${BOOST_TOOLSET_CXX}
+    if [[ ! -f ./b2 ]] ; then
+        ./bootstrap.sh
+    fi
+    ./b2 \
+        --with-${BOOST_LIBRARY} \
+        --prefix=${MASON_PREFIX} \
+        -j${MASON_CONCURRENCY} \
+        -d0 \
+        --ignore-site-config --user-config=user-config.jam \
+        architecture="${BOOST_ARCH}" \
+        toolset="${BOOST_TOOLSET}" \
+        link=static \
+        variant=release \
+        linkflags="${LDFLAGS:-" "}" \
+        cxxflags="${CXXFLAGS:-" "}" \
+        stage
+    mkdir -p $(dirname ${MASON_PREFIX}/${MASON_LIB_FILE})
+    mv stage/${MASON_LIB_FILE} ${MASON_PREFIX}/${MASON_LIB_FILE}
+}
+
+mason_run "$@"

--- a/scripts/boost_libregex/1.67.0/.travis.yml
+++ b/scripts/boost_libregex/1.67.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-4.8-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libregex/1.67.0/script.sh
+++ b/scripts/boost_libregex/1.67.0/script.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+BOOST_LIBRARY=${THIS_DIR#boost_lib}
+MASON_NAME=boost_lib${BOOST_LIBRARY}
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+mason_run "$@"

--- a/scripts/boost_libregex_icu/1.67.0/.travis.yml
+++ b/scripts/boost_libregex_icu/1.67.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-4.8-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libregex_icu/1.67.0/script.sh
+++ b/scripts/boost_libregex_icu/1.67.0/script.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+# Note: cannot deduce from directory since it is named in a custom way
+#BOOST_LIBRARY=${THIS_DIR#boost_lib}
+BOOST_LIBRARY=regex
+MASON_NAME=boost_lib${BOOST_LIBRARY}_icu
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+function mason_prepare_compile {
+    ${MASON_DIR}/mason install icu 55.1
+    MASON_ICU=$(${MASON_DIR}/mason prefix icu 55.1)
+}
+
+# custom compile that gets icu working
+function mason_compile {
+    gen_config ${BOOST_TOOLSET} ${BOOST_TOOLSET_CXX}
+    if [[ ! -f ./b2 ]] ; then
+        ./bootstrap.sh
+    fi
+    echo 'int main() { return 0; }' > libs/regex/build/has_icu_test.cpp
+    ./b2 \
+        --with-${BOOST_LIBRARY} \
+        --prefix=${MASON_PREFIX} \
+        -j${MASON_CONCURRENCY} \
+        -sHAVE_ICU=1 -sICU_PATH=${MASON_ICU} --reconfigure --debug-configuration \
+        -d0 \
+        --ignore-site-config --user-config=user-config.jam \
+        architecture="${BOOST_ARCH}" \
+        toolset="${BOOST_TOOLSET}" \
+        link=static \
+        variant=release \
+        linkflags="${LDFLAGS:-" "}" \
+        cxxflags="${CXXFLAGS:-" "}" \
+        stage
+    mkdir -p $(dirname ${MASON_PREFIX}/${MASON_LIB_FILE})
+    mv stage/${MASON_LIB_FILE} ${MASON_PREFIX}/${MASON_LIB_FILE}
+}
+
+mason_run "$@"

--- a/scripts/boost_libregex_icu57/1.67.0/.travis.yml
+++ b/scripts/boost_libregex_icu57/1.67.0/.travis.yml
@@ -1,0 +1,18 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.2
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-4.8-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libregex_icu57/1.67.0/script.sh
+++ b/scripts/boost_libregex_icu57/1.67.0/script.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+# Note: cannot deduce from directory since it is named in a custom way
+#BOOST_LIBRARY=${THIS_DIR#boost_lib}
+BOOST_LIBRARY=regex
+MASON_NAME=boost_lib${BOOST_LIBRARY}_icu57
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+function mason_prepare_compile {
+    ${MASON_DIR}/mason install icu 57.1
+    MASON_ICU=$(${MASON_DIR}/mason prefix icu 57.1)
+}
+
+# custom compile that gets icu working
+function mason_compile {
+    gen_config ${BOOST_TOOLSET} ${BOOST_TOOLSET_CXX}
+    if [[ ! -f ./b2 ]] ; then
+        ./bootstrap.sh
+    fi
+    echo 'int main() { return 0; }' > libs/regex/build/has_icu_test.cpp
+    ./b2 \
+        --with-${BOOST_LIBRARY} \
+        --prefix=${MASON_PREFIX} \
+        -j${MASON_CONCURRENCY} \
+        -sHAVE_ICU=1 -sICU_PATH=${MASON_ICU} --reconfigure --debug-configuration \
+        -d0 -a \
+        --ignore-site-config --user-config=user-config.jam \
+        architecture="${BOOST_ARCH}" \
+        toolset="${BOOST_TOOLSET}" \
+        link=static \
+        variant=release \
+        linkflags="${LDFLAGS:-" "}" \
+        cxxflags="-fvisibility=hidden ${CXXFLAGS:-" "}" \
+        stage
+    mkdir -p $(dirname ${MASON_PREFIX}/${MASON_LIB_FILE})
+    mv stage/${MASON_LIB_FILE} ${MASON_PREFIX}/${MASON_LIB_FILE}
+}
+
+mason_run "$@"

--- a/scripts/boost_libsystem/1.67.0/.travis.yml
+++ b/scripts/boost_libsystem/1.67.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-4.8-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libsystem/1.67.0/script.sh
+++ b/scripts/boost_libsystem/1.67.0/script.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+BOOST_LIBRARY=${THIS_DIR#boost_lib}
+MASON_NAME=boost_lib${BOOST_LIBRARY}
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+mason_run "$@"

--- a/scripts/boost_libtest/1.67.0/.travis.yml
+++ b/scripts/boost_libtest/1.67.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-4.8-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libtest/1.67.0/script.sh
+++ b/scripts/boost_libtest/1.67.0/script.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+BOOST_LIBRARY=${THIS_DIR#boost_lib}
+MASON_NAME=boost_lib${BOOST_LIBRARY}
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+mason_run "$@"

--- a/scripts/boost_libthread/1.67.0/.travis.yml
+++ b/scripts/boost_libthread/1.67.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-4.8-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libthread/1.67.0/script.sh
+++ b/scripts/boost_libthread/1.67.0/script.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+BOOST_LIBRARY=${THIS_DIR#boost_lib}
+MASON_NAME=boost_lib${BOOST_LIBRARY}
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+mason_run "$@"


### PR DESCRIPTION
Created with:

```bash
git checkout -b boost-1.67.0
./utils/new_boost.sh create 1.67.0 1.66.0
git add scripts/boost*/1.67.0/
git commit -a -m "boost 1.67.0"
./utils/new_boost.sh trigger 1.67.0
```

Then I noticed the boost_python builds failed. Debugging locally I found that the library name changed. Fixed this in bb564ee and then manually triggered a build for just boost_python in: https://travis-ci.org/mapbox/mason/builds/369861321 with ` ./mason trigger boost_libpython 1.67.0`