### PR TITLE
Public Valhalla 2.4.9

### DIFF
--- a/scripts/valhalla/2.4.9/.travis.yml
+++ b/scripts/valhalla/2.4.9/.travis.yml
@@ -16,10 +16,12 @@ matrix:
       compiler: clang
       sudo: false
       addons:
-        sources:
-          - ubuntu-toolchain-r-test
         apt:
-          packages: [ 'zlib1g-dev', 'libstdc++-5-dev' ]
+          sources:
+          - ubuntu-toolchain-r-test
+          packages:
+          - zlib1g-dev
+          - libstdc++-5-dev
     #- os: linux
     #  env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v5
     #  sudo: false

--- a/scripts/valhalla/2.4.9/.travis.yml
+++ b/scripts/valhalla/2.4.9/.travis.yml
@@ -1,4 +1,4 @@
-language: generic
+language: cpp
 
 matrix:
   include:
@@ -15,6 +15,11 @@ matrix:
       env: MASON_PLATFORM=linux
       compiler: clang
       sudo: false
+      addons:
+        sources:
+          - ubuntu-toolchain-r-test
+        apt:
+          packages: [ 'zlib1g-dev', 'libstdc++-5-dev' ]
     #- os: linux
     #  env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v5
     #  sudo: false

--- a/scripts/valhalla/2.4.9/.travis.yml
+++ b/scripts/valhalla/2.4.9/.travis.yml
@@ -39,4 +39,6 @@ matrix:
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}
+
+after_success:
 - ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/valhalla/2.4.9/.travis.yml
+++ b/scripts/valhalla/2.4.9/.travis.yml
@@ -22,6 +22,7 @@ matrix:
           packages:
           - zlib1g-dev
           - libstdc++-5-dev
+          - libssl-dev
     #- os: linux
     #  env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v5
     #  sudo: false

