### PR TITLE
mason link: overwrite existing

### DIFF
--- a/mason.sh
+++ b/mason.sh
@@ -404,11 +404,17 @@ function run_lndir() {
     #/bin/cp -R -n ${MASON_PREFIX}/* ${TARGET_SUBDIR}
     mason_step "Linking ${MASON_PREFIX}"
     mason_step "Links will be inside ${TARGET_SUBDIR}"
-    if hash lndir 2>/dev/null; then
-        mason_substep "Using $(which lndir) for symlinking"
-        lndir -silent "${MASON_PREFIX}/" "${TARGET_SUBDIR}" 2>/dev/null
+    local cp_help=$(cp --help 2>/dev/null)
+    if [[ $cp_help =~ [[:space:]]--symbolic-link[[:space:]] &&
+          $cp_help =~ [[:space:]]--target-directory= ]]
+    then
+        mason_substep "Using 'cp' for symlinking"
+        find "${MASON_PREFIX}" -mindepth 1 -type d -prune -exec \
+            cp -RPfp --symbolic-link \
+                --target-directory="${TARGET_SUBDIR}" \
+                -- '{}' +
     else
-        mason_substep "Using bash fallback for symlinking (install lndir for faster symlinking)"
+        mason_substep "Using bash fallback for symlinking (GNU cp needed for faster symlinking)"
         bash_lndir "${MASON_PREFIX}/" "${TARGET_SUBDIR}"
     fi
     mason_step "Done linking ${MASON_PREFIX}"


### PR DESCRIPTION
Refs #230, mapnik/mapnik#3955

Not rewriting symlinks leaves links to files from older/different package version in place.

First I rewrote the bash fallback, it was very slow. When symlinking boost headers, for me it ran ~35s when creating the directory tree, and ~3s when only checking existence, not creating/updating any links. The new function runs ~4s when creating or updating the directory tree.

Then I installed `lndir` only to learn it doesn't have any option to the effect of `--force`. So I deemed it unfit for the task. GNU `cp` has option `--symbolic-link`, which runs a bit slower than `lndir`, but still a lot faster than the new bash function. So that is used if available.

**changes in behaviour**
- existing symlinks/files are overwritten
- files in the top-level directory are not symlinked (`mason.ini`, etc.)

It should be noted that I used `find` options `-mindepth` and `-maxdepth`. They're not specified by POSIX, and although OSX does recognize them, I'm not entirely sure they're ok to use here.
