### PR TITLE
Add android to available platforms in README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,7 +533,7 @@ Name | Description
 ---|---
 `MASON_DIR` | The directory where Mason itself is installed. Defaults to the current directory.
 `MASON_ROOT` | Absolute path the `mason_packages` directory. Example: `/Users/user/mason_packages`.
-`MASON_PLATFORM` | Platform of the current invocation. Currently one of `osx`, `ios` or `linux`.
+`MASON_PLATFORM` | Platform of the current invocation. Currently one of `osx`, `ios`, `android`, or `linux`.
 `MASON_PLATFORM_VERSION` | Version of the platform. It must include the architecture if the produced binaries are architecture-specific (e.g. on Linux). Example: `10.10`
 `MASON_NAME` | Name specified in the `script.sh` file. Example: `libuv`
 `MASON_VERSION` | Version specified in the `script.sh` file. Example: `0.11.29`


### PR DESCRIPTION
This is used in the [zlib package](https://github.com/mapbox/mason/blob/a7e35b0f632a8b2f0e338acc9dda0cff04d2f752/scripts/zlib/1.2.8/.travis.yml#L12) so I'm assuming it is available for all packages.