--- a/scripts/valhalla/2.4.9/.travis.yml
+++ b/scripts/valhalla/2.4.9/.travis.yml
@@ -1,0 +1,42 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.2
+      compiler: clang
+    #- os: linux
+    #  env: MASON_PLATFORM_VERSION=i686
+    #  sudo: false
+    #  addons:
+    #    apt:
+    #      packages: [ 'zlib1g-dev:i386' ]
+    - os: linux
+      env: MASON_PLATFORM=linux
+      compiler: clang
+      sudo: false
+    #- os: linux
+    #  env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v5
+    #  sudo: false
+    #- os: linux
+    #  env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v7
+    #  sudo: false
+    #- os: linux
+    #  env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v8
+    #  sudo: false
+    #- os: linux
+    #  env: MASON_PLATFORM=android MASON_ANDROID_ABI=x86
+    #  sudo: false
+    #- os: linux
+    #  env: MASON_PLATFORM=android MASON_ANDROID_ABI=x86-64
+    #  sudo: false
+    #- os: linux
+    #  env: MASON_PLATFORM=android MASON_ANDROID_ABI=mips
+    #  sudo: false
+    #- os: linux
+    #  env: MASON_PLATFORM=android MASON_ANDROID_ABI=mips-64
+    #  sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/valhalla/2.4.9/patch.diff
+++ b/scripts/valhalla/2.4.9/patch.diff
@@ -1,0 +1,15 @@
+diff --git a/configure.ac b/configure.ac
+index a633803c..a36a75e8 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -50,8 +50,8 @@ AC_SUBST(RAPIDJSON_CPPFLAGS, "$RAPIDJSON_CPPFLAGS -DRAPIDJSON_HAS_STDSTRING")
+ 
+ # Note - because libz4 changed it's versioning scheme, we need to check for both >131, and if
+ #        that fails, try >= 1.7.3
+-PKG_CHECK_MODULES([DEPS], [protobuf >= 2.4.0 libcurl >= 7.35.0 zlib >= 1.2.8 liblz4 >= 131],, [
+-  PKG_CHECK_MODULES([DEPS], [protobuf >= 2.4.0 libcurl >= 7.35.0 zlib >= 1.2.8 liblz4 >= 1.7.3])
++PKG_CHECK_MODULES([DEPS], [protobuf >= 2.4.0 libcurl >= 7.35.0 zlib >= 1.2.3 liblz4 >= 131],, [
++  PKG_CHECK_MODULES([DEPS], [protobuf >= 2.4.0 libcurl >= 7.35.0 zlib >= 1.2.3 liblz4 >= 1.7.3])
+ ])
+ 
+ # if we wanted services

--- a/scripts/valhalla/2.4.9/patch.diff
+++ b/scripts/valhalla/2.4.9/patch.diff
@@ -70,6 +70,39 @@ index 94b3af7e..8a153a26 100644
  GraphTile::~GraphTile() {
  }
  
+diff --git a/src/thor/matrix_action.cc b/src/thor/matrix_action.cc
+index a6c79c03..ff142240 100644
+--- a/src/thor/matrix_action.cc
++++ b/src/thor/matrix_action.cc
+@@ -1,3 +1,4 @@
++#include "midgard/logging.h"
+ #include "thor/worker.h"
+ #include "sif/autocost.h"
+ #include "sif/bicyclecost.h"
+diff --git a/src/thor/trace_route_action.cc b/src/thor/trace_route_action.cc
+index 346c85d8..2ee0e99f 100644
+--- a/src/thor/trace_route_action.cc
++++ b/src/thor/trace_route_action.cc
+@@ -8,6 +8,7 @@
+ 
+ #include "exception.h"
+ #include "meili/map_matcher.h"
++#include <valhalla/midgard/logging.h>
+ 
+ #include "thor/route_matcher.h"
+ #include "thor/map_matcher.h"
+diff --git a/src/tyr/locate_serializer.cc b/src/tyr/locate_serializer.cc
+index 1760a9ea..84a7f833 100644
+--- a/src/tyr/locate_serializer.cc
++++ b/src/tyr/locate_serializer.cc
+@@ -1,6 +1,7 @@
+ #include <cstdint>
+ #include "baldr/json.h"
+ #include "tyr/serializers.h"
++#include "midgard/logging.h"
+ 
+ using namespace valhalla;
+ using namespace valhalla::baldr;
 diff --git a/valhalla/baldr/graphreader.h b/valhalla/baldr/graphreader.h
 index dfe1b1fe..d9fe0935 100644
 --- a/valhalla/baldr/graphreader.h

--- a/scripts/valhalla/2.4.9/patch.diff
+++ b/scripts/valhalla/2.4.9/patch.diff
@@ -13,3 +13,107 @@ index a633803c..a36a75e8 100644
  ])
  
  # if we wanted services
