### PR TITLE
Change download location for bzip2 -- the previous one no longer works

### DIFF
--- a/scripts/bzip2/1.0.6/script.sh
+++ b/scripts/bzip2/1.0.6/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=lib/libbz2.a
 
 function mason_load_source {
     mason_download \
-        http://www.bzip.org/1.0.6/bzip2-1.0.6.tar.gz \
+        https://src.fedoraproject.org/repo/pkgs/bzip2/bzip2-1.0.6.tar.gz/00b516f4704d4a7cb50a1d97e6e8e15b/bzip2-1.0.6.tar.gz \
         e47e9034c4116f467618cfaaa4d3aca004094007
 
     mason_extract_tar_gz


### PR DESCRIPTION
The bzip.org domain has expired and been replaced by adware, so the install script that tries to download it now fails (it downloads something, but the hash check fails). This PR switches the download location to use the Fedora project's mirror of the source package -- it hashes identically, and has been there since 2010, so I don't think it's going anywhere.