### PR TITLE
Add latest postgis version

### DIFF
--- a/scripts/gdal/2.4.1/.travis.yml
+++ b/scripts/gdal/2.4.1/.travis.yml
@@ -1,0 +1,13 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.2
+      compiler: clang
+    - os: linux
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/gdal/2.4.1/.travis.yml
+++ b/scripts/gdal/2.4.1/.travis.yml
@@ -13,7 +13,6 @@ matrix:
            - ubuntu-toolchain-r-test
           packages:
            - libstdc++-4.9-dev
-           - xutils-dev
 
 
 script:

--- a/scripts/gdal/2.4.1/.travis.yml
+++ b/scripts/gdal/2.4.1/.travis.yml
@@ -7,6 +7,14 @@ matrix:
       compiler: clang
     - os: linux
       sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-4.9-dev
+           - xutils-dev
+
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/gdal/2.4.1/patch.diff
+++ b/scripts/gdal/2.4.1/patch.diff
@@ -1,0 +1,141 @@
+diff --git a/apps/GNUmakefile b/apps/GNUmakefile
+index a87cd0f..931a988 100644
+--- a/apps/GNUmakefile
++++ b/apps/GNUmakefile
+@@ -79,103 +79,103 @@ gdalbuildvrt_lib.$(OBJ_EXT): gdalbuildvrt_lib.cpp
+ 	$(CXX) -c $(GDAL_INCLUDE) $(CPPFLAGS) $(CXXFLAGS) $< -o $@
+ 
+ gdalinfo$(EXE):	gdalinfo_bin.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) $(CONFIG_LIB_UTILS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) $(CONFIG_LIB_UTILS) -o $@ $(LNK_FLAGS)
+ 
+ gdalserver$(EXE):	gdalserver.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdal_translate$(EXE):	gdal_translate_bin.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdaladdo$(EXE):	gdaladdo.$(OBJ_EXT)  $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdalwarp$(EXE): gdalwarp_bin.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdal_contour$(EXE):	gdal_contour.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ nearblack$(EXE):	nearblack_bin.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdalmanage$(EXE):	gdalmanage.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdal_rasterize$(EXE):	gdal_rasterize_bin.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdaltindex$(EXE):	gdaltindex.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdalbuildvrt$(EXE):	gdalbuildvrt_bin.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ multireadtest$(EXE):	multireadtest.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ dumpoverviews$(EXE):	dumpoverviews.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdalenhance$(EXE):	gdalenhance.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdaldem$(EXE): gdaldem_bin.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdal_grid$(EXE):	gdal_grid_bin.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdalwarpsimple$(EXE): gdalwarpsimple.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdaltransform$(EXE): gdaltransform.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdallocationinfo$(EXE): gdallocationinfo.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdalsrsinfo$(EXE):	gdalsrsinfo.$(OBJ_EXT)  $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdalflattenmask$(EXE): gdalflattenmask.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdaltorture$(EXE): gdaltorture.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdal2ogr$(EXE):	gdal2ogr.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ ogrinfo$(EXE):	ogrinfo.$(OBJ_EXT)  $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $<  $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $<  $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ ogrlineref$(EXE):	ogrlineref.$(OBJ_EXT)  $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $<  $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $<  $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ ogr2ogr$(EXE):	ogr2ogr_bin.$(OBJ_EXT)  $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ testepsg$(EXE):	testepsg.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ ogrtindex$(EXE):	ogrtindex.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ test_ogrsf$(EXE):	test_ogrsf.$(OBJ_EXT)  $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gdalasyncread$(EXE):	gdalasyncread.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ testreprojmulti$(EXE):	testreprojmulti.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gnmmanage$(EXE):	gnmmanage.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ gnmanalyse$(EXE):	gnmanalyse.$(OBJ_EXT) $(DEP_LIBS)
+-	$(LD) $(LNK_FLAGS) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@
++	$(LD) $< $(XTRAOBJ) $(CONFIG_LIBS) -o $@ $(LNK_FLAGS)
+ 
+ clean:
+ 	$(RM) *.o $(BIN_LIST) core gdal-config gdal-config-inst

