### PR TITLE
Add SQLite 3.24.0 optimized for binary size

### DIFF
--- a/scripts/sqlite/3.24.0-min-size/.travis.yml
+++ b/scripts/sqlite/3.24.0-min-size/.travis.yml
@@ -6,12 +6,15 @@ matrix:
       osx_image: xcode9.4
     - os: linux
       sudo: false
+      compiler: clang
       env: MASON_PLATFORM_VERSION=cortex_a9
     - os: linux
       sudo: false
+      compiler: clang
       env: MASON_PLATFORM_VERSION=i686
     - os: linux
       sudo: false
+      compiler: clang
       env: MASON_PLATFORM_VERSION=x86_64
     - os: linux
       sudo: false

--- a/scripts/sqlite/3.24.0-min-size/.travis.yml
+++ b/scripts/sqlite/3.24.0-min-size/.travis.yml
@@ -1,0 +1,31 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode9.4
+    - os: linux
+      sudo: false
+      env: MASON_PLATFORM_VERSION=cortex_a9
+    - os: linux
+      sudo: false
+      env: MASON_PLATFORM_VERSION=i686
+    - os: linux
+      sudo: false
+      env: MASON_PLATFORM_VERSION=x86_64
+    - os: linux
+      sudo: false
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v7
+    - os: linux
+      sudo: false
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v8
+    - os: linux
+      sudo: false
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=x86
+    - os: linux
+      sudo: false
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=x86-64
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/sqlite/3.24.0-min-size/script.sh
+++ b/scripts/sqlite/3.24.0-min-size/script.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+MASON_NAME=sqlite
+MASON_VERSION=3.24.0-min-size
+MASON_LIB_FILE=lib/libsqlite3.a
+MASON_PKGCONFIG_FILE=lib/pkgconfig/sqlite3.pc
+
+SQLITE_FILE_VERSION=3240000
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        https://www.sqlite.org/2018/sqlite-autoconf-${SQLITE_FILE_VERSION}.tar.gz \
+        ad4be6eaaa45b26edb54d95d4de9debbd3704c9e
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/sqlite-autoconf-${SQLITE_FILE_VERSION}
+}
+
+function mason_compile {
+    # Note: setting CFLAGS overrides the default in sqlite of `-g -O2`
+    # hence we add back the preferred optimization
+    export CFLAGS="${CFLAGS} -Os -flto -DNDEBUG"
+    export LDFLAGS="${LDFLAGS} -flto"
+
+    # We need to use -O2 rather than -Os in LDFLAGS because of
+    # a toolchain issue: https://github.com/android-ndk/ndk/issues/721
+    if [ ${MASON_PLATFORM} == "linux" ] || [ ${MASON_PLATFORM} == "android" ]; then
+        export LDFLAGS="${LDFLAGS} -O2"
+    fi
+
+    if [ ${MASON_PLATFORM} == "linux" ] && [ ${MASON_PLATFORM_VERSION} == "x86_64" ]; then
+        export LDFLAGS="${LDFLAGS} -fuse-ld=gold"
+    fi
+
+    ./configure \
+        --prefix=${MASON_PREFIX} \
+        ${MASON_HOST_ARG} \
+        --enable-static \
+        --with-pic \
+        --disable-shared \
+        --disable-dependency-tracking || cat ${MASON_BUILD_PATH}/config.log
+
+    make install -j${MASON_CONCURRENCY}
+}
+
+function mason_strip_ldflags {
+    shift # -L...
+    shift # -lsqlite3
+    echo "$@"
+}
+
+function mason_ldflags {
+    mason_strip_ldflags $(`mason_pkgconfig` --static --libs)
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"

--- a/scripts/sqlite/3.24.0-min-size/script.sh
+++ b/scripts/sqlite/3.24.0-min-size/script.sh
@@ -22,20 +22,7 @@ function mason_load_source {
 function mason_compile {
     # Note: setting CFLAGS overrides the default in sqlite of `-g -O2`
     # hence we add back the preferred optimization
-    export CFLAGS="${CFLAGS} -Os -flto -fPIC -DNDEBUG"
-    export LDFLAGS="${LDFLAGS} -flto -fPIC"
-
-    # We need to use -O2 rather than -Os in LDFLAGS because of
-    # a toolchain issue: https://github.com/android-ndk/ndk/issues/721
-    if [ ${MASON_PLATFORM} == "linux" ] || [ ${MASON_PLATFORM} == "android" ]; then
-        export LDFLAGS="${LDFLAGS} -O2"
-    fi
-
-    if [ ${MASON_PLATFORM} == "linux" ] && [ ${MASON_PLATFORM_VERSION} == "x86_64" ]; then
-        export LDFLAGS="${LDFLAGS} -fuse-ld=gold"
-    fi
-
-    ./configure \
+    CFLAGS="${CFLAGS} -Os -DNDEBUG" ./configure \
         --prefix=${MASON_PREFIX} \
         ${MASON_HOST_ARG} \
         --enable-static \

--- a/scripts/sqlite/3.24.0-min-size/script.sh
+++ b/scripts/sqlite/3.24.0-min-size/script.sh
@@ -22,8 +22,8 @@ function mason_load_source {
 function mason_compile {
     # Note: setting CFLAGS overrides the default in sqlite of `-g -O2`
     # hence we add back the preferred optimization
-    export CFLAGS="${CFLAGS} -Os -flto -DNDEBUG"
-    export LDFLAGS="${LDFLAGS} -flto"
+    export CFLAGS="${CFLAGS} -Os -flto -fPIC -DNDEBUG"
+    export LDFLAGS="${LDFLAGS} -flto -fPIC"
 
     # We need to use -O2 rather than -Os in LDFLAGS because of
     # a toolchain issue: https://github.com/android-ndk/ndk/issues/721


### PR DESCRIPTION
Using both `-Os` and `-flto` (which we've [found to substantially reduce binary size](https://github.com/mapbox/mapbox-gl-native/runs/10667579)).

Testing over in https://github.com/mapbox/mapbox-gl-native/pull/12596.

This could serve as an example for https://github.com/mapbox/cpp/issues/22