### PR TITLE
Add nunicode version 1.8

### DIFF
--- a/scripts/nunicode/1.8/.travis.yml
+++ b/scripts/nunicode/1.8/.travis.yml
@@ -1,0 +1,40 @@
+language: cpp
+
+sudo: false
+
+matrix:
+  include:
+    - os: osx
+      env: MASON_PLATFORM=osx
+      compiler: clang
+    - os: linux
+      env: MASON_PLATFORM=linux
+      compiler: clang
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v5
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v7
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v8
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=x86
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=x86-64
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=mips
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=mips-64
+
+addons:
+  apt:
+    sources: [ 'ubuntu-toolchain-r-test', 'george-edison55-precise-backports' ]
+    packages: [ 'libstdc++-5-dev', 'cmake', 'cmake-data' ]
+
+install:
+- if [[ $(uname -s) == 'Darwin' && $(which brew) == '' ]]; then brew install cmake; fi
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+
+after_success:
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/nunicode/1.8/script.sh
+++ b/scripts/nunicode/1.8/script.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+MASON_NAME=nunicode
+MASON_VERSION=1.8
+MASON_LIB_FILE=lib/libnu.a
+MASON_PKGCONFIG_FILE=lib/pkgconfig/nu.pc
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download https://bitbucket.org/alekseyt/nunicode/get/1.8.tar.bz2 \
+        d4788a570b8eafec01eaa7a3425a3529d9f70842
+
+    mason_extract_tar_bz2
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/alekseyt-nunicode-246bb27014ab
+}
+
+function mason_compile {
+    mkdir -p build-dir
+    cd build-dir
+
+    # patch CMakeLists file
+    cat ../CMakeLists.txt | sed -e '/find_package.Sqlite3/ s/^/#/' > ../CMakeLists.txt.new && cp ../CMakeLists.txt.new ../CMakeLists.txt
+
+    if [ ${MASON_PLATFORM} = 'android' ]; then
+        ${MASON_DIR}/utils/android.sh > toolchain.cmake
+
+        cmake \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=${MASON_PREFIX} \
+            -DCMAKE_TOOLCHAIN_FILE=toolchain.cmake \
+            ..
+    else
+        cmake \
+            -DCMAKE_BUILD_TYPE=RELEASE \
+            -DCMAKE_INSTALL_PREFIX=${MASON_PREFIX} \
+            ..
+    fi
+
+    make install -j${MASON_CONCURRENCY}
+}
+
+function mason_cflags {
+    echo -I${MASON_PREFIX}/include
+}
+
+function mason_ldflags {
+    : # We're only using the full path to the archive, which is output in static_libs
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"


### PR DESCRIPTION
I just bumped the download link, hash, and build directory from the 1.7.1 script. I tested the local build on OS X. It's been a while since I've touched any mason packages, hope I'm not missing too many steps.

Version 1.8 of nunicode adds heuristic "unaccent" functionality that we're considering using as a fallback for "diacritic insensitive" comparison on platforms that don't have access to native locale information.

/cc @kkaefer @springmeyer @brunoabinader 