--- a/scripts/gdal/2.4.1/readme.md
+++ b/scripts/gdal/2.4.1/readme.md
@@ -1,0 +1,76 @@
+## Packaging GDAL
+
+### Background
+
+GDAL is one of the harder software libraries to package because it has so many required and potential dependencies.
+
+Also, mason prefers packaging libraries at static archives, which complicates things because this complicates dependency handling: when linking to static libraries you need all of the libraries (passed to the linker) that static archive depends on. For GDAL that is both the C standard library, the C++ standard library, and potentially a lot of libraries other libraries, both with C and C++ dependencies. This is the main reason that the script.sh is so narly. The upside is that then the libraries are standalone at runtime. So, hard to build, easy to run. It's a tradeoff
+
+### Steps to package
+
+This document intends to guide you to the basic steps to package a new version of GDAL in mason.
+
+#### Step 1: Copy a previous GDAL package.
+
+Find the last successful package gdal mason. Perhaps use the highest incremented version:
+
+```
+ls scripts/gdal/
+1.11.1	1.11.1-big-pants  1.11.2  2.0.2  2.1.1	2.1.3  2.2.1  2.2.2  2.2.3  2.2.3-1  2.4.1  dev
+```
+
+It is `2.2.3-1` at the time of this writing.
+
+Then find most recent release at http://download.osgeo.org/gdal/
+
+Create new package:
+
+```
+cd mason
+cp -r scripts/gdal/2.2.3-1 scripts/gdal/2.4.1
+```
+
+Open up `scripts/gdal/2.4.1/script.sh` and edit the `MASON_VERSION` variable to be `2.4.1`
+
+#### Step 2: Now try building
+
+This will fail with an error, but just do it anyway:
+
+```
+./mason build gdal 2.4.1
+```
+
+The error is because the hash changed for the upstream download, because you changed the `MASON_VERSION`.
+
+You will see an error like:
+
+> Hash 38758d9fa5083e8d8e4333c38e132e154da9f25f of file /Users/danespringmeyer/projects/mason/mason_packages/.cache/gdal-2.4.1 doesn't match f4ac4fb76e20cc149d169163914d76d51173ce82
+
+To fix this, edit `scripts/gdal/2.4.1/script.sh` and add the first hash reported on `line 12`.
+
+Now try building again:
+
+```
+./mason build gdal 2.4.1
+```
+
+If it succeeded locally then you are good to continue to the next step.
+
+
+#### Step 3: push to github and build on travis
+
+First create a new mason branch and push all the new scripts:
+
+```
+git checkout -b gdal-2.4.1
+git add scripts/gdal
+git commit scripts/gdal -m "adding GDAL 2.4.1"
+```
+
+Then try triggering a build on travis. To do this do:
+
+```
+./mason trigger gdal 2.4.1
+```
+
+And you watch for the build job to appear at https://travis-ci.org/mapbox/mason/builds. It wll have a "lego" icon and a title like "Building gdal 2.4.1", which denotes a triggered build.

