### PR TITLE
Build2 0.8.0

### DIFF
--- a/scripts/build2/0.8.0/.travis.yml
+++ b/scripts/build2/0.8.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.3
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/build2/0.8.0/.travis.yml
+++ b/scripts/build2/0.8.0/.travis.yml
@@ -1,5 +1,7 @@
 language: generic
 
+dist: trusty
+
 matrix:
   include:
     - os: osx

--- a/scripts/build2/0.8.0/.travis.yml
+++ b/scripts/build2/0.8.0/.travis.yml
@@ -1,7 +1,5 @@
 language: generic
 
-dist: xenial
-
 matrix:
   include:
     - os: osx

--- a/scripts/build2/0.8.0/.travis.yml
+++ b/scripts/build2/0.8.0/.travis.yml
@@ -1,6 +1,6 @@
 language: generic
 
-dist: trusty
+dist: xenial
 
 matrix:
   include:

--- a/scripts/build2/0.8.0/patch.diff
+++ b/scripts/build2/0.8.0/patch.diff
@@ -1,0 +1,41 @@
+diff --git a/build.sh b/build.sh
+index a0c4f55..eac0c77 100755
+--- a/build.sh
++++ b/build.sh
+@@ -260,7 +260,7 @@ run build2/b-boot --version
+ 
+ # Bootstrap, stage 2.
+ #
+-run build2/b-boot $verbose config.cxx="$cxx" config.bin.lib=static build2/exe{b}
++run build2/b-boot $verbose config.cxx="$cxx" config.cc.coptions="$*" config.bin.lib=static config.bin.exe.lib=static config.cxx.loptions="${LDFLAGS}" build2/exe{b}
+ mv build2/b build2/b-boot
+ run build2/b-boot --version
+ 
+@@ -269,7 +269,7 @@ run build2/b-boot --version
+ run cd ..
+ 
+ run build2/build2/b-boot $verbose configure \
+-config.cxx="$cxx" \
++config.cxx="$cxx" config.cc.coptions="$*" config.bin.lib=static config.bin.exe.lib=static config.cxx.loptions="${LDFLAGS}" \
+ config.bin.suffix=-stage \
+ config.bin.rpath="$conf_rpath" \
+ config.install.root="$idir" \
+@@ -293,7 +293,7 @@ cdir="$(pwd)" # Save full path for later.
+ 
+ run bpkg-stage $verbose create \
+ cc \
+-config.cxx="$cxx" \
++config.cxx="$cxx" config.bin.lib=static config.bin.exe.lib=static config.cxx.loptions="${LDFLAGS}" \
+ config.cc.coptions="$*" \
+ config.bin.rpath="$conf_rpath" \
+ config.install.root="$idir" \
+diff --git a/build2/bootstrap.sh b/build2/bootstrap.sh
+index e6088c2..541b3be 100755
+--- a/build2/bootstrap.sh
++++ b/build2/bootstrap.sh
+@@ -136,4 +136,4 @@ src="$src $libbutl/libbutl/*.cxx"
+ # mode since 4.9 doesn't recognize c++1z.
+ #
+ set -x
+-"$cxx" "-I$libbutl" -I. -DBUILD2_BOOTSTRAP '-DBUILD2_HOST_TRIPLET="'"$host"'"' -std=c++1y "$@" -o build2/b-boot $src -lpthread
++"$cxx" "-I$libbutl" -I. -DBUILD2_BOOTSTRAP '-DBUILD2_HOST_TRIPLET="'"$host"'"' -std=c++1y "$@" -o build2/b-boot $src -lpthread -stdlib=libc++ ${LDFLAGS}

