### PR TITLE
[WIP] Fix preservation of symlinks in llvm subpackages

### DIFF
--- a/scripts/clang++/base/common.sh
+++ b/scripts/clang++/base/common.sh
@@ -32,7 +32,8 @@ function mason_build {
 
     # copy c++ headers (on osx these are a symlink to the system headers)
     if [[ -d "${CLANG_PREFIX}/include/c++" ]]; then
-        cp -r "${CLANG_PREFIX}/include/c++" "${MASON_PREFIX}/include/"
+        # todo check if symLink
+        cp -a "${CLANG_PREFIX}/include/c++" "${MASON_PREFIX}/include/"
     fi
 
     # copy libs

--- a/scripts/clang-tidy/base/common.sh
+++ b/scripts/clang-tidy/base/common.sh
@@ -14,7 +14,7 @@ function mason_build {
 
     # copy c++ headers (on osx these are a symlink to the system headers)
     if [[ -d "${CLANG_PREFIX}/include/c++" ]]; then
-        cp -r "${CLANG_PREFIX}/include/c++" "${MASON_PREFIX}/include/"
+        cp -a "${CLANG_PREFIX}/include/c++" "${MASON_PREFIX}/include/"
     fi
 
     # copy c headers


### PR DESCRIPTION
I noticed that the `c++` dir symlink on OS X in the clang++ and clang-tidy packages is not behaving predictably across packaged versions. I think it must be different behavior between `cp -r` in the latest coreutils and `cp -r`  in the default bsd tools on OS X. Need to dig deeper. Putting this up as a reminder of the problem that needs fixing (keeping the symlink)

Currently, in the LLVM 6.0.0 packages clang-tidy's c++ directory is a symlink while clang++ is not (they both should be).