--- a/scripts/gdal/2.4.1/script.sh
+++ b/scripts/gdal/2.4.1/script.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+
+MASON_NAME=gdal
+MASON_VERSION=2.4.1
+MASON_LIB_FILE=lib/libgdal.a
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        http://download.osgeo.org/gdal/${MASON_VERSION}/gdal-${MASON_VERSION}.tar.gz \
+        38758d9fa5083e8d8e4333c38e132e154da9f25f
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
+}
+
+function mason_prepare_compile {
+    # This line is critical: it ensures that we install deps in
+    # the parent folder rather than within the ./build directory
+    # such that our modifications to the .la files work
+    cd $(dirname ${MASON_ROOT})
+    # set up to fix libtool .la files
+    # https://github.com/mapbox/mason/issues/61
+    if [[ $(uname -s) == 'Darwin' ]]; then
+        FIND="\/Users\/travis\/build\/mapbox\/mason"
+    else
+        FIND="\/home\/travis\/build\/mapbox\/mason"
+    fi
+    REPLACE="$(pwd)"
+    REPLACE=${REPLACE////\\/}
+    LIBTIFF_VERSION="4.0.8"
+    PROJ_VERSION="4.9.3"
+    JPEG_VERSION="1.5.2"
+    PNG_VERSION="1.6.32"
+    EXPAT_VERSION="2.2.4"
+    POSTGRES_VERSION="9.6.5"
+    SQLITE_VERSION="3.21.0"
+    CCACHE_VERSION="3.3.1"
+    GEOS_VERSION="3.6.2"
+    ${MASON_DIR}/mason install geos ${GEOS_VERSION}
+    MASON_GEOS=$(${MASON_DIR}/mason prefix geos ${GEOS_VERSION})
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_GEOS}/lib/libgeos.la
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_GEOS}/lib/libgeos_c.la
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_GEOS}/bin/geos-config
+    ${MASON_DIR}/mason install libtiff ${LIBTIFF_VERSION}
+    MASON_TIFF=$(${MASON_DIR}/mason prefix libtiff ${LIBTIFF_VERSION})
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_TIFF}/lib/libtiff.la
+    ${MASON_DIR}/mason install proj ${PROJ_VERSION}
+    MASON_PROJ=$(${MASON_DIR}/mason prefix proj ${PROJ_VERSION})
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_PROJ}/lib/libproj.la
+    ${MASON_DIR}/mason install jpeg_turbo ${JPEG_VERSION}
+    MASON_JPEG=$(${MASON_DIR}/mason prefix jpeg_turbo ${JPEG_VERSION})
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_JPEG}/lib/libjpeg.la
+    ${MASON_DIR}/mason install libpng ${PNG_VERSION}
+    MASON_PNG=$(${MASON_DIR}/mason prefix libpng ${PNG_VERSION})
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_PNG}/lib/libpng.la
+    ${MASON_DIR}/mason install expat ${EXPAT_VERSION}
+    MASON_EXPAT=$(${MASON_DIR}/mason prefix expat ${EXPAT_VERSION})
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_EXPAT}/lib/libexpat.la
+    ${MASON_DIR}/mason install libpq ${POSTGRES_VERSION}
+    MASON_LIBPQ=$(${MASON_DIR}/mason prefix libpq ${POSTGRES_VERSION})
+    ${MASON_DIR}/mason install sqlite ${SQLITE_VERSION}
+    MASON_SQLITE=$(${MASON_DIR}/mason prefix sqlite ${SQLITE_VERSION})
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_SQLITE}/lib/libsqlite3.la
+    # depends on sudo apt-get install zlib1g-dev
+    ${MASON_DIR}/mason install zlib system
+    MASON_ZLIB=$(${MASON_DIR}/mason prefix zlib system)
+    # depends on sudo apt-get install libc6-dev
+    #${MASON_DIR}/mason install iconv system
+    #MASON_ICONV=$(${MASON_DIR}/mason prefix iconv system)
+    export LIBRARY_PATH=${MASON_LIBPQ}/lib:${LIBRARY_PATH:-}
+    ${MASON_DIR}/mason install ccache ${CCACHE_VERSION}
+    MASON_CCACHE=$(${MASON_DIR}/mason prefix ccache ${CCACHE_VERSION})/bin/ccache
+}
+
+function mason_compile {
+    if [[ ${MASON_PLATFORM} == 'linux' ]]; then
+        mason_step "Loading patch"
+        patch -N -p1 < ${MASON_DIR}/scripts/${MASON_NAME}/${MASON_VERSION}/patch.diff
+    fi
+
+    # very custom handling for the C++ lib of geos, which also needs
+    # to be linked when linking statically (since geos_c C API depends on it)
+    if [[ $(uname -s) == 'Linux' ]]; then
+        perl -i -p -e "s/ \-lgeos_c/ \-lgeos_c \-lgeos \-lstdc++ \-lm/g;" configure
+    elif [[ $(uname -s) == 'Darwin' ]]; then
+        perl -i -p -e "s/ \-lgeos_c/ \-lgeos_c \-lgeos \-lc++ \-lm/g;" configure
+    fi
+
+    # note CFLAGS overrides defaults so we need to add optimization flags back
+    export CFLAGS="${CFLAGS} -O3 -DNDEBUG"
+    export CXXFLAGS="${CXXFLAGS} -O3 -DNDEBUG"
+
+    CUSTOM_LIBS="-L${MASON_GEOS}/lib -lgeos_c -lgeos -L${MASON_SQLITE}/lib -lsqlite3 -L${MASON_TIFF}/lib -ltiff -L${MASON_JPEG}/lib -ljpeg -L${MASON_PROJ}/lib -lproj -L${MASON_PNG}/lib -lpng -L${MASON_EXPAT}/lib -lexpat"
+    CUSTOM_CFLAGS="${CFLAGS} -I${MASON_GEOS}/include -I${MASON_LIBPQ}/include -I${MASON_TIFF}/include -I${MASON_JPEG}/include -I${MASON_PROJ}/include -I${MASON_PNG}/include -I${MASON_EXPAT}/include"
+
+    # very custom handling for libpq/postgres support
+    # forcing our portable static library to be used
+    MASON_LIBPQ_PATH=${MASON_LIBPQ}/lib/libpq.a
+
+    if [[ $(uname -s) == 'Linux' ]]; then
+        # on Linux passing -Wl will lead to libtool re-positioning libpq.a in the wrong place (no longer after libgdal.a)
+        # which leads to unresolved symbols
+        CUSTOM_LDFLAGS="${LDFLAGS} ${MASON_LIBPQ_PATH}"
+        # linking statically to libsqlite requires -ldl -pthreads
+        CUSTOM_LDFLAGS="${CUSTOM_LDFLAGS} -ldl -pthread"
+    else
+        # on OSX not passing -Wl will break libtool archive creation leading to confusing arch errors
+        CUSTOM_LDFLAGS="${LDFLAGS} -Wl,${MASON_LIBPQ_PATH}"
+    fi
+    # we have to remove -lpq otherwise it will trigger linking to system /usr/lib/libpq
+    perl -i -p -e "s/\-lpq //g;" configure
+    # on linux -Wl,/path/to/libpq.a still does not work for the configure test
+    # so we have to force it into LIBS. But we don't do this on OS X since it breaks libtool archive logic
+    if [[ $(uname -s) == 'Linux' ]]; then
+        CUSTOM_LIBS="${MASON_LIBPQ}/lib/libpq.a -pthread ${CUSTOM_LIBS}"
+    fi
+
+    export CXX="${MASON_CCACHE} ${CXX}"
+
+    # note: we put ${STDLIB_CXXFLAGS} into CXX instead of LDFLAGS due to libtool oddity:
+    # http://stackoverflow.com/questions/16248360/autotools-libtool-link-library-with-libstdc-despite-stdlib-libc-option-pass
+    if [[ $(uname -s) == 'Darwin' ]]; then
+        export CXX="${CXX} -stdlib=libc++ -std=c++11"
+    fi
+
+    # note: it might be tempting to build with --without-libtool
+    # but I find that will only lead to a shared libgdal.so and will
+    # not produce a static library even if --enable-static is passed
+    LIBS="${CUSTOM_LIBS}" LDFLAGS="${CUSTOM_LDFLAGS}" CFLAGS="${CUSTOM_CFLAGS}" ./configure \
+        --enable-static --disable-shared \
+        ${MASON_HOST_ARG} \
+        --prefix=${MASON_PREFIX} \
+        --with-libz=${MASON_ZLIB} \
+        --disable-rpath \
+        --with-libjson-c=internal \
+        --with-geotiff=internal \
+        --with-expat=${MASON_EXPAT} \
+        --with-threads=yes \
+        --with-fgdb=no \
+        --with-rename-internal-libtiff-symbols=no \
+        --with-rename-internal-libgeotiff-symbols=no \
+        --with-hide-internal-symbols=yes \
+        --with-libtiff=${MASON_TIFF} \
+        --with-jpeg=${MASON_JPEG} \
+        --with-png=${MASON_PNG} \
+        --with-pg=${MASON_LIBPQ}/bin/pg_config \
+        --with-static-proj4=${MASON_PROJ} \
+        --with-sqlite3=${MASON_SQLITE} \
+        --with-geos=${MASON_GEOS}/bin/geos-config \
+        --with-spatialite=no \
+        --with-curl=no \
+        --with-xml2=no \
+        --with-pcraster=no \
+        --with-cfitsio=no \
+        --with-odbc=no \
+        --with-libkml=no \
+        --with-pcidsk=no \
+        --with-jasper=no \
+        --with-gif=no \
+        --with-grib=no \
+        --with-freexl=no \
+        --with-avx=no \
+        --with-sse=no \
+        --with-perl=no \
+        --with-python=no \
+        --with-java=no \
+        --with-podofo=no \
+        --with-pam \
+        --with-webp=no \
+        --with-pcre=no \
+        --with-liblzma=no \
+        --with-netcdf=no \
+        --with-poppler=no \
+        --with-sfcgal=no
+    make -j${MASON_CONCURRENCY}
+    make install
+
+    relativize_gdal_config ${MASON_PREFIX}/bin/gdal-config ${MASON_PREFIX} ${MASON_ROOT}/${MASON_PLATFORM_ID}
+
+}
+
+function relativize_gdal_config() {
+    path_to_gdal_config=${1}
+    prefix_path=${2}
+    build_path=${3}
+    RESOLVE_SYMLINK="readlink"
+    if [[ $(uname -s) == 'Linux' ]];then
+        RESOLVE_SYMLINK="readlink -f"
+    fi
+    mv ${path_to_gdal_config} /tmp/gdal-config-backup
+    # append code at start
+    echo 'if test -L $0; then BASE=$( dirname $( '${RESOLVE_SYMLINK}' "$0" ) ); else BASE=$( dirname "$0" ); fi' > ${path_to_gdal_config}
+    cat /tmp/gdal-config-backup >> ${path_to_gdal_config}
+    chmod +x ${path_to_gdal_config}
+
+    # now modify in place
+    python -c "data=open('${path_to_gdal_config}','r').read();open('${path_to_gdal_config}','w').write(data.replace('${prefix_path}','\$( cd \"\$( dirname \${BASE} )\" && pwd )'))"
+    # fix the path to dep libs (CONFIG_DEP_LIBS)
+    python -c "data=open('${path_to_gdal_config}','r').read();open('${path_to_gdal_config}','w').write(data.replace('${build_path}','\$( cd \"\$( dirname \$( dirname \$( dirname \${BASE}  ) ))\" && pwd )'))"
+    # hack to re-add -lpq since otherwise it will not end up in --dep-libs
+    python -c "data=open('${path_to_gdal_config}','r').read();open('${path_to_gdal_config}','w').write(data.replace('\$CONFIG_DEP_LIBS','\$CONFIG_DEP_LIBS -lpq'))"
+}
+
+
+function mason_cflags {
+    echo "-I${MASON_PREFIX}/include"
+}
+
+function mason_ldflags {
+    echo $(${MASON_PREFIX}/bin/gdal-config --dep-libs --libs)
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"

--- a/scripts/libpq/10.3/.travis.yml
+++ b/scripts/libpq/10.3/.travis.yml
@@ -1,0 +1,13 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.2
+      compiler: clang
+    - os: linux
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/libpq/10.3/patch.diff
+++ b/scripts/libpq/10.3/patch.diff
@@ -1,0 +1,11 @@
+--- src/include/pg_config_manual.h	2013-10-07 20:17:38.000000000 -0700
++++ src/include/pg_config_manual.h	2014-03-08 21:29:48.000000000 -0800
+@@ -144,7 +144,7 @@
+  * here's where to twiddle it.  You can also override this at runtime
+  * with the postmaster's -k switch.
+  */
+-#define DEFAULT_PGSOCKET_DIR  "/tmp"
++#define DEFAULT_PGSOCKET_DIR  "/var/run/postgresql"
+ 
+ /*
+  * The random() function is expected to yield values between 0 and

--- a/scripts/libpq/10.3/script.sh
+++ b/scripts/libpq/10.3/script.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+MASON_NAME=libpq
+MASON_VERSION=10.3
+MASON_LIB_FILE=lib/libpq.a
+MASON_PKGCONFIG_FILE=lib/pkgconfig/libpq.pc
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        http://ftp.postgresql.org/pub/source/v${MASON_VERSION}/postgresql-${MASON_VERSION}.tar.bz2 \
+        e1590a4b2167dcdf164eb887cf83e7da9e155771
+
+    mason_extract_tar_bz2
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/postgresql-${MASON_VERSION}
+}
+
+function mason_compile {
+    if [[ ${MASON_PLATFORM} == 'linux' ]]; then
+        mason_step "Loading patch"
+        patch src/include/pg_config_manual.h ${MASON_DIR}/scripts/${MASON_NAME}/${MASON_VERSION}/patch.diff
+    fi
+
+    # note CFLAGS overrides defaults (-Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -Wno-unused-command-line-argument) so we need to add optimization flags back
+    export CFLAGS="${CFLAGS}  -O3 -DNDEBUG -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -Wno-unused-command-line-argument"
+    ./configure \
+        --prefix=${MASON_PREFIX} \
+        ${MASON_HOST_ARG} \
+        --enable-thread-safety \
+        --enable-largefile \
+        --without-bonjour \
+        --without-openssl \
+        --without-pam \
+        --without-krb5 \
+        --without-gssapi \
+        --without-ossp-uuid \
+        --without-readline \
+        --without-ldap \
+        --without-zlib \
+        --without-libxml \
+        --without-libxslt \
+        --without-selinux \
+        --without-python \
+        --without-perl \
+        --without-tcl \
+        --disable-rpath \
+        --disable-debug \
+        --disable-profiling \
+        --disable-coverage \
+        --disable-dtrace \
+        --disable-depend \
+        --disable-cassert
+
+    make -j${MASON_CONCURRENCY} -C src/bin/pg_config install
+    make -j${MASON_CONCURRENCY} -C src/interfaces/libpq/ install
+    cp src/include/postgres_ext.h ${MASON_PREFIX}/include/
+    cp src/include/pg_config_ext.h ${MASON_PREFIX}/include/
+    rm -f ${MASON_PREFIX}/lib/libpq{*.so*,*.dylib}
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"

--- a/scripts/postgis/2.5.2/.travis.yml
+++ b/scripts/postgis/2.5.2/.travis.yml
@@ -1,0 +1,13 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.2
+      compiler: clang
+    - os: linux
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/postgis/2.5.2/.travis.yml
+++ b/scripts/postgis/2.5.2/.travis.yml
@@ -7,6 +7,12 @@ matrix:
       compiler: clang
     - os: linux
       sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-4.9-dev
 
 script:
 - ./mason build ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/postgis/2.5.2/script.sh
+++ b/scripts/postgis/2.5.2/script.sh
@@ -37,7 +37,7 @@ function mason_prepare_compile {
     POSTGRES_VERSION="10.3"
     XML2_VERSION="2.9.4"
     GEOS_VERSION="3.6.2"
-    GDAL_VERSION="2.2.2"
+    GDAL_VERSION="2.2.3"
     JSON_C_VERSION="0.12.1"
     PROTOBUF_VERSION="3.4.1" # must match the version compiled into protobuf C
     PROTOBUF_C_VERSION="1.3.0"

--- a/scripts/postgis/2.5.2/script.sh
+++ b/scripts/postgis/2.5.2/script.sh
@@ -38,6 +38,7 @@ function mason_prepare_compile {
     XML2_VERSION="2.9.4"
     GEOS_VERSION="3.6.2"
     GDAL_VERSION="2.2.3"
+    SQLITE_VERSION="3.21.0"
     JSON_C_VERSION="0.12.1"
     PROTOBUF_VERSION="3.4.1" # must match the version compiled into protobuf C
     PROTOBUF_C_VERSION="1.3.0"
@@ -80,6 +81,9 @@ function mason_prepare_compile {
     ${MASON_DIR}/mason install gdal ${GDAL_VERSION}
     MASON_GDAL=$(${MASON_DIR}/mason prefix gdal ${GDAL_VERSION})
     ln -sf ${MASON_GDAL}/include ${MASON_GDAL}/include/gdal
+    ${MASON_DIR}/mason install sqlite ${SQLITE_VERSION}
+    MASON_SQLITE=$(${MASON_DIR}/mason prefix sqlite ${SQLITE_VERSION})
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_SQLITE}/lib/libsqlite3.la
     perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_GDAL}/lib/libgdal.la
     perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_PROJ}/lib/libproj.la
     perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_XML2}/lib/libxml2.la
@@ -100,18 +104,19 @@ function mason_compile {
       -L${MASON_ZLIB}/lib -lz \
       -L${MASON_TIFF}/lib -ltiff \
       -L${MASON_JPEG}/lib -ljpeg \
+      -L${MASON_PROJ}/lib -lsqlite3 \
       -L${MASON_PROJ}/lib -lproj \
       -L${MASON_PNG}/lib -lpng \
       -L${MASON_JSON_C}/lib -ljson-c \
       -L${MASON_PROTOBUF_C}/lib -lprotobuf-c \
       -L${MASON_PROTOBUF}/lib -lprotobuf-lite \
       -L${MASON_EXPAT}/lib -lexpat \
-      -L${MASON_PROJ}/lib -lproj \
       -L${MASON_XML2}/lib -lxml2"
     export CFLAGS="${CFLAGS} -O3 -DNDEBUG -I$(pwd)/liblwgeom/ \
       -I$(pwd)/raster/ -I$(pwd)/raster/rt_core/ \
       -I${MASON_TIFF}/include \
       -I${MASON_JPEG}/include \
+      -I${MASON_SQLITE}/include \
       -I${MASON_PROJ}/include \
       -I${MASON_PNG}/include \
       -I${MASON_EXPAT}/include \
@@ -121,7 +126,6 @@ function mason_compile {
       -I${MASON_PROTOBUF}/include \
       -I${MASON_POSTGRES}/include/server \
       -I${MASON_GEOS}/include \
-      -I${MASON_PROJ}/include \
       -I${MASON_XML2}/include/libxml2"
 
     if [[ $(uname -s) == 'Darwin' ]]; then

--- a/scripts/postgis/2.5.2/script.sh
+++ b/scripts/postgis/2.5.2/script.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+
+MASON_NAME=postgis
+MASON_VERSION=2.5.2
+MASON_LIB_FILE=bin/shp2pgsql
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        http://download.osgeo.org/postgis/source/postgis-${MASON_VERSION}.tar.gz \
+        e2e23b177f889a8f00c67737ac80180abed0f83d
+
+    mason_extract_tar_gz
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/postgis-${MASON_VERSION}
+}
+
+function mason_prepare_compile {
+    # This line is critical: it ensures that we install deps in
+    # the parent folder rather than within the ./build directory
+    # such that our modifications to the .la files work
+    cd $(dirname ${MASON_ROOT})
+    # set up to fix libtool .la files
+    # https://github.com/mapbox/mason/issues/61
+    if [[ $(uname -s) == 'Darwin' ]]; then
+        FIND="\/Users\/travis\/build\/mapbox\/mason"
+    else
+        FIND="\/home\/travis\/build\/mapbox\/mason"
+    fi
+    REPLACE="$(pwd)"
+    REPLACE=${REPLACE////\\/}
+    LIBTIFF_VERSION="4.0.8"
+    PROJ_VERSION="4.9.3"
+    JPEG_VERSION="1.5.2"
+    PNG_VERSION="1.6.32"
+    EXPAT_VERSION="2.2.4"
+    POSTGRES_VERSION="10.3"
+    XML2_VERSION="2.9.4"
+    GEOS_VERSION="3.6.2"
+    GDAL_VERSION="2.2.2"
+    JSON_C_VERSION="0.12.1"
+    PROTOBUF_VERSION="3.4.1" # must match the version compiled into protobuf C
+    PROTOBUF_C_VERSION="1.3.0"
+    ${MASON_DIR}/mason install postgres ${POSTGRES_VERSION}
+    MASON_POSTGRES=$(${MASON_DIR}/mason prefix postgres ${POSTGRES_VERSION})
+    ${MASON_DIR}/mason install libxml2 ${XML2_VERSION}
+    MASON_XML2=$(${MASON_DIR}/mason prefix libxml2 ${XML2_VERSION})
+    ${MASON_DIR}/mason install geos ${GEOS_VERSION}
+    MASON_GEOS=$(${MASON_DIR}/mason prefix geos ${GEOS_VERSION})
+    ${MASON_DIR}/mason install libtiff ${LIBTIFF_VERSION}
+    MASON_TIFF=$(${MASON_DIR}/mason prefix libtiff ${LIBTIFF_VERSION})
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_TIFF}/lib/libtiff.la
+    ${MASON_DIR}/mason install proj ${PROJ_VERSION}
+    MASON_PROJ=$(${MASON_DIR}/mason prefix proj ${PROJ_VERSION})
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_PROJ}/lib/libproj.la
+    ${MASON_DIR}/mason install jpeg_turbo ${JPEG_VERSION}
+    MASON_JPEG=$(${MASON_DIR}/mason prefix jpeg_turbo ${JPEG_VERSION})
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_JPEG}/lib/libjpeg.la
+    ${MASON_DIR}/mason install libpng ${PNG_VERSION}
+    MASON_PNG=$(${MASON_DIR}/mason prefix libpng ${PNG_VERSION})
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_PNG}/lib/libpng.la
+    ${MASON_DIR}/mason install expat ${EXPAT_VERSION}
+    MASON_EXPAT=$(${MASON_DIR}/mason prefix expat ${EXPAT_VERSION})
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_EXPAT}/lib/libexpat.la
+    ${MASON_DIR}/mason install json-c ${JSON_C_VERSION}
+    MASON_JSON_C=$(${MASON_DIR}/mason prefix json-c ${JSON_C_VERSION})
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_JSON_C}/lib/libjson-c.la
+    ${MASON_DIR}/mason install protobuf_c ${PROTOBUF_C_VERSION}
+    MASON_PROTOBUF_C=$(${MASON_DIR}/mason prefix protobuf_c ${PROTOBUF_C_VERSION})
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_PROTOBUF_C}/lib/libprotobuf-c.la
+    ${MASON_DIR}/mason install protobuf ${PROTOBUF_VERSION}
+    MASON_PROTOBUF=$(${MASON_DIR}/mason prefix protobuf ${PROTOBUF_VERSION})
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_PROTOBUF}/lib/libprotobuf-lite.la
+    ${MASON_DIR}/mason install libpq ${POSTGRES_VERSION}
+    MASON_LIBPQ=$(${MASON_DIR}/mason prefix libpq ${POSTGRES_VERSION})
+    ${MASON_DIR}/mason install zlib system
+    MASON_ZLIB=$(${MASON_DIR}/mason prefix zlib system)
+    #${MASON_DIR}/mason install iconv system
+    #MASON_ICONV=$(${MASON_DIR}/mason prefix iconv system)
+    ${MASON_DIR}/mason install gdal ${GDAL_VERSION}
+    MASON_GDAL=$(${MASON_DIR}/mason prefix gdal ${GDAL_VERSION})
+    ln -sf ${MASON_GDAL}/include ${MASON_GDAL}/include/gdal
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_GDAL}/lib/libgdal.la
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_PROJ}/lib/libproj.la
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_XML2}/lib/libxml2.la
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_XML2}/bin/xml2-config
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_GEOS}/lib/libgeos.la
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_GEOS}/lib/libgeos_c.la
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_GEOS}/bin/geos-config
+
+}
+
+function mason_compile {
+    # put protoc-c on path (comes from protobuf_c)
+    export PATH=${MASON_PROTOBUF_C}/bin:${PATH}
+    which protoc-c
+    export LDFLAGS="${LDFLAGS} \
+      -L${MASON_GDAL}/lib -lgdal \
+      -L${MASON_GEOS}/lib -lgeos_c -lgeos\
+      -L${MASON_ZLIB}/lib -lz \
+      -L${MASON_TIFF}/lib -ltiff \
+      -L${MASON_JPEG}/lib -ljpeg \
+      -L${MASON_PROJ}/lib -lproj \
+      -L${MASON_PNG}/lib -lpng \
+      -L${MASON_JSON_C}/lib -ljson-c \
+      -L${MASON_PROTOBUF_C}/lib -lprotobuf-c \
+      -L${MASON_PROTOBUF}/lib -lprotobuf-lite \
+      -L${MASON_EXPAT}/lib -lexpat \
+      -L${MASON_PROJ}/lib -lproj \
+      -L${MASON_XML2}/lib -lxml2"
+    export CFLAGS="${CFLAGS} -O3 -DNDEBUG -I$(pwd)/liblwgeom/ \
+      -I$(pwd)/raster/ -I$(pwd)/raster/rt_core/ \
+      -I${MASON_TIFF}/include \
+      -I${MASON_JPEG}/include \
+      -I${MASON_PROJ}/include \
+      -I${MASON_PNG}/include \
+      -I${MASON_EXPAT}/include \
+      -I${MASON_GDAL}/include \
+      -I${MASON_JSON_C}/include \
+      -I${MASON_PROTOBUF_C}/include \
+      -I${MASON_PROTOBUF}/include \
+      -I${MASON_POSTGRES}/include/server \
+      -I${MASON_GEOS}/include \
+      -I${MASON_PROJ}/include \
+      -I${MASON_XML2}/include/libxml2"
+
+    if [[ $(uname -s) == 'Darwin' ]]; then
+        export LDFLAGS="${LDFLAGS} -Wl,-lc++ -Wl,${MASON_GDAL}/lib/libgdal.a -Wl,${MASON_POSTGRES}/lib/libpq.a -liconv"
+    else
+        export LDFLAGS="${LDFLAGS} ${MASON_GDAL}/lib/libgdal.a -lgeos_c -lgeos -lxml2 -lproj -lexpat -lpng -ljson-c -lprotobuf-c -lprotobuf-lite -ltiff -ljpeg ${MASON_POSTGRES}/lib/libpq.a -pthread -ldl -lz -lstdc++ -lm"
+    fi
+
+
+    MASON_LIBPQ_PATH=${MASON_POSTGRES}/lib/libpq.a
+    MASON_LIBPQ_PATH2=${MASON_LIBPQ_PATH////\\/}
+    perl -i -p -e "s/\-lpq/${MASON_LIBPQ_PATH2} -pthread/g;" configure
+    perl -i -p -e "s/librtcore\.a/librtcore\.a \.\.\/\.\.\/liblwgeom\/\.libs\/liblwgeom\.a/g;" raster/loader/Makefile.in
+
+    if [[ $(uname -s) == 'Linux' ]]; then
+      # help initGEOS configure check
+      perl -i -p -e "s/\-lgeos_c  /\-lgeos_c \-lgeos \-lstdc++ \-lm /g;" configure
+      # help GDALAllRegister configure check
+      CMD="data=open('./configure','r').read();open('./configure','w')"
+      CMD="${CMD}.write(data.replace('\`\$GDAL_CONFIG --libs\`','\"-lgdal -lgeos_c -lgeos -lxml2 -lproj -lexpat -lpng -ljson-c -lprotobuf-c -lprotobuf-lite -ltiff -ljpeg ${MASON_POSTGRES}/lib/libpq.a -pthread -ldl -lz -lstdc++ -lm\"'))"
+      python -c "${CMD}"
+    fi
+
+    ./configure \
+        --enable-static --disable-shared \
+        --prefix=$(mktemp -d) \
+        ${MASON_HOST_ARG} \
+        --with-projdir=${MASON_PROJ} \
+        --with-geosconfig=${MASON_GEOS}/bin/geos-config \
+        --with-pgconfig=${MASON_POSTGRES}/bin/pg_config \
+        --with-xml2config=${MASON_XML2}/bin/xml2-config \
+        --with-gdalconfig=${MASON_GDAL}/bin/gdal-config \
+        --with-jsondir=${MASON_JSON_C} \
+        --with-protobufdir=${MASON_PROTOBUF_C} \
+        --without-gui \
+        --with-topology \
+        --with-raster \
+        --with-sfcgal=no \
+        --without-sfcgal \
+        --disable-nls || (cat config.log && exit 1)
+    # -j${MASON_CONCURRENCY} disabled due to https://trac.osgeo.org/postgis/ticket/3345
+    make LDFLAGS="$LDFLAGS" CFLAGS="$CFLAGS"
+    make install LDFLAGS="$LDFLAGS" CFLAGS="$CFLAGS"
+    # the meat of postgis installs into postgres directory
+    # so we actually want to package postgres with the postgis stuff
+    # inside, so here we symlink it
+    mkdir -p $(dirname $MASON_PREFIX)
+    ln -sf ${MASON_POSTGRES} ${MASON_PREFIX}
+}
+
+function mason_cflags {
+  :
+}
+
+function mason_ldflags {
+  :
+}
+
+function mason_static_libs {
+  :
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"

--- a/scripts/postgis/2.5.2/script.sh
+++ b/scripts/postgis/2.5.2/script.sh
@@ -37,7 +37,7 @@ function mason_prepare_compile {
     POSTGRES_VERSION="10.3"
     XML2_VERSION="2.9.4"
     GEOS_VERSION="3.6.2"
-    GDAL_VERSION="2.2.3"
+    GDAL_VERSION="2.4.1"
     SQLITE_VERSION="3.21.0"
     JSON_C_VERSION="0.12.1"
     PROTOBUF_VERSION="3.4.1" # must match the version compiled into protobuf C

--- a/scripts/protobuf/3.4.1/script.sh
+++ b/scripts/protobuf/3.4.1/script.sh
@@ -3,7 +3,7 @@
 MASON_NAME=protobuf
 MASON_VERSION=3.4.1
 
-if [ ${MASON_PLATFORM} == 'ios' ]; then
+if [[ ${MASON_PLATFORM} == 'ios' ]]; then
     MASON_LIB_FILE=lib-isim-i386/libprotobuf-lite.a
     MASON_PKGCONFIG_FILE=lib-isim-i386/pkgconfig/protobuf-lite.pc
 else
@@ -28,23 +28,23 @@ function mason_compile {
     export CFLAGS="${CFLAGS} -O3 -DNDEBUG"
     export CXXFLAGS="${CXXFLAGS} -O3 -DNDEBUG"
 
-    if [ ${MASON_PLATFORM} == 'android' ]; then
+    if [[ ${MASON_PLATFORM} == 'android' ]]; then
         export LDFLAGS="${LDFLAGS} -llog"
     fi
 
-    if [ ${MASON_PLATFORM} == 'android' ] || [ ${MASON_PLATFORM} == 'ios' ]; then
+    if [[ ${MASON_PLATFORM} == 'android' ]] || [[ ${MASON_PLATFORM} == 'ios' ]]; then
         local PREFIX=$(MASON_PLATFORM= MASON_PLATFORM_VERSION= ${MASON_DIR}/mason prefix ${MASON_NAME} ${MASON_VERSION})
-        if [ ! -d ${PREFIX} ]; then
+        if [[ ! -d ${PREFIX} ]]; then
             $(MASON_PLATFORM= MASON_PLATFORM_VERSION= ${MASON_DIR}/mason install ${MASON_NAME} ${MASON_VERSION})
         fi
         export PROTOBUF_XC_ARG="--with-protoc=${PREFIX}/bin/protoc"
     fi
 
-    if [ ${MASON_PLATFORM} == 'ios' ]; then
+    if [[ ${MASON_PLATFORM} == 'ios' ]]; then
         export MACOSX_DEPLOYMENT_TARGET="10.8"
     fi
 
-    if [ -f Makefile ]; then
+    if [[ -f Makefile ]]; then
         make distclean
     fi
 
@@ -65,7 +65,7 @@ function mason_clean {
 }
 
 function mason_config_custom {
-    if [ ${MASON_PLATFORM} == 'android' ]; then
+    if [[ ${MASON_PLATFORM} == 'android' ]]; then
         MASON_CONFIG_LDFLAGS="${MASON_CONFIG_LDFLAGS} -llog"
     fi
 }

--- a/scripts/protobuf_c/1.3.0/script.sh
+++ b/scripts/protobuf_c/1.3.0/script.sh
@@ -20,12 +20,25 @@ function mason_load_source {
 PROTOBUF_VERSION="3.4.1"
 
 function mason_prepare_compile {
+    cd $(dirname ${MASON_ROOT})
     ${MASON_DIR}/mason install protobuf ${PROTOBUF_VERSION}
     MASON_PROTOBUF=$(${MASON_DIR}/mason prefix protobuf ${PROTOBUF_VERSION})
     export PKG_CONFIG_PATH=${MASON_PROTOBUF}/lib/pkgconfig:${PKG_CONFIG_PATH:-}
+    if [[ $(uname -s) == 'Darwin' ]]; then
+        FIND="\/Users\/travis\/build\/mapbox\/mason"
+    else
+        FIND="\/home\/travis\/build\/mapbox\/mason"
+    fi
+    REPLACE="$(pwd)"
+    REPLACE=${REPLACE////\\/}
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_PROTOBUF}/lib/pkgconfig/protobuf.pc
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_PROTOBUF}/lib/pkgconfig/protobuf-lite.pc
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_PROTOBUF}/lib/libprotobuf.la
+    perl -i -p -e "s/${FIND}/${REPLACE}/g;" ${MASON_PROTOBUF}/lib/libprotoc.la
 }
 
 function mason_compile {
+    export PATH=${MASON_PROTOBUF}/bin:${PATH}
     # note CFLAGS overrides defaults (-O2 -g -DNDEBUG) so we need to add optimization flags back
     export CFLAGS="${CFLAGS} -O3 -DNDEBUG"
     export CXXFLAGS="${CXXFLAGS} -O3 -DNDEBUG"


### PR DESCRIPTION
Followup to https://github.com/mapbox/mason/pull/678 which updates to build the latest version of postgis (`2.5.2`) using the latest mason supported version of postgres (`10.3`). Also adds support for the corresponding version of `libpq`.

cc/ @springmeyer 