### PR TITLE
Same as #647 (bzip domain fix) but against cxx-override instead of master

### DIFF
--- a/scripts/bzip2/1.0.6/script.sh
+++ b/scripts/bzip2/1.0.6/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=lib/libbz2.a
 
 function mason_load_source {
     mason_download \
-        http://www.bzip.org/1.0.6/bzip2-1.0.6.tar.gz \
+        https://src.fedoraproject.org/repo/pkgs/bzip2/bzip2-1.0.6.tar.gz/00b516f4704d4a7cb50a1d97e6e8e15b/bzip2-1.0.6.tar.gz \
         e47e9034c4116f467618cfaaa4d3aca004094007
 
     mason_extract_tar_gz


### PR DESCRIPTION
#647 fixes an issue with the bzip2 script in master. carmen-cache currently points at the cxx-overrides branch instead because that's where the PR that fixed our list build problem, #635, landed. As such, I cherry-picked the fix against the cxx-overrides branch. I don't really know anything about the status of that branch other than that we're using it, but from #567 it seems like @springmeyer or @alliecrevier would be good approvers?