+diff --git a/src/baldr/graphreader.cc b/src/baldr/graphreader.cc
+index 520469c0..56b0408f 100644
+--- a/src/baldr/graphreader.cc
++++ b/src/baldr/graphreader.cc
+@@ -247,22 +247,7 @@ const GraphTile* GraphReader::GetGraphTile(const GraphId& graphid) {
+     return inserted;
+   }// Try getting it from flat file
+   else {
+-    // This reads the tile from disk
+-    GraphTile tile(tile_dir_, base);
+-    if (!tile.header()) {
+-      if(tile_url_.empty() || _404s.find(base) != _404s.end())
+-        return nullptr;
+-      tile = GraphTile(tile_url_, base, curler);
+-      if(!tile.header()) {
+-        _404s.insert(base);
+-        return nullptr;
+-      }
+-    }
+-
+-    // Keep a copy in the cache and return it
+-    size_t size = tile.header()->end_offset();
+-    auto inserted = cache_->Put(base, tile, size);
+-    return inserted;
++    return nullptr;
+   }
+ }
+ 
+diff --git a/src/baldr/graphtile.cc b/src/baldr/graphtile.cc
+index 94b3af7e..8a153a26 100644
+--- a/src/baldr/graphtile.cc
++++ b/src/baldr/graphtile.cc
+@@ -123,24 +123,6 @@ GraphTile::GraphTile(const GraphId& graphid, char* ptr, size_t size)
+   Initialize(graphid, ptr, size);
+ }
+ 
+-GraphTile::GraphTile(const std::string& tile_url, const GraphId& graphid, curler_t& curler) {
+-  // Don't bother with invalid ids
+-  if (!graphid.Is_Valid() || graphid.level() > TileHierarchy::get_max_level())
+-    return;
+-
+-  // Get the response returned from curl
+-  std::string uri = tile_url + filesystem::path_separator + FileSuffix(graphid.Tile_Base());
+-  long http_code;
+-  auto tile_data = curler(uri, http_code);
+-
+-  // If its good try to use it
+-  if(http_code == 200) {
+-    graphtile_ = std::make_shared<std::vector<char> >(std::move(tile_data));
+-    Initialize(graphid, &(*graphtile_)[0], graphtile_->size());
+-    //TODO: optionally write the tile to disk?
+-  }
+-}
+-
+ GraphTile::~GraphTile() {
+ }
+ 
+diff --git a/valhalla/baldr/graphreader.h b/valhalla/baldr/graphreader.h
+index dfe1b1fe..d9fe0935 100644
+--- a/valhalla/baldr/graphreader.h
++++ b/valhalla/baldr/graphreader.h
+@@ -6,7 +6,6 @@
+ #include <unordered_map>
+ #include <mutex>
+ 
+-#include <valhalla/baldr/curler.h>
+ #include <valhalla/baldr/graphid.h>
+ #include <valhalla/baldr/graphtile.h>
+ #include <valhalla/baldr/tilehierarchy.h>
+@@ -562,7 +561,6 @@ class GraphReader {
+   static std::shared_ptr<const GraphReader::tile_extract_t> get_extract_instance(const boost::property_tree::ptree& pt);
+ 
+   // Stuff for getting at remote tiles
+-  curler_t curler;
+   std::string tile_url_;
+   std::unordered_set<GraphId> _404s;
+   // Information about where the tiles are kept
+diff --git a/valhalla/baldr/graphtile.h b/valhalla/baldr/graphtile.h
+index 7e80e549..03c16378 100644
+--- a/valhalla/baldr/graphtile.h
++++ b/valhalla/baldr/graphtile.h
+@@ -19,7 +19,6 @@
+ #include <valhalla/baldr/sign.h>
+ #include <valhalla/baldr/edgeinfo.h>
+ #include <valhalla/baldr/admininfo.h>
+-#include <valhalla/baldr/curler.h>
+ 
+ #include <valhalla/midgard/util.h>
+ #include <valhalla/midgard/aabb2.h>
+@@ -60,14 +59,6 @@ class GraphTile {
+    */
+   GraphTile(const GraphId& graphid, char* ptr, size_t size);
+ 
+-  /**
+-   * Constructor given the graph Id, in memory tile data
+-   * @param  tile_url URL of tile
+-   * @param  graphid Tile Id
+-   * @param  curler curler that will handle tile downloading
+-   */
+-  GraphTile(const std::string& tile_url, const GraphId& graphid, curler_t& curler);
+-
+   /**
+    * Destructor
+    */

--- a/scripts/valhalla/2.4.9/script.sh
+++ b/scripts/valhalla/2.4.9/script.sh
@@ -35,6 +35,9 @@ function mason_prepare_compile {
         MASON_ZLIB_LDFLAGS="-L$(${MASON_DIR}/mason prefix zlib_shared ${ZLIB_SHARED_VERSION})/lib"
     fi
 
+    ${MASON_DIR}/mason install lz4 1.8.2
+    ${MASON_DIR}/mason link lz4 1.8.2
+
     ${MASON_DIR}/mason install protobuf 3.5.1
     ${MASON_DIR}/mason link protobuf 3.5.1
 
@@ -62,7 +65,6 @@ function mason_prepare_compile {
 
     ${MASON_DIR}/mason install sqlite 3.21.0
     ${MASON_DIR}/mason link sqlite 3.21.0
-
 
     # set up to fix libtool .la files
     # https://github.com/mapbox/mason/issues/61
@@ -100,6 +102,8 @@ export
 
     NOCONFIGURE=1 ./autogen.sh
 
+
+    PKG_CONFIG_PATH="${MASON_ROOT}/.link/lib/pkgconfig" \
     ./configure \
         --prefix="$MASON_PREFIX" \
         ${MASON_HOST_ARG} \

--- a/scripts/valhalla/2.4.9/script.sh
+++ b/scripts/valhalla/2.4.9/script.sh
@@ -136,9 +136,7 @@ export
 }
 
 function mason_strip_ldflags {
-    shift # -L...
-    shift # -lpng16
-    echo "$@"
+    :
 }
 
 function mason_cflags {
@@ -146,7 +144,7 @@ function mason_cflags {
 }
 
 function mason_ldflags {
-    mason_strip_ldflags $(`mason_pkgconfig` --static --libs)
+    :
 }
 
 function mason_clean {

--- a/scripts/valhalla/2.4.9/script.sh
+++ b/scripts/valhalla/2.4.9/script.sh
@@ -38,8 +38,8 @@ function mason_prepare_compile {
     ${MASON_DIR}/mason install lz4 1.8.2
     ${MASON_DIR}/mason link lz4 1.8.2
 
-    ${MASON_DIR}/mason install protobuf 3.5.1
-    ${MASON_DIR}/mason link protobuf 3.5.1
+    ${MASON_DIR}/mason install protobuf 3.5.1-cxx11abi
+    ${MASON_DIR}/mason link protobuf 3.5.1-cxx11abi
 
     ${MASON_DIR}/mason install boost 1.66.0
     ${MASON_DIR}/mason link boost 1.66.0

--- a/scripts/valhalla/2.4.9/script.sh
+++ b/scripts/valhalla/2.4.9/script.sh
@@ -38,8 +38,8 @@ function mason_prepare_compile {
     ${MASON_DIR}/mason install lz4 1.8.2
     ${MASON_DIR}/mason link lz4 1.8.2
 
-    ${MASON_DIR}/mason install protobuf 3.5.1-cxx11abi
-    ${MASON_DIR}/mason link protobuf 3.5.1-cxx11abi
+    ${MASON_DIR}/mason install protobuf 3.5.1
+    ${MASON_DIR}/mason link protobuf 3.5.1
 
     ${MASON_DIR}/mason install boost 1.66.0
     ${MASON_DIR}/mason link boost 1.66.0

--- a/scripts/valhalla/2.4.9/script.sh
+++ b/scripts/valhalla/2.4.9/script.sh
@@ -108,6 +108,8 @@ function mason_compile {
 
 export
 
+    patch -N -p1 < ${MASON_DIR}/scripts/${MASON_NAME}/${MASON_VERSION}/patch.diff
+
     NOCONFIGURE=1 ./autogen.sh
 
 

--- a/scripts/valhalla/2.4.9/script.sh
+++ b/scripts/valhalla/2.4.9/script.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+
+MASON_NAME=valhalla
+MASON_VERSION=2.4.9
+MASON_LIB_FILE=lib/libpng.a
+#MASON_PKGCONFIG_FILE=lib/pkgconfig/libpng.pc
+
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+#    mason_download \
+#        https://github.com/valhalla/${MASON_NAME}/archive/${MASON_VERSION}.tar.gz \
+#        12718a7f8d26f707469895fb2a7e69f748356f7d
+#
+#    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
+
+    if [ ! -d "$MASON_BUILD_PATH" ] ; then
+        mkdir -p "$MASON_BUILD_PATH"
+        git clone --branch "$MASON_VERSION" --recursive https://github.com/valhalla/valhalla.git "$MASON_BUILD_PATH"
+    fi
+}
+
+function mason_prepare_compile {
+    # Install the zlib dependency when cross compiling as usually the host system only
+    # provides the zlib headers and libraries in the path for the host architecture.
+    if [ ${MASON_PLATFORM_VERSION} == "cortex_a9" ] || [ ${MASON_PLATFORM_VERSION} == "i686" ]; then
+        cd $(dirname ${MASON_ROOT})
+        ${MASON_DIR}/mason install zlib_shared ${ZLIB_SHARED_VERSION}
+        ${MASON_DIR}/mason link zlib_shared ${ZLIB_SHARED_VERSION}
+
+        MASON_ZLIB_CFLAGS="$(${MASON_DIR}/mason cflags zlib_shared ${ZLIB_SHARED_VERSION})"
+        MASON_ZLIB_LDFLAGS="-L$(${MASON_DIR}/mason prefix zlib_shared ${ZLIB_SHARED_VERSION})/lib"
+    fi
+
+    ${MASON_DIR}/mason install protobuf 3.5.1
+    ${MASON_DIR}/mason link protobuf 3.5.1
+
+    ${MASON_DIR}/mason install boost 1.66.0
+    ${MASON_DIR}/mason link boost 1.66.0
+    ${MASON_DIR}/mason install boost_libprogram_options 1.66.0
+    ${MASON_DIR}/mason link boost_libprogram_options 1.66.0
+    ${MASON_DIR}/mason install boost_libsystem 1.66.0
+    ${MASON_DIR}/mason link boost_libsystem 1.66.0
+    ${MASON_DIR}/mason install boost_libthread 1.66.0
+    ${MASON_DIR}/mason link boost_libthread 1.66.0
+    ${MASON_DIR}/mason install boost_libfilesystem 1.66.0
+    ${MASON_DIR}/mason link boost_libfilesystem 1.66.0
+    ${MASON_DIR}/mason install boost_libregex 1.66.0
+    ${MASON_DIR}/mason link boost_libregex 1.66.0
+    ${MASON_DIR}/mason install boost_libdate_time 1.66.0
+    ${MASON_DIR}/mason link boost_libdate_time 1.66.0
+    ${MASON_DIR}/mason install boost_libiostreams 1.66.0
+    ${MASON_DIR}/mason link boost_libiostreams 1.66.0
+
+    ${MASON_DIR}/mason install lua 5.3.0
+    ${MASON_DIR}/mason link lua 5.3.0
+
+}
+
+function mason_compile {
+    export CXXFLAGS="-isystem ${MASON_ROOT}/.link/include ${CXXFLAGS:-}"
+    export CFLAGS="-isystem ${MASON_ROOT}/.link/include ${CFLAGS:-}"
+    export LDFLAGS="-L${MASON_ROOT}/.link/lib ${LDFLAGS:-}"
+    export PATH="${MASON_ROOT}/.link/bin:${PATH}"
+    export LUA="${MASON_ROOT}/.link/bin/lua"
+    export LUA_INCLUDE="-isystem ${MASON_ROOT}/.link/include"
+    export LUA_LIB="-llua"
+
+#declare -x MASON_BUILD_PATH="/Users/danpat/mapbox/mason/mason_packages/.build/valhalla-2.4.9"
+#declare -x MASON_DIR="/Users/danpat/mapbox/mason"
+#declare -x MASON_DYNLIB_SUFFIX="dylib"
+#declare -x MASON_HOST_ARG="--host=x86_64-apple-darwin"
+#declare -x MASON_PLATFORM_VERSION="x86_64"
+#declare -x MASON_ROOT="/Users/danpat/mapbox/mason/mason_packages"
+
+export
+
+    ./autogen.sh
+
+    ./configure \
+        --with-protobuf-includes="$MASON_ROOT/.link/include" \
+        --with-protobuf-libdir="$MASON_ROOT/.link/lib" \
+        --prefix="$MASON_PREFIX" \
+        ${MASON_HOST_ARG} \
+        --enable-static \
+        --with-pic \
+        --disable-shared \
+        --disable-dependency-tracking \
+        --disable-python-bindings
+
+    V=1 VERBOSE=1 make install -j${MASON_CONCURRENCY}
+}
+
+function mason_strip_ldflags {
+    shift # -L...
+    shift # -lpng16
+    echo "$@"
+}
+
+function mason_ldflags {
+    mason_strip_ldflags $(`mason_pkgconfig` --static --libs)
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"

--- a/scripts/valhalla/2.4.9/script.sh
+++ b/scripts/valhalla/2.4.9/script.sh
@@ -66,6 +66,14 @@ function mason_prepare_compile {
     ${MASON_DIR}/mason install sqlite 3.21.0
     ${MASON_DIR}/mason link sqlite 3.21.0
 
+    if [ ${MASON_PLATFORM} = 'osx' ]; then
+        ${MASON_DIR}/mason install libcurl system
+        ${MASON_DIR}/mason link libcurl system
+    else
+        ${MASON_DIR}/mason install libcurl 7.50.2
+        ${MASON_DIR}/mason link libcurl 7.50.2
+    fi
+
     # set up to fix libtool .la files
     # https://github.com/mapbox/mason/issues/61
     if [[ $(uname -s) == 'Darwin' ]]; then

--- a/scripts/valhalla/2.4.9/script.sh
+++ b/scripts/valhalla/2.4.9/script.sh
@@ -50,6 +50,8 @@ function mason_prepare_compile {
     ${MASON_DIR}/mason link boost_libfilesystem 1.66.0
     ${MASON_DIR}/mason install boost_libregex_icu57 1.66.0
     ${MASON_DIR}/mason link boost_libregex_icu57 1.66.0
+    ${MASON_DIR}/mason install boost_libregex 1.66.0
+    ${MASON_DIR}/mason link boost_libregex 1.66.0
     ${MASON_DIR}/mason install boost_libdate_time 1.66.0
     ${MASON_DIR}/mason link boost_libdate_time 1.66.0
     ${MASON_DIR}/mason install boost_libiostreams 1.66.0
@@ -76,9 +78,6 @@ function mason_prepare_compile {
     ${MASON_DIR}/mason link geos 3.6.2
     MASON_GEOS=$(${MASON_DIR}/mason prefix geos 3.6.2)
     perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_GEOS}/bin/geos-config
-   
-
-
 }
 
 function mason_compile {

--- a/scripts/valhalla/2.4.9/script.sh
+++ b/scripts/valhalla/2.4.9/script.sh
@@ -2,8 +2,8 @@
 
 MASON_NAME=valhalla
 MASON_VERSION=2.4.9
-MASON_LIB_FILE=lib/libpng.a
-#MASON_PKGCONFIG_FILE=lib/pkgconfig/libpng.pc
+MASON_LIB_FILE=lib/libvalhalla.a
+#MASON_PKGCONFIG_FILE=lib/pkgconfig/libvalhalla.pc
 
 
 . ${MASON_DIR}/mason.sh
@@ -91,7 +91,7 @@ function mason_prepare_compile {
 }
 
 function mason_compile {
-    export CXXFLAGS="-isystem ${MASON_ROOT}/.link/include ${CXXFLAGS:-}"
+    export CXXFLAGS="-isystem ${MASON_ROOT}/.link/include ${CXXFLAGS:-} -D_GLIBCXX_USE_CXX11_ABI=0"
     export CFLAGS="-isystem ${MASON_ROOT}/.link/include ${CFLAGS:-}"
     export LDFLAGS="-L${MASON_ROOT}/.link/lib ${LDFLAGS:-}"
     export PATH="${MASON_ROOT}/.link/bin:${PATH}"
@@ -120,6 +120,8 @@ export
         --enable-static \
         --with-pic \
         --disable-shared \
+        --disable-services \
+        --disable-data_tools \
         --disable-dependency-tracking \
         --disable-python-bindings \
         --with-pkgconfigdir="${MASON_ROOT}/.link/lib/pkgconfig" \


### PR DESCRIPTION
# DO NOT MERGE YET

Packaging for Valhalla 2.4.9 binaries and libraries.  Currently only includes runtime dependencies, does not build/bundle tile-creation, and service binaries.

## TODO:

- [x] package lz4 with mason
- [x] ~~package prime_server with mason~~ (will not include services in this package version)
- [x] use libcurl from mason
- [x] Figure out how to link in openssl

## Notes

To build/test this locally, clone this branch, then do `./mason build valhalla 2.4.9`