### PR TITLE
Icu 63.1 min static data

### DIFF
--- a/mason.sh
+++ b/mason.sh
@@ -314,44 +314,54 @@ function mason_clear_existing {
 
 
 function mason_download {
+    # if you need to download more than one thing give each a suffix
+    if [ ! -z ${3} ]; then
+        SLUG_SUFFIX="_${3}"
+    fi
+
     mkdir -p "${MASON_ROOT}/.cache"
     cd "${MASON_ROOT}/.cache"
-    if [ ! -f "${MASON_SLUG}" ] ; then
+    if [ ! -f "${MASON_SLUG}${SLUG_SUFFIX}" ] ; then
         mason_step "Downloading $1..."
         local CURL_RESULT=0
-        curl --retry 3 ${MASON_CURL_ARGS} -f -S -L "$1" -o "${MASON_SLUG}"  || CURL_RESULT=$?
+        curl --retry 3 ${MASON_CURL_ARGS} -f -S -L "$1" -o "${MASON_SLUG}${SLUG_SUFFIX}"  || CURL_RESULT=$?
         if [[ ${CURL_RESULT} != 0 ]]; then
             mason_error "Failed to download ${1} (returncode: $CURL_RESULT)"
             exit $CURL_RESULT
         fi
     fi
 
-    MASON_HASH=$(git hash-object "${MASON_SLUG}")
+    MASON_HASH=$(git hash-object "${MASON_SLUG}${SLUG_SUFFIX}")
     if [ "$2" != "${MASON_HASH}" ] ; then
-        mason_error "Hash ${MASON_HASH} of file ${MASON_ROOT}/.cache/${MASON_SLUG} doesn't match $2"
+        mason_error "Hash ${MASON_HASH} of file ${MASON_ROOT}/.cache/${MASON_SLUG}${SLUG_SUFFIX} doesn't match $2"
         exit 1
     fi
 }
 
 function mason_setup_build_dir {
-    rm -rf "${MASON_ROOT}/.build/${MASON_SLUG}"
+    rm -rf "${MASON_ROOT}/.build/${MASON_SLUG}${SLUG_SUFFIX}"
     mkdir -p "${MASON_ROOT}/.build/"
     cd "${MASON_ROOT}/.build/"
 }
 
 function mason_extract_tar_gz {
-    mason_setup_build_dir
-    tar xzf "../.cache/${MASON_SLUG}" $@
+    mason_setup_build_dir 
+    tar xzf "../.cache/${MASON_SLUG}${SLUG_SUFFIX}" $@ 
 }
 
 function mason_extract_tar_bz2 {
     mason_setup_build_dir
-    tar xjf "../.cache/${MASON_SLUG}" $@
+    tar xjf "../.cache/${MASON_SLUG}${SLUG_SUFFIX}" $@
 }
 
 function mason_extract_tar_xz {
     mason_setup_build_dir
-    tar xJf "../.cache/${MASON_SLUG}" $@
+    tar xJf "../.cache/${MASON_SLUG}${SLUG_SUFFIX}" $@
+}
+
+function mason_extract_zip {
+    mason_setup_build_dir
+    unzip -aqo "../.cache/${MASON_SLUG}${SLUG_SUFFIX}" $@
 }
 
 function mason_prepare_compile {

--- a/mason.sh
+++ b/mason.sh
@@ -254,7 +254,6 @@ MASON_NAME=${MASON_NAME:-nopackage}
 MASON_VERSION=${MASON_VERSION:-noversion}
 MASON_HEADER_ONLY=${MASON_HEADER_ONLY:-false}
 MASON_SLUG=${MASON_NAME}-${MASON_VERSION}
-MASON_SLUG_SUFFIX=
 if [[ ${MASON_HEADER_ONLY} == true ]]; then
     MASON_PLATFORM_ID=headers
 else
@@ -315,56 +314,44 @@ function mason_clear_existing {
 
 
 function mason_download {
-    # if you need to download more than one thing give each a suffix
-    if [ $# -gt 2 ]; then
-        MASON_SLUG_SUFFIX="_${3}"
-    else
-        MASON_SLUG_SUFFIX=
-    fi
-
     mkdir -p "${MASON_ROOT}/.cache"
     cd "${MASON_ROOT}/.cache"
-    if [ ! -f "${MASON_SLUG}${MASON_SLUG_SUFFIX}" ] ; then
+    if [ ! -f "${MASON_SLUG}" ] ; then
         mason_step "Downloading $1..."
         local CURL_RESULT=0
-        curl --retry 3 ${MASON_CURL_ARGS} -f -S -L "$1" -o "${MASON_SLUG}${MASON_SLUG_SUFFIX}"  || CURL_RESULT=$?
+        curl --retry 3 ${MASON_CURL_ARGS} -f -S -L "$1" -o "${MASON_SLUG}"  || CURL_RESULT=$?
         if [[ ${CURL_RESULT} != 0 ]]; then
             mason_error "Failed to download ${1} (returncode: $CURL_RESULT)"
             exit $CURL_RESULT
         fi
     fi
 
-    MASON_HASH=$(git hash-object "${MASON_SLUG}${MASON_SLUG_SUFFIX}")
+    MASON_HASH=$(git hash-object "${MASON_SLUG}")
     if [ "$2" != "${MASON_HASH}" ] ; then
-        mason_error "Hash ${MASON_HASH} of file ${MASON_ROOT}/.cache/${MASON_SLUG}${MASON_SLUG_SUFFIX} doesn't match $2"
+        mason_error "Hash ${MASON_HASH} of file ${MASON_ROOT}/.cache/${MASON_SLUG} doesn't match $2"
         exit 1
     fi
 }
 
 function mason_setup_build_dir {
-    rm -rf "${MASON_ROOT}/.build/${MASON_SLUG}${MASON_SLUG_SUFFIX}"
+    rm -rf "${MASON_ROOT}/.build/${MASON_SLUG}"
     mkdir -p "${MASON_ROOT}/.build/"
     cd "${MASON_ROOT}/.build/"
 }
 
 function mason_extract_tar_gz {
-    mason_setup_build_dir 
-    tar xzf "../.cache/${MASON_SLUG}${MASON_SLUG_SUFFIX}" $@
+    mason_setup_build_dir
+    tar xzf "../.cache/${MASON_SLUG}" $@
 }
 
 function mason_extract_tar_bz2 {
     mason_setup_build_dir
-    tar xjf "../.cache/${MASON_SLUG}${MASON_SLUG_SUFFIX}" $@
+    tar xjf "../.cache/${MASON_SLUG}" $@
 }
 
 function mason_extract_tar_xz {
     mason_setup_build_dir
-    tar xJf "../.cache/${MASON_SLUG}${MASON_SLUG_SUFFIX}" $@
-}
-
-function mason_extract_zip {
-    mason_setup_build_dir
-    unzip -aqo "../.cache/${MASON_SLUG}${MASON_SLUG_SUFFIX}" $@
+    tar xJf "../.cache/${MASON_SLUG}" $@
 }
 
 function mason_prepare_compile {

--- a/mason.sh
+++ b/mason.sh
@@ -254,6 +254,7 @@ MASON_NAME=${MASON_NAME:-nopackage}
 MASON_VERSION=${MASON_VERSION:-noversion}
 MASON_HEADER_ONLY=${MASON_HEADER_ONLY:-false}
 MASON_SLUG=${MASON_NAME}-${MASON_VERSION}
+MASON_SLUG_SUFFIX=
 if [[ ${MASON_HEADER_ONLY} == true ]]; then
     MASON_PLATFORM_ID=headers
 else
@@ -315,53 +316,55 @@ function mason_clear_existing {
 
 function mason_download {
     # if you need to download more than one thing give each a suffix
-    if [ ! -z ${3} ]; then
-        SLUG_SUFFIX="_${3}"
+    if [ $# -gt 2 ]; then
+        MASON_SLUG_SUFFIX="_${3}"
+    else
+        MASON_SLUG_SUFFIX=
     fi
 
     mkdir -p "${MASON_ROOT}/.cache"
     cd "${MASON_ROOT}/.cache"
-    if [ ! -f "${MASON_SLUG}${SLUG_SUFFIX}" ] ; then
+    if [ ! -f "${MASON_SLUG}${MASON_SLUG_SUFFIX}" ] ; then
         mason_step "Downloading $1..."
         local CURL_RESULT=0
-        curl --retry 3 ${MASON_CURL_ARGS} -f -S -L "$1" -o "${MASON_SLUG}${SLUG_SUFFIX}"  || CURL_RESULT=$?
+        curl --retry 3 ${MASON_CURL_ARGS} -f -S -L "$1" -o "${MASON_SLUG}${MASON_SLUG_SUFFIX}"  || CURL_RESULT=$?
         if [[ ${CURL_RESULT} != 0 ]]; then
             mason_error "Failed to download ${1} (returncode: $CURL_RESULT)"
             exit $CURL_RESULT
         fi
     fi
 
-    MASON_HASH=$(git hash-object "${MASON_SLUG}${SLUG_SUFFIX}")
+    MASON_HASH=$(git hash-object "${MASON_SLUG}${MASON_SLUG_SUFFIX}")
     if [ "$2" != "${MASON_HASH}" ] ; then
-        mason_error "Hash ${MASON_HASH} of file ${MASON_ROOT}/.cache/${MASON_SLUG}${SLUG_SUFFIX} doesn't match $2"
+        mason_error "Hash ${MASON_HASH} of file ${MASON_ROOT}/.cache/${MASON_SLUG}${MASON_SLUG_SUFFIX} doesn't match $2"
         exit 1
     fi
 }
 
 function mason_setup_build_dir {
-    rm -rf "${MASON_ROOT}/.build/${MASON_SLUG}${SLUG_SUFFIX}"
+    rm -rf "${MASON_ROOT}/.build/${MASON_SLUG}${MASON_SLUG_SUFFIX}"
     mkdir -p "${MASON_ROOT}/.build/"
     cd "${MASON_ROOT}/.build/"
 }
 
 function mason_extract_tar_gz {
     mason_setup_build_dir 
-    tar xzf "../.cache/${MASON_SLUG}${SLUG_SUFFIX}" $@ 
+    tar xzf "../.cache/${MASON_SLUG}${MASON_SLUG_SUFFIX}" $@
 }
 
 function mason_extract_tar_bz2 {
     mason_setup_build_dir
-    tar xjf "../.cache/${MASON_SLUG}${SLUG_SUFFIX}" $@
+    tar xjf "../.cache/${MASON_SLUG}${MASON_SLUG_SUFFIX}" $@
 }
 
 function mason_extract_tar_xz {
     mason_setup_build_dir
-    tar xJf "../.cache/${MASON_SLUG}${SLUG_SUFFIX}" $@
+    tar xJf "../.cache/${MASON_SLUG}${MASON_SLUG_SUFFIX}" $@
 }
 
 function mason_extract_zip {
     mason_setup_build_dir
-    unzip -aqo "../.cache/${MASON_SLUG}${SLUG_SUFFIX}" $@
+    unzip -aqo "../.cache/${MASON_SLUG}${MASON_SLUG_SUFFIX}" $@
 }
 
 function mason_prepare_compile {

--- a/scripts/icu/63.1-min-static-data/.travis.yml
+++ b/scripts/icu/63.1-min-static-data/.travis.yml
@@ -1,0 +1,41 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      compiler: clang
+      sudo: false
+    - os: osx
+      env: MASON_PLATFORM=ios
+      compiler: clang
+    - os: linux
+      env: MASON_PLATFORM_VERSION=cortex_a9
+    - os: linux
+      env: MASON_PLATFORM_VERSION=i686
+    - os: linux
+      compiler: clang
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
+    - os: osx
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v5
+    - os: osx
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v7
+    - os: osx
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v8
+    - os: osx
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=x86
+    - os: osx
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=x86-64
+    - os: osx
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=mips
+    - os: osx
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=mips-64
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/icu/63.1-min-static-data/script.sh
+++ b/scripts/icu/63.1-min-static-data/script.sh
@@ -33,7 +33,7 @@ function mason_prepare_compile {
         #  Also instead of using the regular build steps, we could use a dedicated built target that just builds the tools
         mason_substep "Moving host ICU build directory to ${MASON_ROOT}/.build/icu-host"
         rm -rf ${MASON_ROOT}/.build/icu-host
-        cp -R ${MASON_BUILD_PATH}/source ${MASON_ROOT}/.build/icu-host
+        cp -R ${MASON_BUILD_PATH}/icu4c/source ${MASON_ROOT}/.build/icu-host
     fi
 }
 

--- a/scripts/icu/63.1-min-static-data/script.sh
+++ b/scripts/icu/63.1-min-static-data/script.sh
@@ -63,17 +63,17 @@ function trim_data {
         # make a local version and remove the line continuations
         l=$(echo $f | sed -e "s/\(.*\)files.mk/\1local.mk/g")
         cp -rp $f $l
-        sed -i -e :a -e '/\\$/N; s/\\\n//; ta' $l
+        sed -i'' -e :a -e '/\\$/N; s/\\\n//; ta' $l
 
         # if its locale, unit or currency we use our supported lang list
         if [ "$(echo $l | grep -cE 'locales|unit|curr')" -eq 1 ]; then
-            sed -i -e '/^#/!s/SOURCE.*=.*txt/SOURCE = da.txt de.txt en.txt eo.txt es.txt fi.txt fr.txt he.txt id.txt it.txt ko.txt my.txt nl.txt pl.txt pt.txt pt_PT.txt ro.txt ru.txt sv.txt tr.txt uk.txt vi.txt zh.txt zh_Hans.txt/g' $l
+            sed -i'' -e '/^#/!s/SOURCE.*=.*txt/SOURCE = da.txt de.txt en.txt eo.txt es.txt fi.txt fr.txt he.txt id.txt it.txt ko.txt my.txt nl.txt pl.txt pt.txt pt_PT.txt ro.txt ru.txt sv.txt tr.txt uk.txt vi.txt zh.txt zh_Hans.txt/g' $l
         # if its misc we need a couple of things
         elif [ $(echo $l | grep -cF "misc") -eq 1 ]; then
-            sed -i -e '/^#/!s/SOURCE.*=.*txt/SOURCE = numberingSystems.txt icuver.txt icustd.txt/g' $l
+            sed -i'' -e '/^#/!s/SOURCE.*=.*txt/SOURCE = numberingSystems.txt icuver.txt icustd.txt/g' $l
         # otherwise the scuttle the whole thing
         else
-            sed -i -e '/^#/!s/SOURCE.*=.*txt/SOURCE = /g' $l
+            sed -i'' -e '/^#/!s/SOURCE.*=.*txt/SOURCE = /g' $l
         fi
     done
 }

--- a/scripts/icu/63.1-min-static-data/script.sh
+++ b/scripts/icu/63.1-min-static-data/script.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+
+# Build ICU common package (libicuuc.a) with data file separate and with support for legacy conversion and break iteration turned off in order to minimize size
+
+MASON_NAME=icu
+MASON_VERSION=63.1-min-static-data
+MASON_LIB_FILE=lib/libicuuc.a
+#MASON_PKGCONFIG_FILE=lib/pkgconfig/icu-uc.pc
+
+. ${MASON_DIR}/mason.sh
+
+MASON_BUILD_DEBUG=0 # Enable to build library with debug symbols
+MASON_CROSS_BUILD=0
+
+function mason_load_source {
+    mason_download \
+        http://download.icu-project.org/files/icu4c/63.1/icu4c-63_1-src.tgz \
+        3e24e6839878321f5193a3c4aa6f02210052fb31 \
+        source
+
+    mason_extract_tar_gz
+
+    mason_download \
+        http://download.icu-project.org/files/icu4c/63.1/icu4c-63_1-data.zip \
+        a0eb02a525822ea5ab409e04cf280bacccbb5d4d \
+        data
+
+    mason_extract_zip -d ${MASON_NAME}/source
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}
+}
+
+function mason_prepare_compile {
+    if [[ ${MASON_PLATFORM} == 'ios' || ${MASON_PLATFORM} == 'android' || ${MASON_PLATFORM_VERSION} != `uname -m` ]]; then
+        mason_substep "Cross-compiling ICU. Starting with host build of ICU to generate tools."
+
+        pushd ${MASON_ROOT}/..
+        env -i HOME="$HOME" PATH="$PATH" USER="$USER" ${MASON_DIR}/mason build ${MASON_NAME} ${MASON_VERSION}
+        popd
+
+        # TODO: Copies a bunch of files to a kind of orphaned place, do we need to do something to clean up after the build?
+        #  Copying the whole build directory is the easiest way to do a cross build, but we could limit this to a small subset of files (icucross.mk, the tools directory, probably a few others...)
+        #  Also instead of using the regular build steps, we could use a dedicated built target that just builds the tools
+        mason_substep "Moving host ICU build directory to ${MASON_ROOT}/.build/icu-host"
+        rm -rf ${MASON_ROOT}/.build/icu-host
+        cp -R ${MASON_BUILD_PATH}/source ${MASON_ROOT}/.build/icu-host
+    fi
+}
+
+function trim_data {
+    mason_substep "Trimming ICU data to small number of locals and datasets"
+
+    # for some reason there is also a dat file in there!
+    rm -f data/in/icudt63l.dat
+
+    # move all non algorithmic code point mappings so they arent used
+    for f in $(find data/mappings -name '*.mk'); do
+        mv $f ${f}_
+    done
+
+    # make local versions of each data set
+    for f in $(find data -path mappings -prune -o -name '*files.mk'); do
+        # make a local version and remove the line continuations
+        l=$(echo $f | sed -e "s/\(.*\)files.mk/\1local.mk/g")
+        cp -rp $f $l
+        sed -i -e :a -e '/\\$/N; s/\\\n//; ta' $l
+
+        # if its locale, unit or currency we use our supported lang list
+        if [ "$(echo $l | grep -cE 'locales|unit|curr')" -eq 1 ]; then
+            sed -i -e '/^#/!s/SOURCE.*=.*txt/SOURCE = da.txt de.txt en.txt eo.txt es.txt fi.txt fr.txt he.txt id.txt it.txt ko.txt my.txt nl.txt pl.txt pt.txt pt_PT.txt ro.txt ru.txt sv.txt tr.txt uk.txt vi.txt zh.txt zh_Hans.txt/g' $l
+        # if its misc we need a couple of things
+        elif [ $(echo $l | grep -cF "misc") -eq 1 ]; then
+            sed -i -e '/^#/!s/SOURCE.*=.*txt/SOURCE = numberingSystems.txt icuver.txt icustd.txt/g' $l
+        # otherwise the scuttle the whole thing
+        else
+            sed -i -e '/^#/!s/SOURCE.*=.*txt/SOURCE = /g' $l
+        fi
+    done
+}
+
+function mason_compile {
+    if [[ ${MASON_PLATFORM} == 'ios' || ${MASON_PLATFORM} == 'android' || ${MASON_PLATFORM_VERSION} != `uname -m` ]]; then
+        MASON_CROSS_BUILD=1
+    fi
+    mason_compile_base
+}
+
+function mason_compile_base {
+    pushd  ${MASON_BUILD_PATH}/source
+    
+    # trim out a bunch of the data so that the data static library is as small as possible
+    trim_data
+
+    # Using uint_least16_t instead of char16_t because Android Clang doesn't recognize char16_t
+    # I'm being shady and telling users of the library to use char16_t, so there's an implicit raw cast
+    ICU_CORE_CPP_FLAGS="-DU_CHARSET_IS_UTF8=1 -DU_CHAR_TYPE=uint_least16_t"
+    ICU_MODULE_CPP_FLAGS="${ICU_CORE_CPP_FLAGS} -DUCONFIG_NO_LEGACY_CONVERSION=1 -DUCONFIG_NO_BREAK_ITERATION=1"
+    
+    CFLAGS="${CFLAGS:-} ${ICU_CORE_CPP_FLAGS} ${ICU_MODULE_CPP_FLAGS} -fvisibility=hidden $(icu_debug_cpp) -Os"
+    CXXFLAGS="${CXXFLAGS:-} ${ICU_CORE_CPP_FLAGS} ${ICU_MODULE_CPP_FLAGS} -fvisibility=hidden $(icu_debug_cpp) -Os"
+
+    echo "Configuring with ${MASON_HOST_ARG}"
+
+    ./configure ${MASON_HOST_ARG} --prefix=${MASON_PREFIX} \
+    $(icu_debug_configure) \
+    $(cross_build_configure) \
+    --with-data-packaging=static \
+    --enable-renaming \
+    --enable-strict \
+    --enable-static \
+    --enable-draft \
+    --disable-rpath \
+    --disable-shared \
+    --disable-tests \
+    --disable-extras \
+    --disable-tracing \
+    --disable-layout \
+    --disable-icuio \
+    --disable-samples \
+    --disable-dyload || cat config.log
+
+
+    # Must do make clean after configure to clear out object files left over from previous build on different architecture
+    make clean
+    make -j${MASON_CONCURRENCY}
+    make install
+    popd
+}
+
+function icu_debug_cpp {
+    if [ ${MASON_BUILD_DEBUG} == 1 ]; then
+        echo "-g"
+    fi
+}
+
+function icu_debug_configure {
+    if [ ${MASON_BUILD_DEBUG} == 1 ]; then
+        echo "--enable-debug --disable-release"
+    else
+        echo "--enable-release --disable-debug"
+    fi
+}
+
+function cross_build_configure {
+    # Building tools is disabled in cross-build mode. Using the host-built version of the tools is the whole point of the --with-cross-build flag
+    if [ ${MASON_CROSS_BUILD} == 1 ]; then
+        echo "--with-cross-build=${MASON_ROOT}/.build/icu-host --disable-tools"
+    else
+        echo "--enable-tools"
+    fi
+}
+
+function mason_cflags {
+    echo "-I${MASON_PREFIX}/include -DUCHAR_TYPE=char16_t"
+}
+
+function mason_ldflags {
+    echo ""
+}
+
+mason_run "$@"

--- a/scripts/icu/63.1-min-static-data/script.sh
+++ b/scripts/icu/63.1-min-static-data/script.sh
@@ -62,8 +62,7 @@ function trim_data {
     for f in $(find data -path mappings -prune -o -name '*files.mk'); do
         # make a local version and remove the line continuations
         l=$(echo $f | sed -e "s/\(.*\)files.mk/\1local.mk/g")
-        cp -rp $f $l
-        sed -i'' -e :a -e '/\\$/N; s/\\\n//; ta' $l
+        sed -e :a -e '/\\$/N; s/\\\n//; ta' $f > $l
 
         # if its locale, unit or currency we use our supported lang list
         if [ "$(echo $l | grep -cE 'locales|unit|curr')" -eq 1 ]; then


### PR DESCRIPTION
This is a build of ICU with `-Os` and with the data packaging set to put the data in a static lib. This also removes a significant amount of the data. It narrows down the datasets to just: `locales`, `unit`, `currency` and a couple basic things in `misc`. Additionaly for those datasets the only locales supported are:

    da de en eo es fi fr he id it ko my nl pl pt pt_PT ro ru sv tr uk vi zh zh_Hans

With all of these changes the total data size of the data library is down from 26MB to 3.1MB. Which is quite convenient for cross platform libraries that have to ship the same code to a variety of platforms.

There was a slight issue with the standard download/unpacking workflow. ICU does not ship the "code" used to build the data in the same targz as the code. Because of this the package must download the code and the data-code and splice them together (to get the static library with data built-in). What I've done is updated the downloading function with the ability to add a suffix to the file you downloaded. This allows the unpacking functions to then use the same suffix and thefore avoids destroying the cache of the other files that were downloaded for the package in question. Because of this change I am wondering if I should update the mason version from `0.18.0` to `0.19.0` or if even just new packages in mason also obviate the version update? @springmeyer or maybe @brunoabinader can you advise?