--- a/scripts/build2/0.8.0/script.sh
+++ b/scripts/build2/0.8.0/script.sh
@@ -28,7 +28,7 @@ function mason_compile {
     perl -i -p -e "s/=static/=static config.bin.exe.lib=static config.cxx.coptions=-stdlib=libc++ config.cxx.loptions='${LDFLAGS}' /g;" ./build.sh
     perl -i -p -e "s/suffix=-stage /suffix=-stage config.bin.lib=static config.bin.exe.lib=static config.cxx.coptions=-stdlib=libc++ config.cxx.loptions='${LDFLAGS}' /g;" ./build.sh
     perl -i -p -e "s/coptions=-O3 /coptions=-O3 config.bin.lib=static config.bin.exe.lib=static config.cxx.coptions=-stdlib=libc++ config.cxx.loptions='${LDFLAGS}' /g;" ./build.sh
-    ./build.sh --install-dir ${MASON_PREFIX} --sudo "" --trust yes ${CXX:-clang++}
+    ./build.sh --install-dir ${MASON_PREFIX} --verbose 3 --sudo "" --trust yes ${CXX:-clang++} -O3 -stdlib=libc++
 }
 
 function mason_cflags {

--- a/scripts/build2/0.8.0/script.sh
+++ b/scripts/build2/0.8.0/script.sh
@@ -17,17 +17,14 @@ function mason_load_source {
 }
 
 function mason_compile {
-    # NOTE: build2 requires a c++17 capable compiler and it uses CXX11_ABI features in libstdc++ (so it must be build with _GLIBCXX_USE_CXX11_ABI=1)
+    # NOTE: build2 requires a c++17 capable compiler and it uses CXX11_ABI features in libstdc++ (so it must be built with _GLIBCXX_USE_CXX11_ABI=1)
     # Since we want the binaries to be portable to pre cxx11 abi machines, we statically link against libc++ instead of linking against libstdc++
     # note with clang 4.x will hit "header 'shared_mutex' not found and cannot be generated" because c++17 support is lacking
     LDFLAGS=""
     if [[ $(uname -s) == 'Linux' ]]; then
         LDFLAGS="-Wl,--start-group -lc++ -lc++abi -pthread -lrt"
     fi
-    perl -i -p -e "s/pthread/pthread -stdlib=libc++ ${LDFLAGS} /g;" ./build2/bootstrap.sh
-    perl -i -p -e "s/=static/=static config.bin.exe.lib=static config.cxx.coptions=-stdlib=libc++ config.cxx.loptions='${LDFLAGS}' /g;" ./build.sh
-    perl -i -p -e "s/suffix=-stage /suffix=-stage config.bin.lib=static config.bin.exe.lib=static config.cxx.coptions=-stdlib=libc++ config.cxx.loptions='${LDFLAGS}' /g;" ./build.sh
-    perl -i -p -e "s/coptions=-O3 /coptions=-O3 config.bin.lib=static config.bin.exe.lib=static config.cxx.coptions=-stdlib=libc++ config.cxx.loptions='${LDFLAGS}' /g;" ./build.sh
+    patch -N -p1 < ${MASON_DIR}/scripts/${MASON_NAME}/${MASON_VERSION}/patch.diff
     ./build.sh --install-dir ${MASON_PREFIX} --verbose 3 --sudo "" --trust yes ${CXX:-clang++} -O3 -stdlib=libc++ ${LDFLAGS}
 }
 

--- a/scripts/build2/0.8.0/script.sh
+++ b/scripts/build2/0.8.0/script.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+MASON_NAME=build2
+MASON_VERSION=0.8.0
+MASON_LIB_FILE=bin/bpkg
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        https://download.build2.org/${MASON_VERSION}/build2-toolchain-${MASON_VERSION}.tar.gz \
+        4ddfaa4f763ea7d99da4a9002f9714715e838e56
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/build2-toolchain-${MASON_VERSION}
+}
+
+function mason_compile {
+    # NOTE: build2 requires a c++17 capable compiler and it uses CXX11_ABI features in libstdc++ (so it must be build with _GLIBCXX_USE_CXX11_ABI=1)
+    # Since we want the binaries to be portable to pre cxx11 abi machines, we statically link against libc++ instead of linking against libstdc++
+    # note with clang 4.x will hit "header 'shared_mutex' not found and cannot be generated" because c++17 support is lacking
+    LDFLAGS=""
+    if [[ $(uname -s) == 'Linux' ]]; then
+        LDFLAGS="-Wl,--start-group -lc++ -lc++abi -pthread -lrt"
+    fi
+    perl -i -p -e "s/pthread/pthread -stdlib=libc++ ${LDFLAGS} /g;" ./build2/bootstrap.sh
+    perl -i -p -e "s/=static/=static config.bin.exe.lib=static config.cxx.coptions=-stdlib=libc++ config.cxx.loptions='${LDFLAGS}' /g;" ./build.sh
+    perl -i -p -e "s/suffix=-stage /suffix=-stage config.bin.lib=static config.bin.exe.lib=static config.cxx.coptions=-stdlib=libc++ config.cxx.loptions='${LDFLAGS}' /g;" ./build.sh
+    perl -i -p -e "s/coptions=-O3 /coptions=-O3 config.bin.lib=static config.bin.exe.lib=static config.cxx.coptions=-stdlib=libc++ config.cxx.loptions='${LDFLAGS}' /g;" ./build.sh
+    ./build.sh --install-dir ${MASON_PREFIX} --sudo "" --trust yes ${CXX:-clang++}
+}
+
+function mason_cflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+mason_run "$@"

--- a/scripts/build2/0.8.0/script.sh
+++ b/scripts/build2/0.8.0/script.sh
@@ -28,7 +28,7 @@ function mason_compile {
     perl -i -p -e "s/=static/=static config.bin.exe.lib=static config.cxx.coptions=-stdlib=libc++ config.cxx.loptions='${LDFLAGS}' /g;" ./build.sh
     perl -i -p -e "s/suffix=-stage /suffix=-stage config.bin.lib=static config.bin.exe.lib=static config.cxx.coptions=-stdlib=libc++ config.cxx.loptions='${LDFLAGS}' /g;" ./build.sh
     perl -i -p -e "s/coptions=-O3 /coptions=-O3 config.bin.lib=static config.bin.exe.lib=static config.cxx.coptions=-stdlib=libc++ config.cxx.loptions='${LDFLAGS}' /g;" ./build.sh
-    ./build.sh --install-dir ${MASON_PREFIX} --verbose 3 --sudo "" --trust yes ${CXX:-clang++} -O3 -stdlib=libc++
+    ./build.sh --install-dir ${MASON_PREFIX} --verbose 3 --sudo "" --trust yes ${CXX:-clang++} -O3 -stdlib=libc++ ${LDFLAGS}
 }
 
 function mason_cflags {


### PR DESCRIPTION
Adds the latest release of build2 (https://lists.build2.org/archives/announce/2018/000010.html) patched so that:

 - It is statically linked to libc++ on linux
 - Which enables the c+17 code to run on systems as old as ubuntu precise