### PR TITLE
Mason readme refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,6 @@ Mason works on both **OS X** and **Linux**.
 # Table of Contents
 
 - [Installation](#installation)
-    + [Curl install](#curl-install)
-    + [Submodule](#submodule)
-    + [mason.cmake](#masoncmake)
 - [Configuration](#configuration)
 - [Usage](#usage)
 - [Creating a package](#creating-a-package)
@@ -42,11 +39,11 @@ Mason works on both **OS X** and **Linux**.
 
 There are three recommended ways to install mason, via:
 
-    * curl
-    * a submodule
-    * bundling `mason.cmake`
+* [Curl](#curl)
+* [Submodule](#submodule)
+* [mason.cmake](#masoncmake)
 
-#### Curl install
+#### Curl
 
 To install mason locally:
 
@@ -329,8 +326,8 @@ These are just basic steps to help get you started. Depending on the complexity 
         - url (first parameter): set to the location of your source code archive, e.g. `https://github.com/mapbox/your-lib/archive/v${MASON_VERSION}.tar.gz`
         - checksum (second parameter): set to the checksum you get back after running a checksum function on the source code you want to download. The easiest way to get this checksum is to run `./mason build your-lib 0.1.0` (after setting the `mason_download` url) which will fail with an error message that will contain the correct checksum
     - `mason_compile`
-        - for header-only see []() for an example
-        - for code that needs to be compiled see []() for an example
+        - for header-only see [geometry 0.9.2](https://github.com/mapbox/mason/blob/master/scripts/geometry/0.9.2/script.sh#L19) for an example
+        - for code that needs to be compiled see [zlib 1.2.8](https://github.com/mapbox/mason/blob/master/scripts/zlib/1.2.8/script.sh#L20) for an example
 
     You **may** also need to override the follow Mason functions:
 

--- a/README.md
+++ b/README.md
@@ -1,38 +1,50 @@
 # Mason
 
-Mason can compile C/C++ code, publish packages to S3, and install those packages via binaries.
+Mason is a package manager for C/C++ applications that allows developers to easily install different versions of packages and to streamline build-and-publish workflows.
 
-Mason does all its work locally inside `./mason_packages` and therefore does not require privileges for, or conflict with, system-wide packages.
+Mason is like:
 
-Mason works on both OS X and Linux.
+* [npm](https://github.com/npm/npm) because it installs packages in the current working directory (`./mason_packages`) rather than globally (and therefore does not require privileges for, or conflict with, system-wide packages)
+* [homebrew](http://brew.sh/) because it requires no use of `sudo` to install packages
+* [apt-get](https://linux.die.net/man/8/apt-get) or [yum](https://linux.die.net/man/8/yum) because it works on Linux
+
+Mason is unlike:
+
+ * all of the above...
+
+    Mason is a collection of bash scripts and does not depend on any specific runtime language, such as python, node.js, or ruby. It can build and publish a single set of binaries (>= OS X 10.8 and >= Ubuntu Precise), publish header-only files, and install packages. Mason has integrations with [Travis CI](https://travis-ci.org) and [Amazon S3](https://aws.amazon.com/s3) for automated build and deployment.
+
+    Mason strongly prefers static libraries over shared libraries and has zero understanding of dependency trees: it leaves complete control to the developer for how packages relate.
+
+Mason works on both **OS X** and **Linux**.
 
 [![Build Status](https://travis-ci.org/mapbox/mason.svg?branch=master)](https://travis-ci.org/mapbox/mason)
 
-### Goals
+# Table of Contents
 
-Mason is a package manager designed for developers who package standalone applications and who need complete control over dependency versions.
-
-Because Mason is developed by Mapbox the default S3 bucket and set of available packages are driven by Mapbox developers. For other developers: 1) fork Mason and ideally rename it to something like `mason-{yourorg}`, 2) configure it against your own s3 bucket, and 3) go ahead an publish your own packages to an S3 bucket of your creation.
-
-### Comparisons
-
-Mason is like [npm](https://github.com/npm/npm) because it installs packages in the current working directory (`./mason_packages`) rather than globally.
-
-Mason is like [homebrew](http://brew.sh/) because it requires no use of `sudo` to install packages.
-
-Mason is like linux package managers like `apt-get` or `yum` because it works on linux.
-
-Mason is unlike all of the above package managers because:
-
-  - Mason runs on both Linux and OS X and creates a single set of binaries that work on >= OS X 10.8 and >= Ubuntu Precise (rather than building binaries per version).
-  - Mason strongly prefers static libraries over shared libraries
-  - Mason has zero understanding of dependency trees: it leaves complete control to the developer for how packages relate.
-  - Mason does not depend on any specific runtime language (like python, node.js or ruby). It is a just a few bash scripts.
-  - Mason depends on [travis.ci](https://travis-ci.org) for creating and publishing binaries.
+- [Installation](#installation)
+    + [Curl install](#curl-install)
+    + [Submodule](#submodule)
+    + [mason.cmake](#masoncmake)
+- [Configuration](#configuration)
+- [Usage](#usage)
+- [Creating a package](#creating-a-package)
+    * [Prerequisites](#prerequisites)
+    * [Getting started](#getting-started)
+    * [Script structure](#script-structure)
+    * [Mason variables](#mason-variables)
+    * [Mason functions](#mason-functions)
+    * [System packages](#system-packages)
+- [Troubleshooting](#troubleshooting)
+- [Conventions](#conventions)
 
 ## Installation
 
-There are three recommended ways to install mason: via curl, via a submodule, or via bundling `mason.cmake`
+There are three recommended ways to install mason, via:
+
+    * curl
+    * a submodule
+    * bundling `mason.cmake`
 
 #### Curl install
 
@@ -101,6 +113,13 @@ mason_use(<package name> VERSION <package version> HEADER_ONLY)
 
 Note: Leave out `HEADER_ONLY` if the package is a [pre-compiled library](https://github.com/mapbox/cpp/blob/master/glossary.md#precompiled-library). You can see if a package is `HEADER_ONLY` by looking inside the `script.sh` for `MASON_HEADER_ONLY=true` like https://github.com/mapbox/mason/blob/68871660b74023234fa96d482898c820a55bd4bf/scripts/geometry/0.9.0/script.sh#L5
 
+## Configuration
+
+By default Mason publishes packages to a Mapbox S3 bucket. If you want to publish to a different bucket we recommend taking the following steps:
+
+1. Fork Mason and rename it to `mason-{your_org}`
+2. Configure Mason against your own s3 bucket
+3. Publish packages to the new location
 
 ## Usage
 
@@ -112,18 +131,18 @@ mason <command> <library> <version>
 
 The `command` can be one of the following
 
-* `install`: Installs the specified library/version
-* `remove`: Removes the specified library/version
-* `build`: Forces a build from source (= skip pre-built binary detection)
-* `publish`: Uploads the built binaries to the S3 bucket
-* `prefix`: Prints the absolute path to the library installation directory
-* `version`: Prints the actual version of the library (only useful when version is `system`)
-* `cflags`: Prints C/C++ compiler flags
-* `ldflags`: Prints linker flags
-* `link`: Creates symlinks for packages in `mason_packages/.link`
-* `trigger`: Trigger a build and publish operation on Travis CI
+* [install](#install) - installs the specified library/version
+* [remove](#remove) - removes the specified library/version
+* [build](#build) - forces a build from source (= skip pre-built binary detection)
+* [publish](#publish) - uploads the built binaries to the S3 bucket
+* [prefix](#prefix) - prints the absolute path to the library installation directory
+* [version](#version) - prints the actual version of the library (only useful when version is `system`)
+* [cflags](#cflags) - prints C/C++ compiler flags
+* [ldflags](#ldflags) - prints linker flags
+* [link](#link) - creates symlinks for packages in `mason_packages/.link`
+* [trigger](#trigger) - trigger a build and publish operation on Travis CI
 
-### `install`
+### install
 
 ```bash
 $ mason install libuv 0.11.29
@@ -141,7 +160,7 @@ Next, Mason checks whether there are pre-built binaries available in the S3 buck
 If no pre-built binaries are available, Mason is going to build the library according to the script in the `mason_packages/.build` folder, and install into the platform- and library-specific directory.
 
 
-### `remove`
+### remove
 
 ```bash
 $ mason remove libuv 0.11.29
@@ -153,15 +172,15 @@ $ mason remove libuv 0.11.29
 
 Removes the specified library/version from the package directory.
 
-### `build`
+### build
 
 This command works like the `install` command, except that it *doesn't* check for existing library installations, and that it *doesn't* check for pre-built binaries. I.e. it first removes the current installation and *always* builds the library from source. This is useful when you are working on a build script and want to fresh builds.
 
-### `publish`
+### publish
 
 Creates a gzipped tarball of the specified platform/library/version and uploads it to the `mason-binaries` S3 bucket. If you want to use this feature, you need write access to the bucket and need to specify the environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
 
-### `prefix`
+### prefix
 
 ```bash
 ~ $ mason prefix libuv 0.11.29
@@ -170,7 +189,16 @@ Creates a gzipped tarball of the specified platform/library/version and uploads 
 
 This prints the absolute path to the installation directory of the the library/version. Likely, this folder has the typical `include` and `lib` folders.
 
-### `cflags`
+### version
+
+```bash
+~ $ mason version zlib system
+1.2.11
+```
+
+This prints the version of the library, which is only useful when version is `system`. See [System packages](#system-packages) for more details.
+
+### cflags
 
 ```bash
 ~ $ mason cflags libuv 0.11.29
@@ -179,7 +207,7 @@ This prints the absolute path to the installation directory of the the library/v
 
 Prints the C/C++ compiler flags that are required to compile source code with this library. Likely, this is just the include path, but may also contain other flags.
 
-### `ldflags`
+### ldflags
 
 ```bash
 ~ $ mason ldflags libuv 0.11.29
@@ -188,7 +216,7 @@ Prints the C/C++ compiler flags that are required to compile source code with th
 
 Prints the linker flags that are required to link against this library.
 
-### `link`
+### link
 
 ```bash
 ~ $ mason link libuv 0.11.29
@@ -196,7 +224,7 @@ Prints the linker flags that are required to link against this library.
 
 This command only works if the package has already been installed. When run it symlinks the versioned `lib`, `include`, `share`, and `bin` folders of the package into a shared structure that is unversioned. For example if `mason prefix libuv 0.11.29` was `./mason_packages/osx-10.10/libuv/0.11.29` then the library would become available at `./mason_packages/.link/lib/libuv.a`
 
-### `trigger`
+### trigger
 
 In order to ensure that all prebuilt binaries are consistent and reproducible, we perform the final build and publish operation on Travis CI.
 
@@ -231,141 +259,135 @@ curl -s -i https://api.travis-ci.org/auth/github \
 
 For details see https://docs.travis-ci.com/user/triggering-builds and https://github.com/travis-ci/travis.rb#readme
 
-## Writing build scripts
+## Creating a package
 
-Each version of each package has its own directory in `scripts/${package}/${version}`, e.g. [`scripts/libpng/1.6.28`](https://github.com/mapbox/mason/tree/master/scripts/libpng/1.6.28).
+### Prerequisites
 
-Below are details on ways to create packages for:
+Before getting started you should be able to answer the following questions.
 
- - new packages (not previously unpackaged software)
- - new versions of existing packages
- - header-only libraries and pre-compiled libraries
+**What are you packaging?**
 
-### Creating new packages
+There are different steps that you will need to follow depending on the type of library you are packaging. For example, there are fewer steps you need to take if you are creating a package of header-only code. Packaging compiled code has more steps because you'll need to tell Mason how to build your binaries. Another type of package is a [System package](#system-package) which has a unique process as well.
 
-If you are creating a package for previously unpackaged software start by creating a new directory for your `${package}/${version}` from within your mason checkout.
+**Are there previous versions already published?**
 
-For example if you want to name your package `yourlib` and it is version `1.0.0` you would do:
+Check the [list of packages](https://github.com/mapbox/mason/tree/master/scripts) to see if a previous version of your package exists. It's helpful to copy scripts from a previous version rather than creating code from scratch.
 
-```bash
-mkdir -p scripts/yourlib/1.0.0
-```
+If there is no previous version of your package, it is recommended to copy a simple package that has mostly boiler plate code:
 
-The directory must contain two files:
+ - [geometry](https://github.com/mapbox/mason/tree/master/scripts/geometry/0.9.2) for header-only code
+ - [libpng](https://github.com/mapbox/mason/tree/master/scripts/libpng/1.6.32) for building and packaging binaries
 
-    - `script.sh`
-    - `.travis.yml`
+**Where can Mason download your code?**
 
-What you put in those files depend on what type of package you are creating. See:
+Every package needs to tell Mason where to download the code that it will build and publish, for example:
 
- - [Header-only package](#header-only-package)
- - [Pre-compiled library package](#pre-compiled-library-package)
+ - `https://github.com/mapbox/geometry.hpp/archive/v0.9.2.tar.gz` for a Github release: [geometry 0.9.2](https://github.com/mapbox/geometry.hpp/releases/tag/v0.9.2)
+ - `https://github.com/mapbox/geometry.hpp/archive/b0e41cc5635ff8d50e7e1edb73cadf1d2a7ddc83.zip` for pre-release code hosted on Github: [geometry b0e41cc](https://github.com/mapbox/geometry.hpp/tree/b0e41cc5635ff8d50e7e1edb73cadf1d2a7ddc83)
 
-### Creating new versions of packages
+Note: Your code doesn't need to be hosted on Github in order for Mason to work. Your code can be hosted anywhere. Another common location is [SourceForge](#https://sourceforge.net/).
 
-When creating a new package it is recommended to start by copying an existing package.
+### Getting started
 
-Each package must contain two files:
+These are just basic steps to help get you started. Depending on the complexity of building your code, you might have to review the [Script structure](#script-structure) section to get a better idea of how to further configure Mason to be able to create your package.
 
-    - `script.sh`
-    - `.travis.yml`
+1. Create a new directory for your package.
 
-What you put in those files depend on what type of package you are creating. See:
+    From inside your `mason` checkout, create a directory named `${package}/${version}`. For example, if you have a library named `your-lib` that is version `0.1.0` you would:
 
- - [Header-only package](#header-only-package)
- - [Pre-compiled library package](#pre-compiled-library-package)
+    ```bash
+    mkdir -p scripts/your-lib/0.1.0
+    ```
 
-#### Header-only package
+2. Add scripts for building and publishing your package.
 
-For a header-only library, a good example to copy from is the `geometry` package. You can copying the `geometry` package:
+    Each package must have the following two files: `script.sh` and `.travis.yml`. Copy these two files from a previous version of your package, or, if one doesn't exist, from a package of the same type (either compiled-code or header-only) that contains mostly boiler-plate code. For more details on where to look, see [Prerequisites](#prerequisites).
 
-```bash
-cp -r scripts/geometry/0.9.1 scripts/yourlib/1.0.0
-```
+    For example, if you're creating the first package of a library named `your-lib` that is version `0.1.0` you would copy scripts from the `geometry` package:
 
-You will not need to edit the `.travis.yml`, but you will need to edit the `script.sh`.
+    ```bash
+    cp -r scripts/geometry/0.9.1 scripts/your-lib/0.1.0
+    ```
 
-See the [Script structure](#script-structure) section below for details on the `script.sh` format. A `script.sh` is simplier for header-only libraries, so here is a shortlist of things you need to change:
+3. Edit Mason variables in `script.sh`.
 
-- `MASON_NAME`: change it from `geometry` to `yourlib`
-- `MASON_VERSION`: change it from `0.9.1` to your version
+    You **must** set the follow Mason variables:
 
-Then you will also need to update:
+    - `MASON_NAME`: set to the name of your package, e.g. `your-lib`
+    - `MASON_VERSION`: set to the package version, e.g. `0.1.0`
+    - `MASON_BUILD_PATH`: set to the location Mason will use to store header files or binaries before it packages and publishes them
 
- - The github url on line `11` to match your download url
- - The hash on line `12`. To do this, it is easiest to run `./mason build yourlib version` and it will fail, but the error message will contain the correct hash. Copy the hash and put it on line `12`.
+    You **may** also need to set the follow Mason variables:
 
-Now update the `MASON_BUILD_PATH`. You will need to change the text of `geometry.hpp-` to your package name. This will likely work for your entire line:
+    - Other [Mason variables](#mason-variables)
 
-```
-export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
-```
+4. Override Mason functions in `script.sh`.
 
-Now make any adjustments needed to the `mason_compile` section, modifying the copying of headers.
+    You **must** override the follow Mason functions:
 
-#### Pre-compiled library package
+    - `mason_load_source`: you must call `mason_download` and update its parameters:
+        - url (first parameter): set to the location of your source code archive, e.g. `https://github.com/mapbox/your-lib/archive/v${MASON_VERSION}.tar.gz`
+        - checksum (second parameter): set to the checksum you get back after running a checksum function on the source code you want to download. The easiest way to get this checksum is to run `./mason build your-lib 0.1.0` (after setting the `mason_download` url) which will fail with an error message that will contain the correct checksum
+    - `mason_compile`
+        - for header-only see []() for an example
+        - for code that needs to be compiled see []() for an example
 
-For a compiled library package, start by copying the `libpng` package:
+    You **may** also need to override the follow Mason functions:
 
-```bash
-cp -r scripts/libpng/1.6.28 scripts/yourlib/1.0.0
-```
+    - Other [Mason functions](#mason-functions)
 
-See the [Script structure](#script-structure) section below for details on the `script.sh` format.
+### Script structure
 
-#### Script structure
-
-This `script.sh` is structured like:
+This `script.sh` in each package is structured like:
 
 ```bash
 #!/usr/bin/env bash
 
+# This is required for every package.
 MASON_NAME=libuv
 MASON_VERSION=0.11.29
+
+# This is required if Mason will need to build a static library. Specify the relative path in the
+# installation directory.
 MASON_LIB_FILE=lib/libuv.a
+
+# You can specify the relative path to the pkg-config file if Mason needs to build your code before
+# packaging. If the library doesn't have a pkg-config file, you will need to override the functions
+# `mason_cflags` and `mason_ldflags`.
 MASON_PKGCONFIG_FILE=lib/pkgconfig/libuv.pc
-```
 
-Declare these variables first. `MASON_NAME` and `MASON_VERSION` are mandatory. If the install script build a static library, specify the relative path in the installation directory in `MASON_LIB_FILE`. This is used to check whether an installation actually exists before proceeding to download/build the library anew. You can optionally specify `MASON_PKGCONFIG_FILE` as the relative path to the pig-config file if the library has one. If the library doesn't have one, you need to override the functions `mason_cflags` and `mason_ldflags` (see below).
-
-Then, we're loading the build system with
-
-```bash
+# This is required when you need to load the build system to build your code before packaging. You
+# con't need this line if you are packaging header-only code.
 . ${MASON_DIR}/mason.sh
-```
 
-Next, we're defining a function that obtains the source code and unzips it:
-
-```bash
+# Overriding this Mason function is required for all pakcages so Mason knows where to obtain your
+# source code.
 function mason_load_source {
     mason_download \
         https://github.com/joyent/libuv/archive/v0.11.29.tar.gz \
         5bf49a8652f680557cbaf335a160187b2da3bf7f
 
+    # This unpacks the archive into the `mason_packages/.build` folder. If the tarball is BZip2
+    # compressed, you can also use `mason_extract_tar_bz2` instead.
     mason_extract_tar_gz
 
-    export MASON_BUILD_PATH=${MASON_ROOT}/.build/libuv-${MASON_VERSION}
+    # This variable contains the path to the unpacked folder inside the `.build` directory.
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
 }
-```
 
-In that function, you should use `mason_download` as a shortcut to download the tarball. The second argument to is a hash generated with `git hash-object` and used to verify that the source code downloaded matches the expected file. The function also caches downloaded tarballs in the `mason_packages/.cache` folder. You can get the hash object by running `./mason build <package> <version>` locally and this should fail with a message of the expected hash.
-
-`mason_extract_tar_gz` unpacks the archive into the `mason_packages/.build` folder. If the tarball is BZip2 compressed, you can also use `mason_extract_tar_bz2` instead.
-
-Lastly, the `MASON_BUILD_PATH` variable contains the path to the unpacked folder inside the `.build` directory.
-
-Then, you can optionally specify a function that is run before compiling, e.g. a script that generates configuration files:
-
-```bash
+# Override this Mason function if you need to run code before compiling, e.g. a script that
+# generates configuration files.
 function mason_prepare_compile {
     ./autogen.sh
 }
-```
 
-The heart of the script is the `mason_compile` function because it performs the actual build of the source code. There are a few variables available that you need to use to make sure that the package will work correctly.
-
-```bash
+# It is required to override the `mason_compile` function because it performs the actual build of
+# the source code (or just copies header files into a package folder to be published later for
+# header-only code). This is an example of how you would configure and make a static library.
 function mason_compile {
+    # You must set the build system's installation prefix to `MASON_PREFIX`. For cross-platform
+    # builds, you have to specify the `MASON_HOST_ARG`, which is empty for regular builds and is set
+    # to the correct host platform for cross-compiles e.g. iOS builds use `--host=arm-apple-darwin`.
     ./configure \
         --prefix=${MASON_PREFIX} \
         ${MASON_HOST_ARG} \
@@ -373,30 +395,23 @@ function mason_compile {
         --disable-shared \
         --disable-dependency-tracking
 
+    # If the build system supports building concurrently, you can tell it do do so by providing the
+    # number of parallel tasks from `MASON_CONCURRENCY`.
     make install -j${MASON_CONCURRENCY}
 }
-```
 
-In particular, you have to set the build system's installation prefix to `MASON_PREFIX`. For cross-platform builds, you have to specify the `MASON_HOST_ARG`, which is empty for regular builds and is set to the correct host platform for cross-compiles (e.g. iOS builds use `--host=arm-apple-darwin`).
-
-If the build system supports building concurrently, you can tell it do do so by providing the number of parallel tasks from `MASON_CONCURRENCY`.
-
-
-Next, the `mason_clean` function tells Mason how to clean up the build folder. This is required for multi-architecture builds. E.g. iOS builds perform a Simulator (Intel architecture) build first, then an iOS (ARM architecture) build. The results are `lipo`ed into one universal archive file.
-
-```bash
+# Tell Mason how to clean up the build folder. This is required for multi-architecture builds. e.g.
+# iOS builds perform a Simulator (Intel architecture) build first, then an iOS (ARM architecture)
+# build. The results are `lipo`ed into one universal archive file.
 function mason_clean {
     make clean
 }
-```
 
-Finally, we're going to run the everything:
-
-```bash
+# Run everything.
 mason_run "$@"
 ```
 
-### Variables
+### Mason variables
 
 Name | Description
 ---|---
@@ -419,16 +434,14 @@ Name | Description
 `MASON_XCODE_ROOT` | OS X specific; Path to the Xcode Developer directory. Example: `/Applications/Xcode.app/Contents/Developer`
 `MASON_HEADER_ONLY` | Set to `true` to specify this library as header-only, which bypasses building binaries (default `false`)
 
-### Customization
+### Mason functions
 
-In addition to the override functions described above, you can also override the `mason_cflags` and `mason_ldflags` functions. By default, they're using `pkg-config` to determine these flags and print them to standard output. If a library doesn't include a `.pc` file, or has some other mechanism for determining the build flags, you can run them instead:
+These are common Mason function that you might need to override in your package's `script.sh` file depending on the type of library you are packaging. See https://github.com/mapbox/mason/blob/master/mason.sh to view how these functions are implemented by default. There you will find even more `mason_`-functions that you might find useful to override.
 
-
-```bash
-function mason_ldflags {
-    ${MASON_PREFIX}/bin/curl-config --static-libs`
-}
-```
+ `mason_pkgconfig`
+ `mason_cflags`
+ `mason_ldflags`
+ `mason_static_libs`
 
 ### System packages
 

--- a/README.md
+++ b/README.md
@@ -438,10 +438,10 @@ Name | Description
 
 These are common Mason function that you might need to override in your package's `script.sh` file depending on the type of library you are packaging. See https://github.com/mapbox/mason/blob/master/mason.sh to view how these functions are implemented by default. There you will find even more `mason_`-functions that you might find useful to override.
 
- `mason_pkgconfig`
- `mason_cflags`
- `mason_ldflags`
- `mason_static_libs`
+ - `mason_pkgconfig`
+ - `mason_cflags`
+ - `mason_ldflags`
+ - `mason_static_libs`
 
 ### System packages
 


### PR DESCRIPTION
Giving this README some love with some fresh 👁 👁 👁

My goals in modifying this README are:

* To make it easier to navigate between sections
  - By using a Table of Contents and frequent use of header-links 
  - By reordering sections
* To reduce redundancy
  - By combining instructions for creating header-only and compiled-library packages 
* To reduce ambiguity 
  - By explaining how instructions are just for getting started and that, depending on the complexity of the code being packaged, you may need to do more work
  - Also by listing out questions you should ask yourself before creating a package
* To add useful new sections
  - Releasing a package
  - Using a package
  - Mason internals

Reference: https://github.com/mapbox/mason/pull/606

cc @springmeyer @GretaCB 