### PR TITLE
Ensure all scripts use https not http

### DIFF
--- a/scripts/afl/2.19b/script.sh
+++ b/scripts/afl/2.19b/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=bin/afl-fuzz
 
 function mason_load_source {
     mason_download \
-        http://lcamtuf.coredump.cx/afl/releases/afl-2.19b.tgz \
+        https://lcamtuf.coredump.cx/afl/releases/afl-2.19b.tgz \
         6627c7b7c873e26fb7fbb6fd574c93676442d8b2
 
     mason_extract_tar_gz

--- a/scripts/android-ndk/arm-9-r10e/script.sh
+++ b/scripts/android-ndk/arm-9-r10e/script.sh
@@ -9,11 +9,11 @@ MASON_LIB_FILE=
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then
         mason_download \
-            http://dl.google.com/android/ndk/android-ndk-r10e-darwin-x86_64.bin \
+            https://dl.google.com/android/ndk/android-ndk-r10e-darwin-x86_64.bin \
             dea2dd3939eea3289cab075804abb153014b78d3
     elif [ ${MASON_PLATFORM} = 'linux' ]; then
         mason_download \
-            http://dl.google.com/android/ndk/android-ndk-r10e-linux-x86_64.bin \
+            https://dl.google.com/android/ndk/android-ndk-r10e-linux-x86_64.bin \
             285606ba6882d27d99ed469fc5533cc3c93967f5
     fi
 

--- a/scripts/android-ndk/arm-9-r11c/script.sh
+++ b/scripts/android-ndk/arm-9-r11c/script.sh
@@ -9,11 +9,11 @@ MASON_LIB_FILE=
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-r11c-darwin-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-r11c-darwin-x86_64.zip \
             0c6fa2017dd5237f6270887c85feedc4aafb3aef
     elif [ ${MASON_PLATFORM} = 'linux' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-r11c-linux-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-r11c-linux-x86_64.zip \
             0c646e2fceb3ef853e1832f4aa3a0dc4c16d2229
     fi
 

--- a/scripts/android-ndk/arm-9-r12b/script.sh
+++ b/scripts/android-ndk/arm-9-r12b/script.sh
@@ -9,11 +9,11 @@ MASON_LIB_FILE=
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-r12b-darwin-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-r12b-darwin-x86_64.zip \
             1a3bbdde35a240086b022cdf13ddcf40c27caa6e
     elif [ ${MASON_PLATFORM} = 'linux' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-r12b-linux-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-r12b-linux-x86_64.zip \
             c6286e131c233c25537a306eae0a29d50b352b91
     fi
 

--- a/scripts/android-ndk/arm-9-r13b/script.sh
+++ b/scripts/android-ndk/arm-9-r13b/script.sh
@@ -9,11 +9,11 @@ MASON_LIB_FILE=
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-r13b-darwin-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-r13b-darwin-x86_64.zip \
             b822dd239f63cd2e1e72c823c41bd732da2e5ad6
     elif [ ${MASON_PLATFORM} = 'linux' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-r13b-linux-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-r13b-linux-x86_64.zip \
             b95dd1fba5096ca3310a67e90b2a5a8aca3ddec7
     fi
 

--- a/scripts/android-ndk/arm64-21-r10e-gcc/script.sh
+++ b/scripts/android-ndk/arm64-21-r10e-gcc/script.sh
@@ -9,11 +9,11 @@ MASON_LIB_FILE=
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then
         mason_download \
-            http://dl.google.com/android/ndk/android-ndk-r10e-darwin-x86_64.bin \
+            https://dl.google.com/android/ndk/android-ndk-r10e-darwin-x86_64.bin \
             dea2dd3939eea3289cab075804abb153014b78d3
     elif [ ${MASON_PLATFORM} = 'linux' ]; then
         mason_download \
-            http://dl.google.com/android/ndk/android-ndk-r10e-linux-x86_64.bin \
+            https://dl.google.com/android/ndk/android-ndk-r10e-linux-x86_64.bin \
             285606ba6882d27d99ed469fc5533cc3c93967f5
     fi
 

--- a/scripts/android-ndk/arm64-21-r10e/script.sh
+++ b/scripts/android-ndk/arm64-21-r10e/script.sh
@@ -9,11 +9,11 @@ MASON_LIB_FILE=
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then
         mason_download \
-            http://dl.google.com/android/ndk/android-ndk-r10e-darwin-x86_64.bin \
+            https://dl.google.com/android/ndk/android-ndk-r10e-darwin-x86_64.bin \
             dea2dd3939eea3289cab075804abb153014b78d3
     elif [ ${MASON_PLATFORM} = 'linux' ]; then
         mason_download \
-            http://dl.google.com/android/ndk/android-ndk-r10e-linux-x86_64.bin \
+            https://dl.google.com/android/ndk/android-ndk-r10e-linux-x86_64.bin \
             285606ba6882d27d99ed469fc5533cc3c93967f5
     fi
 

--- a/scripts/android-ndk/arm64-21-r11c/script.sh
+++ b/scripts/android-ndk/arm64-21-r11c/script.sh
@@ -9,11 +9,11 @@ MASON_LIB_FILE=
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-r11c-darwin-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-r11c-darwin-x86_64.zip \
             0c6fa2017dd5237f6270887c85feedc4aafb3aef
     elif [ ${MASON_PLATFORM} = 'linux' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-r11c-linux-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-r11c-linux-x86_64.zip \
             0c646e2fceb3ef853e1832f4aa3a0dc4c16d2229
     fi
 

--- a/scripts/android-ndk/arm64-21-r12b/script.sh
+++ b/scripts/android-ndk/arm64-21-r12b/script.sh
@@ -9,11 +9,11 @@ MASON_LIB_FILE=
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-r12b-darwin-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-r12b-darwin-x86_64.zip \
             1a3bbdde35a240086b022cdf13ddcf40c27caa6e
     elif [ ${MASON_PLATFORM} = 'linux' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-r12b-linux-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-r12b-linux-x86_64.zip \
             c6286e131c233c25537a306eae0a29d50b352b91
     fi
 

--- a/scripts/android-ndk/arm64-21-r13b/script.sh
+++ b/scripts/android-ndk/arm64-21-r13b/script.sh
@@ -9,11 +9,11 @@ MASON_LIB_FILE=
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-r13b-darwin-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-r13b-darwin-x86_64.zip \
             b822dd239f63cd2e1e72c823c41bd732da2e5ad6
     elif [ ${MASON_PLATFORM} = 'linux' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-r13b-linux-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-r13b-linux-x86_64.zip \
             b95dd1fba5096ca3310a67e90b2a5a8aca3ddec7
     fi
 

--- a/scripts/android-ndk/mips-9-r10e/script.sh
+++ b/scripts/android-ndk/mips-9-r10e/script.sh
@@ -9,11 +9,11 @@ MASON_LIB_FILE=
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then
         mason_download \
-            http://dl.google.com/android/ndk/android-ndk-r10e-darwin-x86_64.bin \
+            https://dl.google.com/android/ndk/android-ndk-r10e-darwin-x86_64.bin \
             dea2dd3939eea3289cab075804abb153014b78d3
     elif [ ${MASON_PLATFORM} = 'linux' ]; then
         mason_download \
-            http://dl.google.com/android/ndk/android-ndk-r10e-linux-x86_64.bin \
+            https://dl.google.com/android/ndk/android-ndk-r10e-linux-x86_64.bin \
             285606ba6882d27d99ed469fc5533cc3c93967f5
     fi
 

--- a/scripts/android-ndk/mips-9-r11c/script.sh
+++ b/scripts/android-ndk/mips-9-r11c/script.sh
@@ -9,11 +9,11 @@ MASON_LIB_FILE=
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-r11c-darwin-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-r11c-darwin-x86_64.zip \
             0c6fa2017dd5237f6270887c85feedc4aafb3aef
     elif [ ${MASON_PLATFORM} = 'linux' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-r11c-linux-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-r11c-linux-x86_64.zip \
             0c646e2fceb3ef853e1832f4aa3a0dc4c16d2229
     fi
 

--- a/scripts/android-ndk/mips-9-r12b/script.sh
+++ b/scripts/android-ndk/mips-9-r12b/script.sh
@@ -9,11 +9,11 @@ MASON_LIB_FILE=
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-r12b-darwin-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-r12b-darwin-x86_64.zip \
             1a3bbdde35a240086b022cdf13ddcf40c27caa6e
     elif [ ${MASON_PLATFORM} = 'linux' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-r12b-linux-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-r12b-linux-x86_64.zip \
             c6286e131c233c25537a306eae0a29d50b352b91
     fi
 

--- a/scripts/android-ndk/mips64-21-r10e/script.sh
+++ b/scripts/android-ndk/mips64-21-r10e/script.sh
@@ -9,11 +9,11 @@ MASON_LIB_FILE=
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then
         mason_download \
-            http://dl.google.com/android/ndk/android-ndk-r10e-darwin-x86_64.bin \
+            https://dl.google.com/android/ndk/android-ndk-r10e-darwin-x86_64.bin \
             dea2dd3939eea3289cab075804abb153014b78d3
     elif [ ${MASON_PLATFORM} = 'linux' ]; then
         mason_download \
-            http://dl.google.com/android/ndk/android-ndk-r10e-linux-x86_64.bin \
+            https://dl.google.com/android/ndk/android-ndk-r10e-linux-x86_64.bin \
             285606ba6882d27d99ed469fc5533cc3c93967f5
     fi
 

--- a/scripts/android-ndk/mips64-21-r11c/script.sh
+++ b/scripts/android-ndk/mips64-21-r11c/script.sh
@@ -9,11 +9,11 @@ MASON_LIB_FILE=
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-r11c-darwin-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-r11c-darwin-x86_64.zip \
             0c6fa2017dd5237f6270887c85feedc4aafb3aef
     elif [ ${MASON_PLATFORM} = 'linux' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-r11c-linux-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-r11c-linux-x86_64.zip \
             0c646e2fceb3ef853e1832f4aa3a0dc4c16d2229
     fi
 

--- a/scripts/android-ndk/mips64-21-r12b/script.sh
+++ b/scripts/android-ndk/mips64-21-r12b/script.sh
@@ -9,11 +9,11 @@ MASON_LIB_FILE=
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-r12b-darwin-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-r12b-darwin-x86_64.zip \
             1a3bbdde35a240086b022cdf13ddcf40c27caa6e
     elif [ ${MASON_PLATFORM} = 'linux' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-r12b-linux-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-r12b-linux-x86_64.zip \
             c6286e131c233c25537a306eae0a29d50b352b91
     fi
 

--- a/scripts/android-ndk/mips64-21-r13b/script.sh
+++ b/scripts/android-ndk/mips64-21-r13b/script.sh
@@ -9,11 +9,11 @@ MASON_LIB_FILE=
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-r13b-darwin-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-r13b-darwin-x86_64.zip \
             b822dd239f63cd2e1e72c823c41bd732da2e5ad6
     elif [ ${MASON_PLATFORM} = 'linux' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-r13b-linux-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-r13b-linux-x86_64.zip \
             b95dd1fba5096ca3310a67e90b2a5a8aca3ddec7
     fi
 

--- a/scripts/android-ndk/script-r13b.sh
+++ b/scripts/android-ndk/script-r13b.sh
@@ -7,11 +7,11 @@ export MASON_ANDROID_NDK_API_LEVEL=${MASON_ANDROID_PLATFORM_VERSION##*-}
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-${MASON_ANDROID_NDK_VERSION}-darwin-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-${MASON_ANDROID_NDK_VERSION}-darwin-x86_64.zip \
             b822dd239f63cd2e1e72c823c41bd732da2e5ad6
     elif [ ${MASON_PLATFORM} = 'linux' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-${MASON_ANDROID_NDK_VERSION}-linux-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-${MASON_ANDROID_NDK_VERSION}-linux-x86_64.zip \
             b95dd1fba5096ca3310a67e90b2a5a8aca3ddec7
     fi
 

--- a/scripts/android-ndk/script-r14.sh
+++ b/scripts/android-ndk/script-r14.sh
@@ -7,11 +7,11 @@ export MASON_ANDROID_NDK_API_LEVEL=${MASON_ANDROID_PLATFORM_VERSION##*-}
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-${MASON_ANDROID_NDK_VERSION}-darwin-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-${MASON_ANDROID_NDK_VERSION}-darwin-x86_64.zip \
             8ace11815fb839a94ee5601c523ddb629f46232b
     elif [ ${MASON_PLATFORM} = 'linux' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-${MASON_ANDROID_NDK_VERSION}-linux-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-${MASON_ANDROID_NDK_VERSION}-linux-x86_64.zip \
             a8eca41e6a8d6f8776834261d3d0363b9a1abe19
     fi
 

--- a/scripts/android-ndk/script-r16b.sh
+++ b/scripts/android-ndk/script-r16b.sh
@@ -7,11 +7,11 @@ export MASON_ANDROID_NDK_API_LEVEL=${MASON_ANDROID_PLATFORM_VERSION##*-}
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-${MASON_ANDROID_NDK_VERSION}-darwin-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-${MASON_ANDROID_NDK_VERSION}-darwin-x86_64.zip \
             63464a54737c506ba86a7bb534a927b66c425f2c
     elif [ ${MASON_PLATFORM} = 'linux' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-${MASON_ANDROID_NDK_VERSION}-linux-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-${MASON_ANDROID_NDK_VERSION}-linux-x86_64.zip \
             73ac466861f1a8035ad0abe608be2219a212540f
     fi
 

--- a/scripts/android-ndk/x86-9-r10e/script.sh
+++ b/scripts/android-ndk/x86-9-r10e/script.sh
@@ -9,11 +9,11 @@ MASON_LIB_FILE=
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then
         mason_download \
-            http://dl.google.com/android/ndk/android-ndk-r10e-darwin-x86_64.bin \
+            https://dl.google.com/android/ndk/android-ndk-r10e-darwin-x86_64.bin \
             dea2dd3939eea3289cab075804abb153014b78d3
     elif [ ${MASON_PLATFORM} = 'linux' ]; then
         mason_download \
-            http://dl.google.com/android/ndk/android-ndk-r10e-linux-x86_64.bin \
+            https://dl.google.com/android/ndk/android-ndk-r10e-linux-x86_64.bin \
             285606ba6882d27d99ed469fc5533cc3c93967f5
     fi
 

--- a/scripts/android-ndk/x86-9-r11c/script.sh
+++ b/scripts/android-ndk/x86-9-r11c/script.sh
@@ -9,11 +9,11 @@ MASON_LIB_FILE=
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-r11c-darwin-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-r11c-darwin-x86_64.zip \
             0c6fa2017dd5237f6270887c85feedc4aafb3aef
     elif [ ${MASON_PLATFORM} = 'linux' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-r11c-linux-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-r11c-linux-x86_64.zip \
             0c646e2fceb3ef853e1832f4aa3a0dc4c16d2229
     fi
 

--- a/scripts/android-ndk/x86-9-r12b/script.sh
+++ b/scripts/android-ndk/x86-9-r12b/script.sh
@@ -9,11 +9,11 @@ MASON_LIB_FILE=
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-r12b-darwin-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-r12b-darwin-x86_64.zip \
             1a3bbdde35a240086b022cdf13ddcf40c27caa6e
     elif [ ${MASON_PLATFORM} = 'linux' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-r12b-linux-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-r12b-linux-x86_64.zip \
             c6286e131c233c25537a306eae0a29d50b352b91
     fi
 

--- a/scripts/android-ndk/x86_64-21-r10e/script.sh
+++ b/scripts/android-ndk/x86_64-21-r10e/script.sh
@@ -9,11 +9,11 @@ MASON_LIB_FILE=
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then
         mason_download \
-            http://dl.google.com/android/ndk/android-ndk-r10e-darwin-x86_64.bin \
+            https://dl.google.com/android/ndk/android-ndk-r10e-darwin-x86_64.bin \
             dea2dd3939eea3289cab075804abb153014b78d3
     elif [ ${MASON_PLATFORM} = 'linux' ]; then
         mason_download \
-            http://dl.google.com/android/ndk/android-ndk-r10e-linux-x86_64.bin \
+            https://dl.google.com/android/ndk/android-ndk-r10e-linux-x86_64.bin \
             285606ba6882d27d99ed469fc5533cc3c93967f5
     fi
 

--- a/scripts/android-ndk/x86_64-21-r11c/script.sh
+++ b/scripts/android-ndk/x86_64-21-r11c/script.sh
@@ -9,11 +9,11 @@ MASON_LIB_FILE=
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-r11c-darwin-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-r11c-darwin-x86_64.zip \
             0c6fa2017dd5237f6270887c85feedc4aafb3aef
     elif [ ${MASON_PLATFORM} = 'linux' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-r11c-linux-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-r11c-linux-x86_64.zip \
             0c646e2fceb3ef853e1832f4aa3a0dc4c16d2229
     fi
 

--- a/scripts/android-ndk/x86_64-21-r12b/script.sh
+++ b/scripts/android-ndk/x86_64-21-r12b/script.sh
@@ -9,11 +9,11 @@ MASON_LIB_FILE=
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-r12b-darwin-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-r12b-darwin-x86_64.zip \
             1a3bbdde35a240086b022cdf13ddcf40c27caa6e
     elif [ ${MASON_PLATFORM} = 'linux' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-r12b-linux-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-r12b-linux-x86_64.zip \
             c6286e131c233c25537a306eae0a29d50b352b91
     fi
 

--- a/scripts/android-ndk/x86_64-21-r13b/script.sh
+++ b/scripts/android-ndk/x86_64-21-r13b/script.sh
@@ -9,11 +9,11 @@ MASON_LIB_FILE=
 function mason_load_source {
     if [ ${MASON_PLATFORM} = 'osx' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-r13b-darwin-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-r13b-darwin-x86_64.zip \
             b822dd239f63cd2e1e72c823c41bd732da2e5ad6
     elif [ ${MASON_PLATFORM} = 'linux' ]; then
         mason_download \
-            http://dl.google.com/android/repository/android-ndk-r13b-linux-x86_64.zip \
+            https://dl.google.com/android/repository/android-ndk-r13b-linux-x86_64.zip \
             b95dd1fba5096ca3310a67e90b2a5a8aca3ddec7
     fi
 

--- a/scripts/binutils/2.26/script.sh
+++ b/scripts/binutils/2.26/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=bin/ld
 
 function mason_load_source {
     mason_download \
-        http://ftp.gnu.org/gnu/binutils/${MASON_NAME}-${MASON_VERSION}.tar.bz2 \
+        https://ftp.gnu.org/gnu/binutils/${MASON_NAME}-${MASON_VERSION}.tar.bz2 \
         05b22d6ef8003e76f7d05500363a3ee8cc66a7ae
 
     mason_extract_tar_bz2

--- a/scripts/binutils/2.27/script.sh
+++ b/scripts/binutils/2.27/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=lib/libbfd.a
 
 function mason_load_source {
     mason_download \
-        http://ftp.gnu.org/gnu/binutils/${MASON_NAME}-${MASON_VERSION}.tar.bz2 \
+        https://ftp.gnu.org/gnu/binutils/${MASON_NAME}-${MASON_VERSION}.tar.bz2 \
         7e62c56ea660080882af2c8644d566765a77a0b8
 
     mason_extract_tar_bz2

--- a/scripts/binutils/2.28/script.sh
+++ b/scripts/binutils/2.28/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=lib/libbfd.a
 
 function mason_load_source {
     mason_download \
-        http://ftp.gnu.org/gnu/binutils/${MASON_NAME}-${MASON_VERSION}.tar.bz2 \
+        https://ftp.gnu.org/gnu/binutils/${MASON_NAME}-${MASON_VERSION}.tar.bz2 \
         bea61d1a33e4ed8061f1936ef00a633c7fff096e
 
     mason_extract_tar_bz2

--- a/scripts/binutils/2.30/script.sh
+++ b/scripts/binutils/2.30/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=lib/libbfd.a
 
 function mason_load_source {
     mason_download \
-        http://ftp.gnu.org/gnu/binutils/${MASON_NAME}-${MASON_VERSION}.tar.bz2 \
+        https://ftp.gnu.org/gnu/binutils/${MASON_NAME}-${MASON_VERSION}.tar.bz2 \
         9bbe52758d123de00bce46d7c657d10aad97bf38
 
     mason_extract_tar_bz2

--- a/scripts/binutils/2.31/script.sh
+++ b/scripts/binutils/2.31/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=lib/libbfd.a
 
 function mason_load_source {
     mason_download \
-        http://ftp.gnu.org/gnu/binutils/${MASON_NAME}-${MASON_VERSION}.tar.bz2 \
+        https://ftp.gnu.org/gnu/binutils/${MASON_NAME}-${MASON_VERSION}.tar.bz2 \
         602856fd5af10a09a123ae25dfb86e3b436549cf
 
     mason_extract_tar_bz2

--- a/scripts/boost/1.57.0/script.sh
+++ b/scripts/boost/1.57.0/script.sh
@@ -10,7 +10,7 @@ BOOST_ROOT=${MASON_PREFIX}
 
 function mason_load_source {
     mason_download \
-        http://downloads.sourceforge.net/project/boost/boost/1.57.0/boost_1_57_0.tar.bz2 \
+        https://downloads.sourceforge.net/project/boost/boost/1.57.0/boost_1_57_0.tar.bz2 \
         397306fa6d0858c4885fbba7d43a0164dcb7f53e
 
     mason_extract_tar_bz2 boost_1_57_0/boost

--- a/scripts/boost/1.58.0/script.sh
+++ b/scripts/boost/1.58.0/script.sh
@@ -10,7 +10,7 @@ BOOST_ROOT=${MASON_PREFIX}
 
 function mason_load_source {
     mason_download \
-        http://downloads.sourceforge.net/project/boost/boost/1.58.0/boost_1_58_0.tar.bz2 \
+        https://downloads.sourceforge.net/project/boost/boost/1.58.0/boost_1_58_0.tar.bz2 \
         43e46651e762e4daf72a5d21dca86ae151e65378
 
     mason_extract_tar_bz2 boost_1_58_0/boost

--- a/scripts/boost/1.59.0/script.sh
+++ b/scripts/boost/1.59.0/script.sh
@@ -10,7 +10,7 @@ BOOST_ROOT=${MASON_PREFIX}
 
 function mason_load_source {
     mason_download \
-        http://downloads.sourceforge.net/project/boost/boost/1.59.0/boost_1_59_0.tar.bz2 \
+        https://downloads.sourceforge.net/project/boost/boost/1.59.0/boost_1_59_0.tar.bz2 \
         ff2e48f4d7e3c4b393d41e07a2f5d923b990967d
 
     mason_extract_tar_bz2 boost_1_59_0/boost

--- a/scripts/boost/1.60.0/script.sh
+++ b/scripts/boost/1.60.0/script.sh
@@ -10,7 +10,7 @@ BOOST_ROOT=${MASON_PREFIX}
 
 function mason_load_source {
     mason_download \
-        http://downloads.sourceforge.net/project/boost/boost/1.60.0/boost_1_60_0.tar.bz2 \
+        https://downloads.sourceforge.net/project/boost/boost/1.60.0/boost_1_60_0.tar.bz2 \
         40a65135d34c3e3a3cdbe681f06745c086e5b941
 
     mason_extract_tar_bz2 boost_1_60_0/boost

--- a/scripts/boost/1.61.0/script.sh
+++ b/scripts/boost/1.61.0/script.sh
@@ -19,7 +19,7 @@ source ${HERE}/common.sh
 # override default unpacking to just unpack headers
 function mason_load_source {
     mason_download \
-        http://downloads.sourceforge.net/project/boost/boost/${MASON_VERSION}/boost_${BOOST_VERSION}.tar.bz2 \
+        https://downloads.sourceforge.net/project/boost/boost/${MASON_VERSION}/boost_${BOOST_VERSION}.tar.bz2 \
         ${BOOST_SHASUM}
 
     mason_extract_tar_bz2 boost_${BOOST_VERSION}/boost

--- a/scripts/boost/1.62.0/script.sh
+++ b/scripts/boost/1.62.0/script.sh
@@ -18,7 +18,7 @@ source ${HERE}/common.sh
 # override default unpacking to just unpack headers
 function mason_load_source {
     mason_download \
-        http://downloads.sourceforge.net/project/boost/boost/${MASON_VERSION}/boost_${BOOST_VERSION}.tar.bz2 \
+        https://downloads.sourceforge.net/project/boost/boost/${MASON_VERSION}/boost_${BOOST_VERSION}.tar.bz2 \
         ${BOOST_SHASUM}
 
     mason_extract_tar_bz2 boost_${BOOST_VERSION}/boost

--- a/scripts/boost/1.63.0/script.sh
+++ b/scripts/boost/1.63.0/script.sh
@@ -18,7 +18,7 @@ source ${HERE}/common.sh
 # override default unpacking to just unpack headers
 function mason_load_source {
     mason_download \
-        http://downloads.sourceforge.net/project/boost/boost/${MASON_VERSION}/boost_${BOOST_VERSION}.tar.bz2 \
+        https://downloads.sourceforge.net/project/boost/boost/${MASON_VERSION}/boost_${BOOST_VERSION}.tar.bz2 \
         ${BOOST_SHASUM}
 
     mason_extract_tar_bz2 boost_${BOOST_VERSION}/boost

--- a/scripts/boost/1.64.0/script.sh
+++ b/scripts/boost/1.64.0/script.sh
@@ -18,7 +18,7 @@ source ${HERE}/common.sh
 # override default unpacking to just unpack headers
 function mason_load_source {
     mason_download \
-        http://downloads.sourceforge.net/project/boost/boost/${MASON_VERSION}/boost_${BOOST_VERSION}.tar.bz2 \
+        https://downloads.sourceforge.net/project/boost/boost/${MASON_VERSION}/boost_${BOOST_VERSION}.tar.bz2 \
         ${BOOST_SHASUM}
 
     mason_extract_tar_bz2 boost_${BOOST_VERSION}/boost

--- a/scripts/boost/1.65.1/script.sh
+++ b/scripts/boost/1.65.1/script.sh
@@ -18,7 +18,7 @@ source ${HERE}/common.sh
 # override default unpacking to just unpack headers
 function mason_load_source {
     mason_download \
-        http://downloads.sourceforge.net/project/boost/boost/${MASON_VERSION}/boost_${BOOST_VERSION}.tar.bz2 \
+        https://downloads.sourceforge.net/project/boost/boost/${MASON_VERSION}/boost_${BOOST_VERSION}.tar.bz2 \
         ${BOOST_SHASUM}
 
     mason_extract_tar_bz2 boost_${BOOST_VERSION}/boost

--- a/scripts/boost/1.66.0/script.sh
+++ b/scripts/boost/1.66.0/script.sh
@@ -18,7 +18,7 @@ source ${HERE}/common.sh
 # override default unpacking to just unpack headers
 function mason_load_source {
     mason_download \
-        http://downloads.sourceforge.net/project/boost/boost/${MASON_VERSION}/boost_${BOOST_VERSION}.tar.bz2 \
+        https://downloads.sourceforge.net/project/boost/boost/${MASON_VERSION}/boost_${BOOST_VERSION}.tar.bz2 \
         ${BOOST_SHASUM}
 
     mason_extract_tar_bz2 boost_${BOOST_VERSION}/boost

--- a/scripts/boost/1.67.0/script.sh
+++ b/scripts/boost/1.67.0/script.sh
@@ -18,7 +18,7 @@ source ${HERE}/common.sh
 # override default unpacking to just unpack headers
 function mason_load_source {
     mason_download \
-        http://downloads.sourceforge.net/project/boost/boost/${MASON_VERSION}/boost_${BOOST_VERSION}.tar.bz2 \
+        https://downloads.sourceforge.net/project/boost/boost/${MASON_VERSION}/boost_${BOOST_VERSION}.tar.bz2 \
         ${BOOST_SHASUM}
 
     mason_extract_tar_bz2 boost_${BOOST_VERSION}/boost

--- a/scripts/boost_libdate_time/1.57.0/script.sh
+++ b/scripts/boost_libdate_time/1.57.0/script.sh
@@ -14,7 +14,7 @@ MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
 
 function mason_load_source {
     mason_download \
-        http://downloads.sourceforge.net/project/boost/boost/${BOOST_VERSION1}/boost_${BOOST_VERSION2}.tar.bz2 \
+        https://downloads.sourceforge.net/project/boost/boost/${BOOST_VERSION1}/boost_${BOOST_VERSION2}.tar.bz2 \
         397306fa6d0858c4885fbba7d43a0164dcb7f53e
 
     export MASON_BUILD_PATH=${MASON_ROOT}/.build/boost_${BOOST_VERSION2}

--- a/scripts/boost_libfilesystem/1.57.0/script.sh
+++ b/scripts/boost_libfilesystem/1.57.0/script.sh
@@ -14,7 +14,7 @@ MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
 
 function mason_load_source {
     mason_download \
-        http://downloads.sourceforge.net/project/boost/boost/${BOOST_VERSION1}/boost_${BOOST_VERSION2}.tar.bz2 \
+        https://downloads.sourceforge.net/project/boost/boost/${BOOST_VERSION1}/boost_${BOOST_VERSION2}.tar.bz2 \
         397306fa6d0858c4885fbba7d43a0164dcb7f53e
 
     export MASON_BUILD_PATH=${MASON_ROOT}/.build/boost_${BOOST_VERSION2}

--- a/scripts/boost_libiostreams/1.57.0/script.sh
+++ b/scripts/boost_libiostreams/1.57.0/script.sh
@@ -14,7 +14,7 @@ MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
 
 function mason_load_source {
     mason_download \
-        http://downloads.sourceforge.net/project/boost/boost/${BOOST_VERSION1}/boost_${BOOST_VERSION2}.tar.bz2 \
+        https://downloads.sourceforge.net/project/boost/boost/${BOOST_VERSION1}/boost_${BOOST_VERSION2}.tar.bz2 \
         397306fa6d0858c4885fbba7d43a0164dcb7f53e
 
     export MASON_BUILD_PATH=${MASON_ROOT}/.build/boost_${BOOST_VERSION2}

--- a/scripts/boost_libprogram_options/1.57.0/script.sh
+++ b/scripts/boost_libprogram_options/1.57.0/script.sh
@@ -14,7 +14,7 @@ MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
 
 function mason_load_source {
     mason_download \
-        http://downloads.sourceforge.net/project/boost/boost/${BOOST_VERSION1}/boost_${BOOST_VERSION2}.tar.bz2 \
+        https://downloads.sourceforge.net/project/boost/boost/${BOOST_VERSION1}/boost_${BOOST_VERSION2}.tar.bz2 \
         397306fa6d0858c4885fbba7d43a0164dcb7f53e
 
     export MASON_BUILD_PATH=${MASON_ROOT}/.build/boost_${BOOST_VERSION2}

--- a/scripts/boost_libprogram_options/1.59.0/script.sh
+++ b/scripts/boost_libprogram_options/1.59.0/script.sh
@@ -14,7 +14,7 @@ MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
 
 function mason_load_source {
     mason_download \
-        http://downloads.sourceforge.net/project/boost/boost/${BOOST_VERSION1}/boost_${BOOST_VERSION2}.tar.bz2 \
+        https://downloads.sourceforge.net/project/boost/boost/${BOOST_VERSION1}/boost_${BOOST_VERSION2}.tar.bz2 \
         ff2e48f4d7e3c4b393d41e07a2f5d923b990967d
 
     export MASON_BUILD_PATH=${MASON_ROOT}/.build/boost_${BOOST_VERSION2}

--- a/scripts/boost_libprogram_options/1.60.0/script.sh
+++ b/scripts/boost_libprogram_options/1.60.0/script.sh
@@ -14,7 +14,7 @@ MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
 
 function mason_load_source {
     mason_download \
-        http://downloads.sourceforge.net/project/boost/boost/${BOOST_VERSION1}/boost_${BOOST_VERSION2}.tar.bz2 \
+        https://downloads.sourceforge.net/project/boost/boost/${BOOST_VERSION1}/boost_${BOOST_VERSION2}.tar.bz2 \
         40a65135d34c3e3a3cdbe681f06745c086e5b941
 
     export MASON_BUILD_PATH=${MASON_ROOT}/.build/boost_${BOOST_VERSION2}

--- a/scripts/boost_libprogram_options/1.62.0-cxx11abi/script.sh
+++ b/scripts/boost_libprogram_options/1.62.0-cxx11abi/script.sh
@@ -31,7 +31,7 @@ export CXXFLAGS="${CXXFLAGS} -D_GLIBCXX_USE_CXX11_ABI=1"
 
 function mason_load_source {
     mason_download \
-        http://downloads.sourceforge.net/project/boost/boost/${BOOST_VERSION_DOWNLOAD}/boost_${BOOST_VERSION}.tar.bz2 \
+        https://downloads.sourceforge.net/project/boost/boost/${BOOST_VERSION_DOWNLOAD}/boost_${BOOST_VERSION}.tar.bz2 \
         ${BOOST_SHASUM}
 
     export MASON_BUILD_PATH=${MASON_ROOT}/.build/boost_${BOOST_VERSION}

--- a/scripts/boost_libpython/1.57.0/script.sh
+++ b/scripts/boost_libpython/1.57.0/script.sh
@@ -14,7 +14,7 @@ MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
 
 function mason_load_source {
     mason_download \
-        http://downloads.sourceforge.net/project/boost/boost/${BOOST_VERSION1}/boost_${BOOST_VERSION2}.tar.bz2 \
+        https://downloads.sourceforge.net/project/boost/boost/${BOOST_VERSION1}/boost_${BOOST_VERSION2}.tar.bz2 \
         397306fa6d0858c4885fbba7d43a0164dcb7f53e
 
     export MASON_BUILD_PATH=${MASON_ROOT}/.build/boost_${BOOST_VERSION2}

--- a/scripts/boost_libregex/1.57.0/script.sh
+++ b/scripts/boost_libregex/1.57.0/script.sh
@@ -14,7 +14,7 @@ MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
 
 function mason_load_source {
     mason_download \
-        http://downloads.sourceforge.net/project/boost/boost/${BOOST_VERSION1}/boost_${BOOST_VERSION2}.tar.bz2 \
+        https://downloads.sourceforge.net/project/boost/boost/${BOOST_VERSION1}/boost_${BOOST_VERSION2}.tar.bz2 \
         397306fa6d0858c4885fbba7d43a0164dcb7f53e
 
     export MASON_BUILD_PATH=${MASON_ROOT}/.build/boost_${BOOST_VERSION2}

--- a/scripts/boost_libsystem/1.57.0/script.sh
+++ b/scripts/boost_libsystem/1.57.0/script.sh
@@ -14,7 +14,7 @@ MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
 
 function mason_load_source {
     mason_download \
-        http://downloads.sourceforge.net/project/boost/boost/${BOOST_VERSION1}/boost_${BOOST_VERSION2}.tar.bz2 \
+        https://downloads.sourceforge.net/project/boost/boost/${BOOST_VERSION1}/boost_${BOOST_VERSION2}.tar.bz2 \
         397306fa6d0858c4885fbba7d43a0164dcb7f53e
 
     export MASON_BUILD_PATH=${MASON_ROOT}/.build/boost_${BOOST_VERSION2}

--- a/scripts/boost_libtest/1.57.0/script.sh
+++ b/scripts/boost_libtest/1.57.0/script.sh
@@ -14,7 +14,7 @@ MASON_LIB_FILE=lib/libboost_unit_test_framework.a
 
 function mason_load_source {
     mason_download \
-        http://downloads.sourceforge.net/project/boost/boost/${BOOST_VERSION1}/boost_${BOOST_VERSION2}.tar.bz2 \
+        https://downloads.sourceforge.net/project/boost/boost/${BOOST_VERSION1}/boost_${BOOST_VERSION2}.tar.bz2 \
         397306fa6d0858c4885fbba7d43a0164dcb7f53e
 
     export MASON_BUILD_PATH=${MASON_ROOT}/.build/boost_${BOOST_VERSION2}

--- a/scripts/boost_libthread/1.57.0/script.sh
+++ b/scripts/boost_libthread/1.57.0/script.sh
@@ -14,7 +14,7 @@ MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
 
 function mason_load_source {
     mason_download \
-        http://downloads.sourceforge.net/project/boost/boost/${BOOST_VERSION1}/boost_${BOOST_VERSION2}.tar.bz2 \
+        https://downloads.sourceforge.net/project/boost/boost/${BOOST_VERSION1}/boost_${BOOST_VERSION2}.tar.bz2 \
         397306fa6d0858c4885fbba7d43a0164dcb7f53e
 
     export MASON_BUILD_PATH=${MASON_ROOT}/.build/boost_${BOOST_VERSION2}

--- a/scripts/cairo/1.12.18/script.sh
+++ b/scripts/cairo/1.12.18/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/cairo.pc
 
 function mason_load_source {
     mason_download \
-        http://cairographics.org/releases/${MASON_NAME}-${MASON_VERSION}.tar.xz \
+        https://cairographics.org/releases/${MASON_NAME}-${MASON_VERSION}.tar.xz \
         34e29ec00864859cc26ac3e45a02d7b2cb65d1c8
 
     mason_extract_tar_xz

--- a/scripts/cairo/1.14.0/script.sh
+++ b/scripts/cairo/1.14.0/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/cairo.pc
 
 function mason_load_source {
     mason_download \
-        http://cairographics.org/releases/${MASON_NAME}-${MASON_VERSION}.tar.xz \
+        https://cairographics.org/releases/${MASON_NAME}-${MASON_VERSION}.tar.xz \
         69b3923f8f113206f6c0e2972de4469d04b04592
 
     mason_extract_tar_xz

--- a/scripts/cairo/1.14.2/script.sh
+++ b/scripts/cairo/1.14.2/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/cairo.pc
 
 function mason_load_source {
     mason_download \
-        http://cairographics.org/releases/${MASON_NAME}-${MASON_VERSION}.tar.xz \
+        https://cairographics.org/releases/${MASON_NAME}-${MASON_VERSION}.tar.xz \
         3202106739cb0cb044c910a9b67769c95d0b6bce
 
     mason_extract_tar_xz

--- a/scripts/cairo/1.14.4/script.sh
+++ b/scripts/cairo/1.14.4/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/cairo.pc
 
 function mason_load_source {
     mason_download \
-        http://cairographics.org/releases/${MASON_NAME}-${MASON_VERSION}.tar.xz \
+        https://cairographics.org/releases/${MASON_NAME}-${MASON_VERSION}.tar.xz \
         ecf18db1e89d99799783757d9026a74012dfafcb
 
     mason_extract_tar_xz

--- a/scripts/cairo/1.14.6/script.sh
+++ b/scripts/cairo/1.14.6/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/cairo.pc
 
 function mason_load_source {
     mason_download \
-        http://cairographics.org/releases/${MASON_NAME}-${MASON_VERSION}.tar.xz \
+        https://cairographics.org/releases/${MASON_NAME}-${MASON_VERSION}.tar.xz \
         b19d7d7b4e290eb6377ddc3688984cb66da036cb
 
     mason_extract_tar_xz

--- a/scripts/cairo/1.14.8/script.sh
+++ b/scripts/cairo/1.14.8/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/cairo.pc
 
 function mason_load_source {
     mason_download \
-        http://cairographics.org/releases/${MASON_NAME}-${MASON_VERSION}.tar.xz \
+        https://cairographics.org/releases/${MASON_NAME}-${MASON_VERSION}.tar.xz \
         b6a7b9d02e24fdd5fc5c44d30040f14d361a0950
 
     mason_extract_tar_xz

--- a/scripts/cmake/3.2.2/script.sh
+++ b/scripts/cmake/3.2.2/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=bin/cmake
 
 function mason_load_source {
     mason_download \
-        http://www.cmake.org/files/v3.2/cmake-3.2.2.tar.gz \
+        https://www.cmake.org/files/v3.2/cmake-3.2.2.tar.gz \
         b7cb39c390dcd8abad4af33d5507b68965e488b4
 
     mason_extract_tar_gz

--- a/scripts/cmake/3.5.2/script.sh
+++ b/scripts/cmake/3.5.2/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=bin/cmake
 
 function mason_load_source {
     mason_download \
-        http://www.cmake.org/files/v3.5/cmake-${MASON_VERSION}.tar.gz \
+        https://www.cmake.org/files/v3.5/cmake-${MASON_VERSION}.tar.gz \
         70cbd618e8ac39414928d79c949968e7dd7a5605
 
     mason_extract_tar_gz

--- a/scripts/cmake/3.6.2/script.sh
+++ b/scripts/cmake/3.6.2/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=bin/cmake
 
 function mason_load_source {
     mason_download \
-        http://www.cmake.org/files/v3.6/cmake-${MASON_VERSION}.tar.gz \
+        https://www.cmake.org/files/v3.6/cmake-${MASON_VERSION}.tar.gz \
         f2c114944dafb319c27bdca214ca7e0739a71cb0
 
     mason_extract_tar_gz

--- a/scripts/cmake/3.7.1/script.sh
+++ b/scripts/cmake/3.7.1/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=bin/cmake
 
 function mason_load_source {
     mason_download \
-        http://www.cmake.org/files/v3.7/cmake-${MASON_VERSION}.tar.gz \
+        https://www.cmake.org/files/v3.7/cmake-${MASON_VERSION}.tar.gz \
         591a89d83e3659884c52e6cf7009725a6b4e94e5
 
     mason_extract_tar_gz

--- a/scripts/cmake/3.7.2/script.sh
+++ b/scripts/cmake/3.7.2/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=bin/cmake
 
 function mason_load_source {
     mason_download \
-        http://www.cmake.org/files/v3.7/cmake-${MASON_VERSION}.tar.gz \
+        https://www.cmake.org/files/v3.7/cmake-${MASON_VERSION}.tar.gz \
         35e73aad419b0dca4d5f8e8ba483e29ff54b7f05
 
     mason_extract_tar_gz

--- a/scripts/cmake/3.8.2/script.sh
+++ b/scripts/cmake/3.8.2/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=bin/cmake
 
 function mason_load_source {
     mason_download \
-        http://www.cmake.org/files/v3.8/cmake-${MASON_VERSION}.tar.gz \
+        https://www.cmake.org/files/v3.8/cmake-${MASON_VERSION}.tar.gz \
         7c5b04d0fda1c77f495bbaaa720dac089243c7e7
 
     mason_extract_tar_gz

--- a/scripts/crosstool-ng/1.23.0/script.sh
+++ b/scripts/crosstool-ng/1.23.0/script.sh
@@ -9,7 +9,7 @@ MASON_LIB_FILE=bin/ct-ng
 
 function mason_load_source {
     mason_download \
-        http://crosstool-ng.org/download/crosstool-ng/${MASON_NAME}-${MASON_VERSION}.tar.bz2 \
+        https://crosstool-ng.org/download/crosstool-ng/${MASON_NAME}-${MASON_VERSION}.tar.bz2 \
         1b69890d021b5b50a96b70be0fad3bd6e64a6e9e
 
     mason_extract_tar_bz2

--- a/scripts/freetype/2.5.4/script.sh
+++ b/scripts/freetype/2.5.4/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/freetype2.pc
 
 function mason_load_source {
     mason_download \
-        http://nongnu.askapache.com/freetype/freetype-${MASON_VERSION}.tar.bz2 \
+        https://nongnu.askapache.com/freetype/freetype-${MASON_VERSION}.tar.bz2 \
         0646f7e62a6191affe92270e2544e6011f5227e8
 
     mason_extract_tar_bz2

--- a/scripts/freetype/2.5.5/script.sh
+++ b/scripts/freetype/2.5.5/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/freetype2.pc
 
 function mason_load_source {
     mason_download \
-        http://nongnu.askapache.com/freetype/freetype-${MASON_VERSION}.tar.bz2 \
+        https://nongnu.askapache.com/freetype/freetype-${MASON_VERSION}.tar.bz2 \
         c857bfa638b9c71e48baacd1cb12be446b62c333
 
     mason_extract_tar_bz2

--- a/scripts/freetype/2.6.5/script.sh
+++ b/scripts/freetype/2.6.5/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/freetype2.pc
 
 function mason_load_source {
     mason_download \
-        http://nongnu.askapache.com/freetype/freetype-${MASON_VERSION}.tar.bz2 \
+        https://nongnu.askapache.com/freetype/freetype-${MASON_VERSION}.tar.bz2 \
         24dd30c95d3795cb3d82a760b9858992de262630
 
     mason_extract_tar_bz2

--- a/scripts/freetype/2.6/script.sh
+++ b/scripts/freetype/2.6/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/freetype2.pc
 
 function mason_load_source {
     mason_download \
-        http://nongnu.askapache.com/freetype/freetype-${MASON_VERSION}.tar.bz2 \
+        https://nongnu.askapache.com/freetype/freetype-${MASON_VERSION}.tar.bz2 \
         3cdf364b5db1c1adba670b188d76035ecba2d77c
 
     mason_extract_tar_bz2

--- a/scripts/freetype/2.7.1/script.sh
+++ b/scripts/freetype/2.7.1/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/freetype2.pc
 
 function mason_load_source {
     mason_download \
-        http://nongnu.askapache.com/freetype/freetype-${MASON_VERSION}.tar.bz2 \
+        https://nongnu.askapache.com/freetype/freetype-${MASON_VERSION}.tar.bz2 \
         51abc6f9afd5bbcbdcc0d9ea20b145f0ff1be632
 
     mason_extract_tar_bz2

--- a/scripts/gdal/1.11.1-big-pants/script.sh
+++ b/scripts/gdal/1.11.1-big-pants/script.sh
@@ -79,7 +79,7 @@ function mason_compile {
     fi
 
     # note: we put ${STDLIB_CXXFLAGS} into CXX instead of LDFLAGS due to libtool oddity:
-    # http://stackoverflow.com/questions/16248360/autotools-libtool-link-library-with-libstdc-despite-stdlib-libc-option-pass
+    # https://stackoverflow.com/questions/16248360/autotools-libtool-link-library-with-libstdc-despite-stdlib-libc-option-pass
     if [[ $(uname -s) == 'Darwin' ]]; then
         CXX="${CXX} -stdlib=libc++ -std=c++11"
     fi

--- a/scripts/gdal/1.11.1/script.sh
+++ b/scripts/gdal/1.11.1/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=lib/libgdal.a
 
 function mason_load_source {
     mason_download \
-        http://download.osgeo.org/gdal/${MASON_VERSION}/gdal-${MASON_VERSION}.tar.gz \
+        https://download.osgeo.org/gdal/${MASON_VERSION}/gdal-${MASON_VERSION}.tar.gz \
         6a06e527e6a5abd565a67f84caadf9f891e5f49b
 
     mason_extract_tar_gz
@@ -57,7 +57,7 @@ function mason_compile {
     # not produce a shared library no matter if --enable-shared is passed
 
     # note: we put ${STDLIB_CXXFLAGS} into CXX instead of LDFLAGS due to libtool oddity:
-    # http://stackoverflow.com/questions/16248360/autotools-libtool-link-library-with-libstdc-despite-stdlib-libc-option-pass
+    # https://stackoverflow.com/questions/16248360/autotools-libtool-link-library-with-libstdc-despite-stdlib-libc-option-pass
     if [[ $(uname -s) == 'Darwin' ]]; then
         CXX="${CXX} -stdlib=libc++ -std=c++11"
     fi

--- a/scripts/gdal/1.11.2/script.sh
+++ b/scripts/gdal/1.11.2/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=lib/libgdal.a
 
 function mason_load_source {
     mason_download \
-        http://download.osgeo.org/gdal/${MASON_VERSION}/gdal-${MASON_VERSION}.tar.gz \
+        https://download.osgeo.org/gdal/${MASON_VERSION}/gdal-${MASON_VERSION}.tar.gz \
         50660f82fb01ff1c97f6342a3fbbe5bdc6d01b09
 
     mason_extract_tar_gz
@@ -57,7 +57,7 @@ function mason_compile {
     # not produce a shared library no matter if --enable-shared is passed
 
     # note: we put ${STDLIB_CXXFLAGS} into CXX instead of LDFLAGS due to libtool oddity:
-    # http://stackoverflow.com/questions/16248360/autotools-libtool-link-library-with-libstdc-despite-stdlib-libc-option-pass
+    # https://stackoverflow.com/questions/16248360/autotools-libtool-link-library-with-libstdc-despite-stdlib-libc-option-pass
     if [[ $(uname -s) == 'Darwin' ]]; then
         CXX="${CXX} -stdlib=libc++ -std=c++11"
     fi

--- a/scripts/gdal/2.0.2/script.sh
+++ b/scripts/gdal/2.0.2/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=lib/libgdal.a
 
 function mason_load_source {
     mason_download \
-        http://download.osgeo.org/gdal/${MASON_VERSION}/gdal-${MASON_VERSION}.tar.gz \
+        https://download.osgeo.org/gdal/${MASON_VERSION}/gdal-${MASON_VERSION}.tar.gz \
         6b82c9f5e356774a8451182d8720ed4a262a0d5e
 
     mason_extract_tar_gz
@@ -81,7 +81,7 @@ function mason_compile {
     fi
 
     # note: we put ${STDLIB_CXXFLAGS} into CXX instead of LDFLAGS due to libtool oddity:
-    # http://stackoverflow.com/questions/16248360/autotools-libtool-link-library-with-libstdc-despite-stdlib-libc-option-pass
+    # https://stackoverflow.com/questions/16248360/autotools-libtool-link-library-with-libstdc-despite-stdlib-libc-option-pass
     if [[ $(uname -s) == 'Darwin' ]]; then
         CXX="${CXX} -stdlib=libc++ -std=c++11"
     fi

--- a/scripts/gdal/2.1.1/script.sh
+++ b/scripts/gdal/2.1.1/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=lib/libgdal.a
 
 function mason_load_source {
     mason_download \
-        http://download.osgeo.org/gdal/${MASON_VERSION}/gdal-${MASON_VERSION}.tar.gz \
+        https://download.osgeo.org/gdal/${MASON_VERSION}/gdal-${MASON_VERSION}.tar.gz \
         66aa2e083027cff36c000060f4e61ce5e1405307
 
     mason_extract_tar_gz
@@ -81,7 +81,7 @@ function mason_compile {
     fi
 
     # note: we put ${STDLIB_CXXFLAGS} into CXX instead of LDFLAGS due to libtool oddity:
-    # http://stackoverflow.com/questions/16248360/autotools-libtool-link-library-with-libstdc-despite-stdlib-libc-option-pass
+    # https://stackoverflow.com/questions/16248360/autotools-libtool-link-library-with-libstdc-despite-stdlib-libc-option-pass
     if [[ $(uname -s) == 'Darwin' ]]; then
         CXX="${CXX} -stdlib=libc++ -std=c++11"
     fi

--- a/scripts/gdal/2.1.3/script.sh
+++ b/scripts/gdal/2.1.3/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=lib/libgdal.a
 
 function mason_load_source {
     mason_download \
-        http://download.osgeo.org/gdal/${MASON_VERSION}/gdal-${MASON_VERSION}.tar.gz \
+        https://download.osgeo.org/gdal/${MASON_VERSION}/gdal-${MASON_VERSION}.tar.gz \
         552231f8ffe060ba30e37f1a8e6c4665bcf3cd1d
 
     mason_extract_tar_gz
@@ -90,7 +90,7 @@ function mason_compile {
     export CXX="${MASON_CCACHE} ${CXX}"
 
     # note: we put ${STDLIB_CXXFLAGS} into CXX instead of LDFLAGS due to libtool oddity:
-    # http://stackoverflow.com/questions/16248360/autotools-libtool-link-library-with-libstdc-despite-stdlib-libc-option-pass
+    # https://stackoverflow.com/questions/16248360/autotools-libtool-link-library-with-libstdc-despite-stdlib-libc-option-pass
     if [[ $(uname -s) == 'Darwin' ]]; then
         export CXX="${CXX} -stdlib=libc++ -std=c++11"
     fi

--- a/scripts/gdal/2.2.1/script.sh
+++ b/scripts/gdal/2.2.1/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=lib/libgdal.a
 
 function mason_load_source {
     mason_download \
-        http://download.osgeo.org/gdal/${MASON_VERSION}/gdal-${MASON_VERSION}.tar.gz \
+        https://download.osgeo.org/gdal/${MASON_VERSION}/gdal-${MASON_VERSION}.tar.gz \
         ed13ebc5b23f3d4a2c88e9d28d2d0b1b97563e3e
 
     mason_extract_tar_gz
@@ -90,7 +90,7 @@ function mason_compile {
     export CXX="${MASON_CCACHE} ${CXX}"
 
     # note: we put ${STDLIB_CXXFLAGS} into CXX instead of LDFLAGS due to libtool oddity:
-    # http://stackoverflow.com/questions/16248360/autotools-libtool-link-library-with-libstdc-despite-stdlib-libc-option-pass
+    # https://stackoverflow.com/questions/16248360/autotools-libtool-link-library-with-libstdc-despite-stdlib-libc-option-pass
     if [[ $(uname -s) == 'Darwin' ]]; then
         export CXX="${CXX} -stdlib=libc++ -std=c++11"
     fi

--- a/scripts/gdal/2.2.2/script.sh
+++ b/scripts/gdal/2.2.2/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=lib/libgdal.a
 
 function mason_load_source {
     mason_download \
-        http://download.osgeo.org/gdal/${MASON_VERSION}/gdal-${MASON_VERSION}.tar.gz \
+        https://download.osgeo.org/gdal/${MASON_VERSION}/gdal-${MASON_VERSION}.tar.gz \
         1ed7b4303cd30c212bb75b763d7447acebad6e95
 
     mason_extract_tar_gz
@@ -100,7 +100,7 @@ function mason_compile {
     export CXX="${MASON_CCACHE} ${CXX}"
 
     # note: we put ${STDLIB_CXXFLAGS} into CXX instead of LDFLAGS due to libtool oddity:
-    # http://stackoverflow.com/questions/16248360/autotools-libtool-link-library-with-libstdc-despite-stdlib-libc-option-pass
+    # https://stackoverflow.com/questions/16248360/autotools-libtool-link-library-with-libstdc-despite-stdlib-libc-option-pass
     if [[ $(uname -s) == 'Darwin' ]]; then
         export CXX="${CXX} -stdlib=libc++ -std=c++11"
     fi

--- a/scripts/gdal/2.2.3-1/script.sh
+++ b/scripts/gdal/2.2.3-1/script.sh
@@ -9,7 +9,7 @@ MASON_LIB_FILE=lib/libgdal.a
 
 function mason_load_source {
     mason_download \
-        http://download.osgeo.org/gdal/${MASON_VERSION2}/gdal-${MASON_VERSION2}.tar.gz \
+        https://download.osgeo.org/gdal/${MASON_VERSION2}/gdal-${MASON_VERSION2}.tar.gz \
         f4ac4fb76e20cc149d169163914d76d51173ce82
 
     mason_extract_tar_gz
@@ -122,7 +122,7 @@ function mason_compile {
     export CXX="${MASON_CCACHE} ${CXX}"
 
     # note: we put ${STDLIB_CXXFLAGS} into CXX instead of LDFLAGS due to libtool oddity:
-    # http://stackoverflow.com/questions/16248360/autotools-libtool-link-library-with-libstdc-despite-stdlib-libc-option-pass
+    # https://stackoverflow.com/questions/16248360/autotools-libtool-link-library-with-libstdc-despite-stdlib-libc-option-pass
     if [[ $(uname -s) == 'Darwin' ]]; then
         export CXX="${CXX} -stdlib=libc++ -std=c++11"
     fi

--- a/scripts/gdal/2.2.3/script.sh
+++ b/scripts/gdal/2.2.3/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=lib/libgdal.a
 
 function mason_load_source {
     mason_download \
-        http://download.osgeo.org/gdal/${MASON_VERSION}/gdal-${MASON_VERSION}RC1.tar.gz \
+        https://download.osgeo.org/gdal/${MASON_VERSION}/gdal-${MASON_VERSION}RC1.tar.gz \
         f4ac4fb76e20cc149d169163914d76d51173ce82
 
     mason_extract_tar_gz
@@ -106,7 +106,7 @@ function mason_compile {
     export CXX="${MASON_CCACHE} ${CXX}"
 
     # note: we put ${STDLIB_CXXFLAGS} into CXX instead of LDFLAGS due to libtool oddity:
-    # http://stackoverflow.com/questions/16248360/autotools-libtool-link-library-with-libstdc-despite-stdlib-libc-option-pass
+    # https://stackoverflow.com/questions/16248360/autotools-libtool-link-library-with-libstdc-despite-stdlib-libc-option-pass
     if [[ $(uname -s) == 'Darwin' ]]; then
         export CXX="${CXX} -stdlib=libc++ -std=c++11"
     fi

--- a/scripts/gdal/2.4.1/script.sh
+++ b/scripts/gdal/2.4.1/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=lib/libgdal.a
 
 function mason_load_source {
     mason_download \
-        http://download.osgeo.org/gdal/${MASON_VERSION}/gdal-${MASON_VERSION}.tar.gz \
+        https://download.osgeo.org/gdal/${MASON_VERSION}/gdal-${MASON_VERSION}.tar.gz \
         38758d9fa5083e8d8e4333c38e132e154da9f25f
 
     mason_extract_tar_gz
@@ -121,7 +121,7 @@ function mason_compile {
     export CXX="${MASON_CCACHE} ${CXX}"
 
     # note: we put ${STDLIB_CXXFLAGS} into CXX instead of LDFLAGS due to libtool oddity:
-    # http://stackoverflow.com/questions/16248360/autotools-libtool-link-library-with-libstdc-despite-stdlib-libc-option-pass
+    # https://stackoverflow.com/questions/16248360/autotools-libtool-link-library-with-libstdc-despite-stdlib-libc-option-pass
     if [[ $(uname -s) == 'Darwin' ]]; then
         export CXX="${CXX} -stdlib=libc++ -std=c++11"
     fi

--- a/scripts/gdal/dev/script.sh
+++ b/scripts/gdal/dev/script.sh
@@ -82,7 +82,7 @@ function mason_compile {
     fi
 
     # note: we put ${STDLIB_CXXFLAGS} into CXX instead of LDFLAGS due to libtool oddity:
-    # http://stackoverflow.com/questions/16248360/autotools-libtool-link-library-with-libstdc-despite-stdlib-libc-option-pass
+    # https://stackoverflow.com/questions/16248360/autotools-libtool-link-library-with-libstdc-despite-stdlib-libc-option-pass
     if [[ $(uname -s) == 'Darwin' ]]; then
         CXX="${CXX} -stdlib=libc++ -std=c++11"
     fi

--- a/scripts/geos/3.4.2/script.sh
+++ b/scripts/geos/3.4.2/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=lib/libgeos.a
 
 function mason_load_source {
     mason_download \
-        http://download.osgeo.org/geos/${MASON_NAME}-${MASON_VERSION}.tar.bz2 \
+        https://download.osgeo.org/geos/${MASON_NAME}-${MASON_VERSION}.tar.bz2 \
         b248842dee2afa6e944693c21571a2999dfafc5a
 
     mason_extract_tar_bz2
@@ -24,7 +24,7 @@ function mason_compile {
     patch -N -p1 < ./patch.diff
 
     # note: we put ${STDLIB_CXXFLAGS} into CXX instead of LDFLAGS due to libtool oddity:
-    # http://stackoverflow.com/questions/16248360/autotools-libtool-link-library-with-libstdc-despite-stdlib-libc-option-pass
+    # https://stackoverflow.com/questions/16248360/autotools-libtool-link-library-with-libstdc-despite-stdlib-libc-option-pass
     if [[ $(uname -s) == 'Darwin' ]]; then
         CXX="${CXX} -stdlib=libc++ -std=c++11"
     fi

--- a/scripts/geos/3.5.0/script.sh
+++ b/scripts/geos/3.5.0/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=lib/libgeos.a
 
 function mason_load_source {
     mason_download \
-        http://download.osgeo.org/geos/${MASON_NAME}-${MASON_VERSION}.tar.bz2 \
+        https://download.osgeo.org/geos/${MASON_NAME}-${MASON_VERSION}.tar.bz2 \
         a641469449fc32b829fb885cb0ea5fdd3333ce62
 
     mason_extract_tar_bz2
@@ -23,7 +23,7 @@ function mason_compile {
     fi
 
     # note: we put ${STDLIB_CXXFLAGS} into CXX instead of LDFLAGS due to libtool oddity:
-    # http://stackoverflow.com/questions/16248360/autotools-libtool-link-library-with-libstdc-despite-stdlib-libc-option-pass
+    # https://stackoverflow.com/questions/16248360/autotools-libtool-link-library-with-libstdc-despite-stdlib-libc-option-pass
     if [[ $(uname -s) == 'Darwin' ]]; then
         CXX="${CXX} -stdlib=libc++ -std=c++11"
     fi

--- a/scripts/geos/3.6.1/script.sh
+++ b/scripts/geos/3.6.1/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=lib/libgeos.a
 
 function mason_load_source {
     mason_download \
-        http://download.osgeo.org/geos/${MASON_NAME}-${MASON_VERSION}.tar.bz2 \
+        https://download.osgeo.org/geos/${MASON_NAME}-${MASON_VERSION}.tar.bz2 \
         c23fa59e6ab8a4e8df634773fb1ac9794fc5d88a
 
     mason_extract_tar_bz2
@@ -23,7 +23,7 @@ function mason_compile {
     #fi
 
     # note: we put ${STDLIB_CXXFLAGS} into CXX instead of LDFLAGS due to libtool oddity:
-    # http://stackoverflow.com/questions/16248360/autotools-libtool-link-library-with-libstdc-despite-stdlib-libc-option-pass
+    # https://stackoverflow.com/questions/16248360/autotools-libtool-link-library-with-libstdc-despite-stdlib-libc-option-pass
     if [[ $(uname -s) == 'Darwin' ]]; then
         CXX="${CXX} -stdlib=libc++ -std=c++11"
     fi

--- a/scripts/geos/3.6.2/script.sh
+++ b/scripts/geos/3.6.2/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=lib/libgeos.a
 
 function mason_load_source {
     mason_download \
-        http://download.osgeo.org/geos/${MASON_NAME}-${MASON_VERSION}.tar.bz2 \
+        https://download.osgeo.org/geos/${MASON_NAME}-${MASON_VERSION}.tar.bz2 \
         9d602e108e77005b0a2eed0bb1fecae8669a706d
 
     mason_extract_tar_bz2
@@ -23,7 +23,7 @@ function mason_compile {
     #fi
 
     # note: we put ${STDLIB_CXXFLAGS} into CXX instead of LDFLAGS due to libtool oddity:
-    # http://stackoverflow.com/questions/16248360/autotools-libtool-link-library-with-libstdc-despite-stdlib-libc-option-pass
+    # https://stackoverflow.com/questions/16248360/autotools-libtool-link-library-with-libstdc-despite-stdlib-libc-option-pass
     if [[ $(uname -s) == 'Darwin' ]]; then
         CXX="${CXX} -stdlib=libc++ -std=c++11"
     fi

--- a/scripts/geowave-jace/0.8.7/script.sh
+++ b/scripts/geowave-jace/0.8.7/script.sh
@@ -7,7 +7,7 @@ MASON_LIB_FILE=lib/libjace.a
 . ${MASON_DIR}/mason.sh
 
 function mason_load_source {
-    mason_download http://s3.amazonaws.com/geowave-rpms/release/TARBALL/geowave-0.8.7-c8ef40c-jace-source.tar.gz \
+    mason_download https://s3.amazonaws.com/geowave-rpms/release/TARBALL/geowave-0.8.7-c8ef40c-jace-source.tar.gz \
     80f7002a063c6b178366e7376597acc53859558b
 
     mason_extract_tar_gz

--- a/scripts/harfbuzz/0.9.40/script.sh
+++ b/scripts/harfbuzz/0.9.40/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/harfbuzz.pc
 
 function mason_load_source {
     mason_download \
-        http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-${MASON_VERSION}.tar.bz2 \
+        https://www.freedesktop.org/software/harfbuzz/release/harfbuzz-${MASON_VERSION}.tar.bz2 \
         a685da85d38c37fd27603165642fc09feb7ae7c1
 
     mason_extract_tar_bz2

--- a/scripts/harfbuzz/0.9.41/script.sh
+++ b/scripts/harfbuzz/0.9.41/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/harfbuzz.pc
 
 function mason_load_source {
     mason_download \
-        http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-${MASON_VERSION}.tar.bz2 \
+        https://www.freedesktop.org/software/harfbuzz/release/harfbuzz-${MASON_VERSION}.tar.bz2 \
         a7d4c722f7d663dfa51503c0c857046b86495a69
 
     mason_extract_tar_bz2

--- a/scripts/harfbuzz/1.1.2/script.sh
+++ b/scripts/harfbuzz/1.1.2/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/harfbuzz.pc
 
 function mason_load_source {
     mason_download \
-        http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-${MASON_VERSION}.tar.bz2 \
+        https://www.freedesktop.org/software/harfbuzz/release/harfbuzz-${MASON_VERSION}.tar.bz2 \
         bcd27708cca5f47c11dba7d2030f33af3ae4f0cf
 
     mason_extract_tar_bz2

--- a/scripts/harfbuzz/1.2.1/script.sh
+++ b/scripts/harfbuzz/1.2.1/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/harfbuzz.pc
 
 function mason_load_source {
     mason_download \
-        http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-${MASON_VERSION}.tar.bz2 \
+        https://www.freedesktop.org/software/harfbuzz/release/harfbuzz-${MASON_VERSION}.tar.bz2 \
         977370efcc118ddd14a9553d9a608b2619b2f786
 
     mason_extract_tar_bz2

--- a/scripts/harfbuzz/1.2.6/script.sh
+++ b/scripts/harfbuzz/1.2.6/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/harfbuzz.pc
 
 function mason_load_source {
     mason_download \
-        http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-${MASON_VERSION}.tar.bz2 \
+        https://www.freedesktop.org/software/harfbuzz/release/harfbuzz-${MASON_VERSION}.tar.bz2 \
         e8c05c3e91603b7f0de9607e66475fdaa4c02970
 
     mason_extract_tar_bz2

--- a/scripts/harfbuzz/1.3.0/script.sh
+++ b/scripts/harfbuzz/1.3.0/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/harfbuzz.pc
 
 function mason_load_source {
     mason_download \
-        http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-${MASON_VERSION}.tar.bz2 \
+        https://www.freedesktop.org/software/harfbuzz/release/harfbuzz-${MASON_VERSION}.tar.bz2 \
         f5674500c67484caa2c9936270d0a100e52f56f0
 
     mason_extract_tar_bz2

--- a/scripts/harfbuzz/1.4.2-ft/script.sh
+++ b/scripts/harfbuzz/1.4.2-ft/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/harfbuzz.pc
 
 function mason_load_source {
     mason_download \
-        http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-${MASON_VERSION/-ft/}.tar.bz2 \
+        https://www.freedesktop.org/software/harfbuzz/release/harfbuzz-${MASON_VERSION/-ft/}.tar.bz2 \
         d8b08c8d792500f414472c8a54f69b08aabb06b4
 
     mason_extract_tar_bz2

--- a/scripts/harfbuzz/1.4.2/script.sh
+++ b/scripts/harfbuzz/1.4.2/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/harfbuzz.pc
 
 function mason_load_source {
     mason_download \
-        http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-${MASON_VERSION}.tar.bz2 \
+        https://www.freedesktop.org/software/harfbuzz/release/harfbuzz-${MASON_VERSION}.tar.bz2 \
         d8b08c8d792500f414472c8a54f69b08aabb06b4
 
     mason_extract_tar_bz2

--- a/scripts/harfbuzz/1.4.4-ft/script.sh
+++ b/scripts/harfbuzz/1.4.4-ft/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/harfbuzz.pc
 
 function mason_load_source {
     mason_download \
-        http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-${MASON_VERSION/-ft/}.tar.bz2 \
+        https://www.freedesktop.org/software/harfbuzz/release/harfbuzz-${MASON_VERSION/-ft/}.tar.bz2 \
         276e4b050f8488903a1ced53fd9a303073d47f06
 
     mason_extract_tar_bz2

--- a/scripts/icu/54.1/script.sh
+++ b/scripts/icu/54.1/script.sh
@@ -9,7 +9,7 @@ MASON_LIB_FILE=lib/libicuuc.a
 
 function mason_load_source {
     mason_download \
-        http://download.icu-project.org/files/icu4c/54.1/icu4c-54_1-src.tgz \
+        https://download.icu-project.org/files/icu4c/54.1/icu4c-54_1-src.tgz \
         d0f79be346f75862ccef8fd641e429d9c129ac14
 
     mason_extract_tar_gz
@@ -19,7 +19,7 @@ function mason_load_source {
 
 function mason_compile {
     # note: -DUCONFIG_NO_BREAK_ITERATION=1 is desired by mapnik (for toTitle)
-    # http://www.icu-project.org/apiref/icu4c/uconfig_8h_source.html
+    # https://www.icu-project.org/apiref/icu4c/uconfig_8h_source.html
     export ICU_CORE_CPP_FLAGS="-DU_CHARSET_IS_UTF8=1"
     # disabled due to breakage with node-mapnik on OS X: https://github.com/mapnik/mapnik-packaging/issues/98
     # -DU_USING_ICU_NAMESPACE=0 -DU_STATIC_IMPLEMENTATION=1 -DU_TIMEZONE=0 -DUCONFIG_NO_LEGACY_CONVERSION=1 -DUCONFIG_NO_FORMATTING=1 -DUCONFIG_NO_TRANSLITERATION=1 -DUCONFIG_NO_REGULAR_EXPRESSIONS=1"

--- a/scripts/icu/55.1/script.sh
+++ b/scripts/icu/55.1/script.sh
@@ -9,7 +9,7 @@ MASON_LIB_FILE=lib/libicuuc.a
 
 function mason_load_source {
     mason_download \
-        http://download.icu-project.org/files/icu4c/55.1/icu4c-55_1-src.tgz \
+        https://download.icu-project.org/files/icu4c/55.1/icu4c-55_1-src.tgz \
         0b38bcdde97971917f0039eeeb5d070ed29e5ad7
 
     mason_extract_tar_gz
@@ -19,7 +19,7 @@ function mason_load_source {
 
 function mason_compile {
     # note: -DUCONFIG_NO_BREAK_ITERATION=1 is desired by mapnik (for toTitle)
-    # http://www.icu-project.org/apiref/icu4c/uconfig_8h_source.html
+    # https://www.icu-project.org/apiref/icu4c/uconfig_8h_source.html
     export ICU_CORE_CPP_FLAGS="-DU_CHARSET_IS_UTF8=1"
     # disabled due to breakage with node-mapnik on OS X: https://github.com/mapnik/mapnik-packaging/issues/98
     # -DU_USING_ICU_NAMESPACE=0 -DU_STATIC_IMPLEMENTATION=1 -DU_TIMEZONE=0 -DUCONFIG_NO_LEGACY_CONVERSION=1 -DUCONFIG_NO_FORMATTING=1 -DUCONFIG_NO_TRANSLITERATION=1 -DUCONFIG_NO_REGULAR_EXPRESSIONS=1"

--- a/scripts/icu/57.1/script.sh
+++ b/scripts/icu/57.1/script.sh
@@ -14,7 +14,7 @@ MASON_CROSS_BUILD=0
 
 function mason_load_source {
     mason_download \
-        http://download.icu-project.org/files/icu4c/57.1/icu4c-57_1-src.tgz \
+        https://download.icu-project.org/files/icu4c/57.1/icu4c-57_1-src.tgz \
         c40f6ec922e10a50812157eae28969c528982196
 
     mason_extract_tar_gz

--- a/scripts/icu/58.1-brkitr/script.sh
+++ b/scripts/icu/58.1-brkitr/script.sh
@@ -14,7 +14,7 @@ MASON_CROSS_BUILD=0
 
 function mason_load_source {
     mason_download \
-        http://download.icu-project.org/files/icu4c/58.1/icu4c-58_1-src.tgz \
+        https://download.icu-project.org/files/icu4c/58.1/icu4c-58_1-src.tgz \
         ad6995ba349ed79dde0f25d125a9b0bb56979420
 
     mason_extract_tar_gz

--- a/scripts/icu/58.1-min-size/script.sh
+++ b/scripts/icu/58.1-min-size/script.sh
@@ -14,7 +14,7 @@ MASON_CROSS_BUILD=0
 
 function mason_load_source {
     mason_download \
-        http://download.icu-project.org/files/icu4c/58.1/icu4c-58_1-src.tgz \
+        https://download.icu-project.org/files/icu4c/58.1/icu4c-58_1-src.tgz \
         ad6995ba349ed79dde0f25d125a9b0bb56979420
 
     mason_extract_tar_gz

--- a/scripts/icu/58.1/script.sh
+++ b/scripts/icu/58.1/script.sh
@@ -14,7 +14,7 @@ MASON_CROSS_BUILD=0
 
 function mason_load_source {
     mason_download \
-        http://download.icu-project.org/files/icu4c/58.1/icu4c-58_1-src.tgz \
+        https://download.icu-project.org/files/icu4c/58.1/icu4c-58_1-src.tgz \
         ad6995ba349ed79dde0f25d125a9b0bb56979420
 
     mason_extract_tar_gz

--- a/scripts/jpeg/v9a/script.sh
+++ b/scripts/jpeg/v9a/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=lib/libjpeg.a
 
 function mason_load_source {
     mason_download \
-        http://www.ijg.org/files/jpegsrc.v9a.tar.gz \
+        https://www.ijg.org/files/jpegsrc.v9a.tar.gz \
         fc3b1eefda3d8a193f9f92a16a1b0c9f56304b6d
 
     mason_extract_tar_gz

--- a/scripts/jpeg_turbo/1.4.0/script.sh
+++ b/scripts/jpeg_turbo/1.4.0/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=lib/libjpeg.a
 
 function mason_load_source {
     mason_download \
-        http://downloads.sourceforge.net/project/libjpeg-turbo/1.4.0/libjpeg-turbo-1.4.0.tar.gz \
+        https://downloads.sourceforge.net/project/libjpeg-turbo/1.4.0/libjpeg-turbo-1.4.0.tar.gz \
         6ce52501e0be70b15cd062efeca8fa57faf84a16
 
     mason_extract_tar_gz

--- a/scripts/jpeg_turbo/1.4.2/script.sh
+++ b/scripts/jpeg_turbo/1.4.2/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=lib/libjpeg.a
 
 function mason_load_source {
     mason_download \
-        http://downloads.sourceforge.net/project/libjpeg-turbo/${MASON_VERSION}/libjpeg-turbo-${MASON_VERSION}.tar.gz \
+        https://downloads.sourceforge.net/project/libjpeg-turbo/${MASON_VERSION}/libjpeg-turbo-${MASON_VERSION}.tar.gz \
         d4638b2261ac3c1c20a2a2e1f8e19fc1f11bf524
 
     mason_extract_tar_gz

--- a/scripts/jpeg_turbo/1.5.0/script.sh
+++ b/scripts/jpeg_turbo/1.5.0/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=lib/libjpeg.a
 
 function mason_load_source {
     mason_download \
-        http://downloads.sourceforge.net/project/libjpeg-turbo/${MASON_VERSION}/libjpeg-turbo-${MASON_VERSION}.tar.gz \
+        https://downloads.sourceforge.net/project/libjpeg-turbo/${MASON_VERSION}/libjpeg-turbo-${MASON_VERSION}.tar.gz \
         b90a76db4d0628bde8381150e355a858e3ced923
 
     mason_extract_tar_gz

--- a/scripts/jpeg_turbo/1.5.1/script.sh
+++ b/scripts/jpeg_turbo/1.5.1/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=lib/libjpeg.a
 
 function mason_load_source {
     mason_download \
-        http://downloads.sourceforge.net/project/libjpeg-turbo/${MASON_VERSION}/libjpeg-turbo-${MASON_VERSION}.tar.gz \
+        https://downloads.sourceforge.net/project/libjpeg-turbo/${MASON_VERSION}/libjpeg-turbo-${MASON_VERSION}.tar.gz \
         4038bb4242a3fc3387d5dc4e37fc2ac7fffaf5da
 
     mason_extract_tar_gz

--- a/scripts/jpeg_turbo/1.5.2/script.sh
+++ b/scripts/jpeg_turbo/1.5.2/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=lib/libjpeg.a
 
 function mason_load_source {
     mason_download \
-        http://downloads.sourceforge.net/project/libjpeg-turbo/${MASON_VERSION}/libjpeg-turbo-${MASON_VERSION}.tar.gz \
+        https://downloads.sourceforge.net/project/libjpeg-turbo/${MASON_VERSION}/libjpeg-turbo-${MASON_VERSION}.tar.gz \
         7096fcfbfd37439d6ae652379e48abe692c11d65
 
     mason_extract_tar_gz

--- a/scripts/lcov/1.12/script.sh
+++ b/scripts/lcov/1.12/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=usr/bin/lcov
 
 function mason_load_source {
     mason_download \
-        http://downloads.sourceforge.net/ltp/lcov-1.12.tar.gz \
+        https://downloads.sourceforge.net/ltp/lcov-1.12.tar.gz \
         c7470ce9d89bb9c276ef7f461e9ab5b9c9935eff
 
     mason_extract_tar_gz

--- a/scripts/libcurl/7.38.0-boringssl/script.sh
+++ b/scripts/libcurl/7.38.0-boringssl/script.sh
@@ -12,7 +12,7 @@ MASON_PWD=`pwd`
 
 function mason_load_source {
     mason_download \
-        http://curl.haxx.se/download/curl-7.38.0.tar.gz \
+        https://curl.haxx.se/download/curl-7.38.0.tar.gz \
         5463f1b9dc807e4ae8be2ef4ed57e67f677f4426
 
     mason_extract_tar_gz

--- a/scripts/libcurl/7.40.0/script.sh
+++ b/scripts/libcurl/7.40.0/script.sh
@@ -10,7 +10,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/libcurl.pc
 
 function mason_load_source {
     mason_download \
-        http://curl.haxx.se/download/curl-7.40.0.tar.gz \
+        https://curl.haxx.se/download/curl-7.40.0.tar.gz \
         c7c97e02f5fa4302f4c25c72486359f7b46f7d6d
 
     mason_extract_tar_gz

--- a/scripts/libcurl/7.45.0/script.sh
+++ b/scripts/libcurl/7.45.0/script.sh
@@ -12,7 +12,7 @@ OPENSSL_VERSION=1.0.1p
 
 function mason_load_source {
     mason_download \
-        http://curl.haxx.se/download/curl-${MASON_VERSION}.tar.gz \
+        https://curl.haxx.se/download/curl-${MASON_VERSION}.tar.gz \
         cf5b820a1ab30e49083784c46fe3ec9e6d2c84dc
 
     mason_extract_tar_gz

--- a/scripts/libcurl/7.50.2/script.sh
+++ b/scripts/libcurl/7.50.2/script.sh
@@ -12,7 +12,7 @@ OPENSSL_VERSION=1.0.2d
 
 function mason_load_source {
     mason_download \
-        http://curl.haxx.se/download/curl-${MASON_VERSION}.tar.gz \
+        https://curl.haxx.se/download/curl-${MASON_VERSION}.tar.gz \
         35d5c0d1dba88989961b3e95843c6b26a2d4fba8
 
     mason_extract_tar_gz

--- a/scripts/libjpeg-turbo/1.4.2/script.sh
+++ b/scripts/libjpeg-turbo/1.4.2/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=lib/libjpeg.a
 
 function mason_load_source {
     mason_download \
-        http://downloads.sourceforge.net/project/libjpeg-turbo/1.4.2/libjpeg-turbo-1.4.2.tar.gz \
+        https://downloads.sourceforge.net/project/libjpeg-turbo/1.4.2/libjpeg-turbo-1.4.2.tar.gz \
         d4638b2261ac3c1c20a2a2e1f8e19fc1f11bf524
 
     mason_extract_tar_gz

--- a/scripts/libpng/1.6.16/script.sh
+++ b/scripts/libpng/1.6.16/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/libpng.pc
 
 function mason_load_source {
     mason_download \
-        http://prdownloads.sourceforge.net/libpng/libpng-1.6.16.tar.gz?download \
+        https://prdownloads.sourceforge.net/libpng/libpng-1.6.16.tar.gz?download \
         b0449a7d05447842f3f19642c2104e0a57db13a8
 
     mason_extract_tar_gz

--- a/scripts/libpng/1.6.17/script.sh
+++ b/scripts/libpng/1.6.17/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/libpng.pc
 
 function mason_load_source {
     mason_download \
-        http://prdownloads.sourceforge.net/libpng/libpng-${MASON_VERSION}.tar.gz?download \
+        https://prdownloads.sourceforge.net/libpng/libpng-${MASON_VERSION}.tar.gz?download \
         ccc3b2243585a8aedf762fc72ffcc253aaed9298
 
     mason_extract_tar_gz

--- a/scripts/libpng/1.6.18/script.sh
+++ b/scripts/libpng/1.6.18/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/libpng.pc
 
 function mason_load_source {
     mason_download \
-        http://prdownloads.sourceforge.net/libpng/libpng-${MASON_VERSION}.tar.gz?download \
+        https://prdownloads.sourceforge.net/libpng/libpng-${MASON_VERSION}.tar.gz?download \
         d9ed998cee89dc6ea3427c17882b5cfe7882429a
 
     mason_extract_tar_gz

--- a/scripts/libpng/1.6.20/script.sh
+++ b/scripts/libpng/1.6.20/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/libpng.pc
 
 function mason_load_source {
     mason_download \
-        http://downloads.sourceforge.net/project/libpng/libpng16/older-releases/${MASON_VERSION}/libpng-${MASON_VERSION}.tar.gz \
+        https://downloads.sourceforge.net/project/libpng/libpng16/older-releases/${MASON_VERSION}/libpng-${MASON_VERSION}.tar.gz \
         0b5df1201ea4b63777a9c9c49ff26a45dd87890e
 
     mason_extract_tar_gz

--- a/scripts/libpng/1.6.21/script.sh
+++ b/scripts/libpng/1.6.21/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/libpng.pc
 
 function mason_load_source {
     mason_download \
-        http://downloads.sourceforge.net/project/libpng/libpng16/${MASON_VERSION}/libpng-${MASON_VERSION}.tar.gz \
+        https://downloads.sourceforge.net/project/libpng/libpng16/${MASON_VERSION}/libpng-${MASON_VERSION}.tar.gz \
         1604e875b732b08ae81e155259422f1c1407255d
 
     mason_extract_tar_gz

--- a/scripts/libpng/1.6.24/script.sh
+++ b/scripts/libpng/1.6.24/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/libpng.pc
 
 function mason_load_source {
     mason_download \
-        http://superb-sea2.dl.sourceforge.net/project/${MASON_NAME}/${MASON_NAME}16/${MASON_VERSION}/${MASON_NAME}-${MASON_VERSION}.tar.gz \
+        https://superb-sea2.dl.sourceforge.net/project/${MASON_NAME}/${MASON_NAME}16/${MASON_VERSION}/${MASON_NAME}-${MASON_VERSION}.tar.gz \
         ea724d11c25753ebad23ca0f63518b7f17c46a6a
 
     mason_extract_tar_gz

--- a/scripts/libpng/1.6.25/script.sh
+++ b/scripts/libpng/1.6.25/script.sh
@@ -12,7 +12,7 @@ ZLIB_SHARED_VERSION=1.2.8
 
 function mason_load_source {
     mason_download \
-        http://downloads.sourceforge.net/project/libpng/libpng16/older-releases/${MASON_VERSION}/libpng-${MASON_VERSION}.tar.gz \
+        https://downloads.sourceforge.net/project/libpng/libpng16/older-releases/${MASON_VERSION}/libpng-${MASON_VERSION}.tar.gz \
         a88b710714a8e27e5e5aa52de28076860fc7748c
 
     mason_extract_tar_gz

--- a/scripts/libpng/1.6.28/script.sh
+++ b/scripts/libpng/1.6.28/script.sh
@@ -12,7 +12,7 @@ ZLIB_SHARED_VERSION=1.2.8
 
 function mason_load_source {
     mason_download \
-        http://downloads.sourceforge.net/project/libpng/libpng16/older-releases/${MASON_VERSION}/libpng-${MASON_VERSION}.tar.gz \
+        https://downloads.sourceforge.net/project/libpng/libpng16/older-releases/${MASON_VERSION}/libpng-${MASON_VERSION}.tar.gz \
         a424121a192420e2fbbea20db1d13dca0c7c99ca
 
     mason_extract_tar_gz

--- a/scripts/libpng/1.6.32/script.sh
+++ b/scripts/libpng/1.6.32/script.sh
@@ -12,7 +12,7 @@ ZLIB_SHARED_VERSION=1.2.8
 
 function mason_load_source {
     mason_download \
-        http://downloads.sourceforge.net/project/libpng/libpng16/${MASON_VERSION}/libpng-${MASON_VERSION}.tar.gz \
+        https://downloads.sourceforge.net/project/libpng/libpng16/${MASON_VERSION}/libpng-${MASON_VERSION}.tar.gz \
         752b19285db1aab9d0b8f5ef2312390734f71e70
 
     mason_extract_tar_gz

--- a/scripts/libpq/10.3/script.sh
+++ b/scripts/libpq/10.3/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/libpq.pc
 
 function mason_load_source {
     mason_download \
-        http://ftp.postgresql.org/pub/source/v${MASON_VERSION}/postgresql-${MASON_VERSION}.tar.bz2 \
+        https://ftp.postgresql.org/pub/source/v${MASON_VERSION}/postgresql-${MASON_VERSION}.tar.bz2 \
         e1590a4b2167dcdf164eb887cf83e7da9e155771
 
     mason_extract_tar_bz2

--- a/scripts/libpq/9.4.0/script.sh
+++ b/scripts/libpq/9.4.0/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/libpq.pc
 
 function mason_load_source {
     mason_download \
-        http://ftp.postgresql.org/pub/source/v9.4.0/postgresql-9.4.0.tar.bz2 \
+        https://ftp.postgresql.org/pub/source/v9.4.0/postgresql-9.4.0.tar.bz2 \
         d1cf3f96059532a99445e34a15cf0ef67f8da9c7
 
     mason_extract_tar_bz2

--- a/scripts/libpq/9.4.1/script.sh
+++ b/scripts/libpq/9.4.1/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/libpq.pc
 
 function mason_load_source {
     mason_download \
-        http://ftp.postgresql.org/pub/source/v${MASON_VERSION}/postgresql-${MASON_VERSION}.tar.bz2 \
+        https://ftp.postgresql.org/pub/source/v${MASON_VERSION}/postgresql-${MASON_VERSION}.tar.bz2 \
         1fcc75dccdb9ffd3f30e723828cbfce00c9b13fd
 
     mason_extract_tar_bz2

--- a/scripts/libpq/9.5.2/script.sh
+++ b/scripts/libpq/9.5.2/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/libpq.pc
 
 function mason_load_source {
     mason_download \
-        http://ftp.postgresql.org/pub/source/v${MASON_VERSION}/postgresql-${MASON_VERSION}.tar.bz2 \
+        https://ftp.postgresql.org/pub/source/v${MASON_VERSION}/postgresql-${MASON_VERSION}.tar.bz2 \
         9c7bd5c1c601075ff6d5ea7615f9461d5b1f4c88
 
     mason_extract_tar_bz2

--- a/scripts/libpq/9.6.1/script.sh
+++ b/scripts/libpq/9.6.1/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/libpq.pc
 
 function mason_load_source {
     mason_download \
-        http://ftp.postgresql.org/pub/source/v${MASON_VERSION}/postgresql-${MASON_VERSION}.tar.bz2 \
+        https://ftp.postgresql.org/pub/source/v${MASON_VERSION}/postgresql-${MASON_VERSION}.tar.bz2 \
         6aef3fb521aaf987a9363a314ff7d5539b6601cd
 
     mason_extract_tar_bz2

--- a/scripts/libpq/9.6.2/script.sh
+++ b/scripts/libpq/9.6.2/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/libpq.pc
 
 function mason_load_source {
     mason_download \
-        http://ftp.postgresql.org/pub/source/v${MASON_VERSION}/postgresql-${MASON_VERSION}.tar.bz2 \
+        https://ftp.postgresql.org/pub/source/v${MASON_VERSION}/postgresql-${MASON_VERSION}.tar.bz2 \
         183f73527051430934a20bf08646b16373cddcca
 
     mason_extract_tar_bz2

--- a/scripts/libpq/9.6.5/script.sh
+++ b/scripts/libpq/9.6.5/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/libpq.pc
 
 function mason_load_source {
     mason_download \
-        http://ftp.postgresql.org/pub/source/v${MASON_VERSION}/postgresql-${MASON_VERSION}.tar.bz2 \
+        https://ftp.postgresql.org/pub/source/v${MASON_VERSION}/postgresql-${MASON_VERSION}.tar.bz2 \
         de4007bbb8a5869cc3f193ae34b2fbd9e4b876c4
 
     mason_extract_tar_bz2

--- a/scripts/libshp2/1.3.0/script.sh
+++ b/scripts/libshp2/1.3.0/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=lib/libshp.a
 
 function mason_load_source {
     mason_download \
-        http://download.osgeo.org/shapelib/shapelib-${MASON_VERSION}.tar.gz \
+        https://download.osgeo.org/shapelib/shapelib-${MASON_VERSION}.tar.gz \
         4b3cc10fd5ac228d749ab0a19d485b475b7d5fb5
 
     mason_extract_tar_gz

--- a/scripts/libtiff/4.0.4beta/script.sh
+++ b/scripts/libtiff/4.0.4beta/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/libtiff-4.pc
 
 function mason_load_source {
     mason_download \
-        http://download.osgeo.org/libtiff/tiff-${MASON_VERSION}.tar.gz \
+        https://download.osgeo.org/libtiff/tiff-${MASON_VERSION}.tar.gz \
         7bbd91b09cef1a4c29d3cccb7e656ee32587e5ef
 
     mason_extract_tar_gz

--- a/scripts/libtiff/4.0.6/script.sh
+++ b/scripts/libtiff/4.0.6/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/libtiff-4.pc
 
 function mason_load_source {
     mason_download \
-        http://download.osgeo.org/libtiff/tiff-${MASON_VERSION}.tar.gz \
+        https://download.osgeo.org/libtiff/tiff-${MASON_VERSION}.tar.gz \
         a6c275bb0a444f9b43f5cd3f15e0400599dc5ffc
 
     mason_extract_tar_gz

--- a/scripts/libtiff/4.0.7/script.sh
+++ b/scripts/libtiff/4.0.7/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/libtiff-4.pc
 
 function mason_load_source {
     mason_download \
-        http://download.osgeo.org/libtiff/tiff-${MASON_VERSION}.tar.gz \
+        https://download.osgeo.org/libtiff/tiff-${MASON_VERSION}.tar.gz \
         3ef673aa786929fea2f997439e33473777465927
 
     mason_extract_tar_gz

--- a/scripts/libtiff/4.0.8/script.sh
+++ b/scripts/libtiff/4.0.8/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/libtiff-4.pc
 
 function mason_load_source {
     mason_download \
-        http://download.osgeo.org/libtiff/tiff-${MASON_VERSION}.tar.gz \
+        https://download.osgeo.org/libtiff/tiff-${MASON_VERSION}.tar.gz \
         eb172e79e887fc3b9e4b3e9639c49182ffe563a0
 
     mason_extract_tar_gz

--- a/scripts/libzip/0.11.2/script.sh
+++ b/scripts/libzip/0.11.2/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/libzip.pc
 
 function mason_load_source {
     mason_download \
-        http://www.nih.at/libzip/libzip-0.11.2.tar.gz \
+        https://www.nih.at/libzip/libzip-0.11.2.tar.gz \
         5e2407b231390e1cb8234541e89693ae57487170
 
     mason_extract_tar_gz

--- a/scripts/libzip/1.0.1/script.sh
+++ b/scripts/libzip/1.0.1/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/libzip.pc
 
 function mason_load_source {
     mason_download \
-        http://www.nih.at/libzip/libzip-${MASON_VERSION}.tar.gz \
+        https://www.nih.at/libzip/libzip-${MASON_VERSION}.tar.gz \
         b7761ee2ef581979df32f42637042f5663d766bf
 
     mason_extract_tar_gz

--- a/scripts/libzip/1.1.3/script.sh
+++ b/scripts/libzip/1.1.3/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/libzip.pc
 
 function mason_load_source {
     mason_download \
-        http://www.nih.at/libzip/libzip-${MASON_VERSION}.tar.gz \
+        https://www.nih.at/libzip/libzip-${MASON_VERSION}.tar.gz \
         4bc18317d0607d5a24b618a6a5c1c229dade48e8
 
     mason_extract_tar_gz

--- a/scripts/llnode/1.4.1/script.sh
+++ b/scripts/llnode/1.4.1/script.sh
@@ -26,7 +26,7 @@ function mason_compile {
     git clone --depth 1 https://chromium.googlesource.com/external/gyp.git tools/gyp
     # ../src/llv8.cc:256:43: error: expected ')'
      #snprintf(tmp, sizeof(tmp), " fn=0x%016" PRIx64, fn.raw());
-    # need to define STDC macros since libc++ adheres to spec: http://en.cppreference.com/w/cpp/types/integer
+    # need to define STDC macros since libc++ adheres to spec: https://en.cppreference.com/w/cpp/types/integer
     export CXXFLAGS="-stdlib=libc++ ${CXXFLAGS} -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS"
     export LDFLAGS="-stdlib=libc++ ${LDFLAGS}"
     # per the llvm package, on linux we statically link libc++ for full portability

--- a/scripts/llnode/1.7.1/script.sh
+++ b/scripts/llnode/1.7.1/script.sh
@@ -31,7 +31,7 @@ function mason_prepare_compile {
 function mason_compile {
     # ../src/llv8.cc:256:43: error: expected ')'
      #snprintf(tmp, sizeof(tmp), " fn=0x%016" PRIx64, fn.raw());
-    # need to define STDC macros since libc++ adheres to spec: http://en.cppreference.com/w/cpp/types/integer
+    # need to define STDC macros since libc++ adheres to spec: https://en.cppreference.com/w/cpp/types/integer
     export CXXFLAGS="-stdlib=libc++ ${CXXFLAGS} -I${LLVM_PATH}/include -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS"
     export LDFLAGS="-stdlib=libc++ ${LDFLAGS}"
     export CXX="${LLVM_PATH}/bin/clang++"

--- a/scripts/lua/5.1.0/script.sh
+++ b/scripts/lua/5.1.0/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=lib/liblua.a
 
 function mason_load_source {
     mason_download \
-        http://www.lua.org/ftp/lua-5.1.tar.gz \
+        https://www.lua.org/ftp/lua-5.1.tar.gz \
         3f8d5a84a38423829765512118bbf26c500b0c06
 
     mason_extract_tar_gz

--- a/scripts/lua/5.2.4/script.sh
+++ b/scripts/lua/5.2.4/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=lib/liblua.a
 
 function mason_load_source {
     mason_download \
-        http://www.lua.org/ftp/lua-${MASON_VERSION}.tar.gz \
+        https://www.lua.org/ftp/lua-${MASON_VERSION}.tar.gz \
         6dd4526fdae5a7f76e44febf4d3066614920c43e
 
     mason_extract_tar_gz

--- a/scripts/lua/5.3.0/script.sh
+++ b/scripts/lua/5.3.0/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=lib/liblua.a
 
 function mason_load_source {
     mason_download \
-        http://www.lua.org/ftp/lua-5.3.0.tar.gz \
+        https://www.lua.org/ftp/lua-5.3.0.tar.gz \
         44ffcfd0f38445c76e5d58777089f392bed175c3
 
     mason_extract_tar_gz

--- a/scripts/mapnik/3.0.13-1/script.sh
+++ b/scripts/mapnik/3.0.13-1/script.sh
@@ -17,7 +17,7 @@ function mason_load_source {
 
     #mkdir -p $(dirname ${MASON_BUILD_PATH})
     #if [[ ! -d ${MASON_BUILD_PATH} ]]; then
-    #    git clone -b 3.0.x-mason-upgrades --single-branch http://github.com/mapnik/mapnik ${MASON_BUILD_PATH}
+    #    git clone -b 3.0.x-mason-upgrades --single-branch https://github.com/mapnik/mapnik ${MASON_BUILD_PATH}
     #    (cd ${MASON_BUILD_PATH} && git submodule update --init deps/mapbox/variant/)
     #fi
 }

--- a/scripts/mapnik/3.0.13-2/script.sh
+++ b/scripts/mapnik/3.0.13-2/script.sh
@@ -17,7 +17,7 @@ function mason_load_source {
 
     #mkdir -p $(dirname ${MASON_BUILD_PATH})
     #if [[ ! -d ${MASON_BUILD_PATH} ]]; then
-    #    git clone -b 3.0.x-mason-upgrades --single-branch http://github.com/mapnik/mapnik ${MASON_BUILD_PATH}
+    #    git clone -b 3.0.x-mason-upgrades --single-branch https://github.com/mapnik/mapnik ${MASON_BUILD_PATH}
     #    (cd ${MASON_BUILD_PATH} && git submodule update --init deps/mapbox/variant/)
     #fi
 }

--- a/scripts/mapnik/3.0.13-3/script.sh
+++ b/scripts/mapnik/3.0.13-3/script.sh
@@ -17,7 +17,7 @@ function mason_load_source {
 
     #mkdir -p $(dirname ${MASON_BUILD_PATH})
     #if [[ ! -d ${MASON_BUILD_PATH} ]]; then
-    #    git clone -b 3.0.x-mason-upgrades --single-branch http://github.com/mapnik/mapnik ${MASON_BUILD_PATH}
+    #    git clone -b 3.0.x-mason-upgrades --single-branch https://github.com/mapnik/mapnik ${MASON_BUILD_PATH}
     #    (cd ${MASON_BUILD_PATH} && git submodule update --init deps/mapbox/variant/)
     #fi
 }

--- a/scripts/mapnik/3.0.13/script.sh
+++ b/scripts/mapnik/3.0.13/script.sh
@@ -17,7 +17,7 @@ function mason_load_source {
 
     #mkdir -p $(dirname ${MASON_BUILD_PATH})
     #if [[ ! -d ${MASON_BUILD_PATH} ]]; then
-    #    git clone -b 3.0.x-mason-upgrades --single-branch http://github.com/mapnik/mapnik ${MASON_BUILD_PATH}
+    #    git clone -b 3.0.x-mason-upgrades --single-branch https://github.com/mapnik/mapnik ${MASON_BUILD_PATH}
     #    (cd ${MASON_BUILD_PATH} && git submodule update --init deps/mapbox/variant/)
     #fi
 }

--- a/scripts/mapnik/434511c/script.sh
+++ b/scripts/mapnik/434511c/script.sh
@@ -9,7 +9,7 @@ MASON_LIB_FILE=lib/libmapnik.${MASON_DYNLIB_SUFFIX}
 function mason_load_source {
     export MASON_BUILD_PATH=${MASON_ROOT}/.build/mapnik-v${MASON_VERSION}
      if [[ ! -d ${MASON_BUILD_PATH} ]]; then
-        git clone http://github.com/mapnik/mapnik ${MASON_BUILD_PATH}
+        git clone https://github.com/mapnik/mapnik ${MASON_BUILD_PATH}
         (cd ${MASON_BUILD_PATH} && git checkout ${MASON_VERSION} && git submodule update --init)
     fi
 }

--- a/scripts/mapnik/98c26bc/script.sh
+++ b/scripts/mapnik/98c26bc/script.sh
@@ -9,7 +9,7 @@ MASON_LIB_FILE=lib/libmapnik.${MASON_DYNLIB_SUFFIX}
 function mason_load_source {
     export MASON_BUILD_PATH=${MASON_ROOT}/.build/mapnik-v${MASON_VERSION}
      if [[ ! -d ${MASON_BUILD_PATH} ]]; then
-        git clone http://github.com/mapnik/mapnik ${MASON_BUILD_PATH}
+        git clone https://github.com/mapnik/mapnik ${MASON_BUILD_PATH}
         (cd ${MASON_BUILD_PATH} && git checkout ${MASON_VERSION} && git submodule update --init)
     fi
 }

--- a/scripts/mapnik/a2f5969/script.sh
+++ b/scripts/mapnik/a2f5969/script.sh
@@ -9,7 +9,7 @@ MASON_LIB_FILE=lib/libmapnik.${MASON_DYNLIB_SUFFIX}
 function mason_load_source {
     export MASON_BUILD_PATH=${MASON_ROOT}/.build/mapnik-v${MASON_VERSION}
      if [[ ! -d ${MASON_BUILD_PATH} ]]; then
-        git clone http://github.com/mapnik/mapnik ${MASON_BUILD_PATH}
+        git clone https://github.com/mapnik/mapnik ${MASON_BUILD_PATH}
         (cd ${MASON_BUILD_PATH} && git checkout ${MASON_VERSION} && git submodule update --init)
     fi
 }

--- a/scripts/mapnik/da69fdf66/script.sh
+++ b/scripts/mapnik/da69fdf66/script.sh
@@ -9,7 +9,7 @@ MASON_LIB_FILE=lib/libmapnik.${MASON_DYNLIB_SUFFIX}
 function mason_load_source {
     export MASON_BUILD_PATH=${MASON_ROOT}/.build/mapnik-v${MASON_VERSION}
      if [[ ! -d ${MASON_BUILD_PATH} ]]; then
-        git clone http://github.com/mapnik/mapnik ${MASON_BUILD_PATH}
+        git clone https://github.com/mapnik/mapnik ${MASON_BUILD_PATH}
         (cd ${MASON_BUILD_PATH} && git checkout ${MASON_VERSION} && git submodule update --init)
     fi
 }

--- a/scripts/mapnik/df0bbe4/script.sh
+++ b/scripts/mapnik/df0bbe4/script.sh
@@ -9,7 +9,7 @@ MASON_LIB_FILE=lib/libmapnik.${MASON_DYNLIB_SUFFIX}
 function mason_load_source {
     export MASON_BUILD_PATH=${MASON_ROOT}/.build/mapnik-v${MASON_VERSION}
      if [[ ! -d ${MASON_BUILD_PATH} ]]; then
-        git clone http://github.com/mapnik/mapnik ${MASON_BUILD_PATH}
+        git clone https://github.com/mapnik/mapnik ${MASON_BUILD_PATH}
         (cd ${MASON_BUILD_PATH} && git checkout ${MASON_VERSION} && git submodule update --init)
     fi
 }

--- a/scripts/mapnik/f02a25901/script.sh
+++ b/scripts/mapnik/f02a25901/script.sh
@@ -9,7 +9,7 @@ MASON_LIB_FILE=lib/libmapnik.${MASON_DYNLIB_SUFFIX}
 function mason_load_source {
     export MASON_BUILD_PATH=${MASON_ROOT}/.build/mapnik-v${MASON_VERSION}
      if [[ ! -d ${MASON_BUILD_PATH} ]]; then
-        git clone http://github.com/mapnik/mapnik ${MASON_BUILD_PATH}
+        git clone https://github.com/mapnik/mapnik ${MASON_BUILD_PATH}
         (cd ${MASON_BUILD_PATH} && git checkout ${MASON_VERSION} && git submodule update --init)
     fi
 }

--- a/scripts/nasm/2.11.06/script.sh
+++ b/scripts/nasm/2.11.06/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=bin/nasm
 
 function mason_load_source {
     mason_download \
-        http://www.nasm.us/pub/nasm/releasebuilds/${MASON_VERSION}/${MASON_NAME}-${MASON_VERSION}.tar.bz2 \
+        https://www.nasm.us/pub/nasm/releasebuilds/${MASON_VERSION}/${MASON_NAME}-${MASON_VERSION}.tar.bz2 \
         9602eca86270d4df37f53ae4de2342073ad4adc7
 
     mason_extract_tar_bz2

--- a/scripts/nsis/3.01/script.sh
+++ b/scripts/nsis/3.01/script.sh
@@ -18,7 +18,7 @@ function mason_load_source {
 
 function mason_compile {
     if [ ! -f scons-local-2.5.1.tar.gz ]; then
-        wget http://prdownloads.sourceforge.net/scons/scons-local-2.5.1.tar.gz
+        wget https://prdownloads.sourceforge.net/scons/scons-local-2.5.1.tar.gz
         tar xvf scons-local-2.5.1.tar.gz
     fi
     perl -i -p -e "s/'__attribute__\(\(__stdcall__\)\)'/'\"__attribute__\(\(__stdcall__\)\)\"'/g" SCons/Config/gnu

--- a/scripts/openfst/1.6.3/script.sh
+++ b/scripts/openfst/1.6.3/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=lib/libfst.a
 
 function mason_load_source {
     mason_download \
-        http://www.openfst.org/twiki/pub/FST/FstDownload/${MASON_NAME}-${MASON_VERSION}.tar.gz \
+        https://www.openfst.org/twiki/pub/FST/FstDownload/${MASON_NAME}-${MASON_VERSION}.tar.gz \
         9e144c56ea477038d14583376b6414170f0e1b1d
 
     mason_extract_tar_gz

--- a/scripts/parallel/20160422/script.sh
+++ b/scripts/parallel/20160422/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=bin/parallel
 
 function mason_load_source {
     mason_download \
-        http://ftp.gnu.org/gnu/${MASON_NAME}/${MASON_NAME}-${MASON_VERSION}.tar.bz2 \
+        https://ftp.gnu.org/gnu/${MASON_NAME}/${MASON_NAME}-${MASON_VERSION}.tar.bz2 \
         032c35aaecc65aa1298b33c48f0a4418041771e4
 
     mason_extract_tar_bz2

--- a/scripts/pixman/0.32.6/script.sh
+++ b/scripts/pixman/0.32.6/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/pixman-1.pc
 
 function mason_load_source {
     mason_download \
-        http://cairographics.org/releases/pixman-${MASON_VERSION}.tar.gz \
+        https://cairographics.org/releases/pixman-${MASON_VERSION}.tar.gz \
         ef6a79a704290fa28838d02faad3914fe9cbc895
 
     mason_extract_tar_gz

--- a/scripts/pixman/0.34.0/script.sh
+++ b/scripts/pixman/0.34.0/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/pixman-1.pc
 
 function mason_load_source {
     mason_download \
-        http://cairographics.org/releases/pixman-${MASON_VERSION}.tar.gz \
+        https://cairographics.org/releases/pixman-${MASON_VERSION}.tar.gz \
         022e9e5856f4c5a8c9bdea3996c6b199683fce78
 
     mason_extract_tar_gz

--- a/scripts/postgis/2.2.2/script.sh
+++ b/scripts/postgis/2.2.2/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=bin/shp2pgsql
 
 function mason_load_source {
     mason_download \
-        http://download.osgeo.org/postgis/source/postgis-${MASON_VERSION}.tar.gz \
+        https://download.osgeo.org/postgis/source/postgis-${MASON_VERSION}.tar.gz \
         e3a740fc6d9af5d567346f2729ee86af2b6da88c
 
     mason_extract_tar_gz

--- a/scripts/postgis/2.3.2-1/script.sh
+++ b/scripts/postgis/2.3.2-1/script.sh
@@ -9,7 +9,7 @@ MASON_LIB_FILE=bin/shp2pgsql
 
 function mason_load_source {
     mason_download \
-        http://download.osgeo.org/postgis/source/postgis-${MASON_VERSION2}.tar.gz \
+        https://download.osgeo.org/postgis/source/postgis-${MASON_VERSION2}.tar.gz \
         1afe92b14c9329f5ce5cc6a5dbe42575449d508e
 
     mason_extract_tar_gz

--- a/scripts/postgis/2.3.2/script.sh
+++ b/scripts/postgis/2.3.2/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=bin/shp2pgsql
 
 function mason_load_source {
     mason_download \
-        http://download.osgeo.org/postgis/source/postgis-${MASON_VERSION}.tar.gz \
+        https://download.osgeo.org/postgis/source/postgis-${MASON_VERSION}.tar.gz \
         1afe92b14c9329f5ce5cc6a5dbe42575449d508e
 
     mason_extract_tar_gz

--- a/scripts/postgis/2.4.0/script.sh
+++ b/scripts/postgis/2.4.0/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=bin/shp2pgsql
 
 function mason_load_source {
     mason_download \
-        http://download.osgeo.org/postgis/source/postgis-${MASON_VERSION}.tar.gz \
+        https://download.osgeo.org/postgis/source/postgis-${MASON_VERSION}.tar.gz \
         70363fffe2eedfcd6fd24908090f66abc2acb9a5
 
     mason_extract_tar_gz

--- a/scripts/postgis/2.4.1/script.sh
+++ b/scripts/postgis/2.4.1/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=bin/shp2pgsql
 
 function mason_load_source {
     mason_download \
-        http://download.osgeo.org/postgis/source/postgis-${MASON_VERSION}.tar.gz \
+        https://download.osgeo.org/postgis/source/postgis-${MASON_VERSION}.tar.gz \
         2c4bcef6872fe09604bfd10655c136a4e96a528b
 
     mason_extract_tar_gz

--- a/scripts/postgis/2.5.2/script.sh
+++ b/scripts/postgis/2.5.2/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=bin/shp2pgsql
 
 function mason_load_source {
     mason_download \
-        http://download.osgeo.org/postgis/source/postgis-${MASON_VERSION}.tar.gz \
+        https://download.osgeo.org/postgis/source/postgis-${MASON_VERSION}.tar.gz \
         e2e23b177f889a8f00c67737ac80180abed0f83d
 
     mason_extract_tar_gz

--- a/scripts/postgres/10.3/script.sh
+++ b/scripts/postgres/10.3/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/libpq.pc
 
 function mason_load_source {
     mason_download \
-        http://ftp.postgresql.org/pub/source/v${MASON_VERSION}/postgresql-${MASON_VERSION}.tar.bz2 \
+        https://ftp.postgresql.org/pub/source/v${MASON_VERSION}/postgresql-${MASON_VERSION}.tar.bz2 \
         e1590a4b2167dcdf164eb887cf83e7da9e155771
 
     mason_extract_tar_bz2

--- a/scripts/postgres/9.5.2/script.sh
+++ b/scripts/postgres/9.5.2/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=bin/psql
 
 function mason_load_source {
     mason_download \
-        http://ftp.postgresql.org/pub/source/v${MASON_VERSION}/postgresql-${MASON_VERSION}.tar.bz2 \
+        https://ftp.postgresql.org/pub/source/v${MASON_VERSION}/postgresql-${MASON_VERSION}.tar.bz2 \
         9c7bd5c1c601075ff6d5ea7615f9461d5b1f4c88
 
     mason_extract_tar_bz2

--- a/scripts/postgres/9.6.1/script.sh
+++ b/scripts/postgres/9.6.1/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=bin/psql
 
 function mason_load_source {
     mason_download \
-        http://ftp.postgresql.org/pub/source/v${MASON_VERSION}/postgresql-${MASON_VERSION}.tar.bz2 \
+        https://ftp.postgresql.org/pub/source/v${MASON_VERSION}/postgresql-${MASON_VERSION}.tar.bz2 \
         6aef3fb521aaf987a9363a314ff7d5539b6601cd
 
     mason_extract_tar_bz2

--- a/scripts/postgres/9.6.2-1/script.sh
+++ b/scripts/postgres/9.6.2-1/script.sh
@@ -10,7 +10,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/libpq.pc
 
 function mason_load_source {
     mason_download \
-        http://ftp.postgresql.org/pub/source/v${MASON_VERSION2}/postgresql-${MASON_VERSION2}.tar.bz2 \
+        https://ftp.postgresql.org/pub/source/v${MASON_VERSION2}/postgresql-${MASON_VERSION2}.tar.bz2 \
         183f73527051430934a20bf08646b16373cddcca
 
     mason_extract_tar_bz2

--- a/scripts/postgres/9.6.2/script.sh
+++ b/scripts/postgres/9.6.2/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/libpq.pc
 
 function mason_load_source {
     mason_download \
-        http://ftp.postgresql.org/pub/source/v${MASON_VERSION}/postgresql-${MASON_VERSION}.tar.bz2 \
+        https://ftp.postgresql.org/pub/source/v${MASON_VERSION}/postgresql-${MASON_VERSION}.tar.bz2 \
         183f73527051430934a20bf08646b16373cddcca
 
     mason_extract_tar_bz2

--- a/scripts/postgres/9.6.5/script.sh
+++ b/scripts/postgres/9.6.5/script.sh
@@ -10,7 +10,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/libpq.pc
 
 function mason_load_source {
     mason_download \
-        http://ftp.postgresql.org/pub/source/v${MASON_VERSION2}/postgresql-${MASON_VERSION2}.tar.bz2 \
+        https://ftp.postgresql.org/pub/source/v${MASON_VERSION2}/postgresql-${MASON_VERSION2}.tar.bz2 \
         de4007bbb8a5869cc3f193ae34b2fbd9e4b876c4
 
     mason_extract_tar_bz2

--- a/scripts/proj/4.8.0/script.sh
+++ b/scripts/proj/4.8.0/script.sh
@@ -9,7 +9,7 @@ MASON_LIB_FILE=lib/libproj.a
 
 function mason_load_source {
     mason_download \
-        http://download.osgeo.org/proj/proj-${MASON_VERSION}.tar.gz \
+        https://download.osgeo.org/proj/proj-${MASON_VERSION}.tar.gz \
         531953338fd3167670cafb44ca59bd58eaa8712d
 
     mason_extract_tar_gz
@@ -18,7 +18,7 @@ function mason_load_source {
 }
 
 function mason_compile {
-    curl --retry 3 -f -# -L http://download.osgeo.org/proj/proj-datumgrid-1.5.zip -o proj-datumgrid-1.5.zip
+    curl --retry 3 -f -# -L https://download.osgeo.org/proj/proj-datumgrid-1.5.zip -o proj-datumgrid-1.5.zip
     cd nad
     unzip -o ../proj-datumgrid-1.5.zip
     cd ../

--- a/scripts/proj/4.9.2/script.sh
+++ b/scripts/proj/4.9.2/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=lib/libproj.a
 
 function mason_load_source {
     mason_download \
-        http://download.osgeo.org/proj/proj-${MASON_VERSION}.tar.gz \
+        https://download.osgeo.org/proj/proj-${MASON_VERSION}.tar.gz \
         d9d35af05af0d43464c280d14e24bf3743494daf
 
     mason_extract_tar_gz
@@ -17,7 +17,7 @@ function mason_load_source {
 }
 
 function mason_compile {
-    curl --retry 3 -f -# -L http://download.osgeo.org/proj/proj-datumgrid-1.5.zip -o proj-datumgrid-1.5.zip
+    curl --retry 3 -f -# -L https://download.osgeo.org/proj/proj-datumgrid-1.5.zip -o proj-datumgrid-1.5.zip
     cd nad
     unzip -o ../proj-datumgrid-1.5.zip
     cd ../

--- a/scripts/proj/4.9.3/script.sh
+++ b/scripts/proj/4.9.3/script.sh
@@ -9,7 +9,7 @@ GRID_VERSION="1.6"
 
 function mason_load_source {
     mason_download \
-        http://download.osgeo.org/proj/proj-${MASON_VERSION}.tar.gz \
+        https://download.osgeo.org/proj/proj-${MASON_VERSION}.tar.gz \
         e3426c86eb2b834de78bf6535eff60d2ff521120
 
     mason_extract_tar_gz
@@ -18,7 +18,7 @@ function mason_load_source {
 }
 
 function mason_compile {
-    curl --retry 3 -f -# -L http://download.osgeo.org/proj/proj-datumgrid-${GRID_VERSION}.zip -o proj-datumgrid-${GRID_VERSION}.zip
+    curl --retry 3 -f -# -L https://download.osgeo.org/proj/proj-datumgrid-${GRID_VERSION}.zip -o proj-datumgrid-${GRID_VERSION}.zip
     cd nad
     unzip -o ../proj-datumgrid-${GRID_VERSION}.zip
     cd ../

--- a/scripts/ragel/6.9/script.sh
+++ b/scripts/ragel/6.9/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=bin/ragel
 
 function mason_load_source {
     mason_download \
-        http://www.colm.net/files/ragel/ragel-${MASON_VERSION}.tar.gz \
+        https://www.colm.net/files/ragel/ragel-${MASON_VERSION}.tar.gz \
         adf45ba5bb04359e6a0f8d5a98bfc10e6388bf21
 
     mason_extract_tar_gz

--- a/scripts/redis/3.0.7/script.sh
+++ b/scripts/redis/3.0.7/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=bin/redis-server
 
 function mason_load_source {
     mason_download \
-        http://download.redis.io/releases/redis-${MASON_VERSION}.tar.gz \
+        https://download.redis.io/releases/redis-${MASON_VERSION}.tar.gz \
         e654c84603529c58ef671fa1a50ea84e758316aa
 
     mason_extract_tar_gz

--- a/scripts/redis/3.2.9-configurable-malloc/script.sh
+++ b/scripts/redis/3.2.9-configurable-malloc/script.sh
@@ -9,7 +9,7 @@ MASON_LIB_FILE=bin/redis-server
 
 function mason_load_source {
     mason_download \
-        http://download.redis.io/releases/redis-${RAW_VERSION}.tar.gz \
+        https://download.redis.io/releases/redis-${RAW_VERSION}.tar.gz \
         6b2cc5a8223d235d1d2673fa8f806baf1847baa9
 
     mason_extract_tar_gz

--- a/scripts/redis/3.2.9/script.sh
+++ b/scripts/redis/3.2.9/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=bin/redis-server
 
 function mason_load_source {
     mason_download \
-        http://download.redis.io/releases/redis-${MASON_VERSION}.tar.gz \
+        https://download.redis.io/releases/redis-${MASON_VERSION}.tar.gz \
         6b2cc5a8223d235d1d2673fa8f806baf1847baa9
 
     mason_extract_tar_gz

--- a/scripts/slang/2.3.1/script.sh
+++ b/scripts/slang/2.3.1/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=lib/libslang.a
 
 function mason_load_source {
     mason_download \
-        http://www.jedsoft.org/releases/slang/slang-${MASON_VERSION}.tar.bz2 \
+        https://www.jedsoft.org/releases/slang/slang-${MASON_VERSION}.tar.bz2 \
         8617d4745d1be3e086adb2fb8ca349a64711afc7
 
     mason_extract_tar_bz2

--- a/scripts/sqlite/3.8.8.1/script.sh
+++ b/scripts/sqlite/3.8.8.1/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/sqlite3.pc
 
 function mason_load_source {
     mason_download \
-        http://www.sqlite.org/2015/sqlite-autoconf-3080801.tar.gz \
+        https://www.sqlite.org/2015/sqlite-autoconf-3080801.tar.gz \
         24012945241c0b55774b8bad2679912e14703a24
 
     mason_extract_tar_gz

--- a/scripts/sqlite/3.8.8.3/script.sh
+++ b/scripts/sqlite/3.8.8.3/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/sqlite3.pc
 
 function mason_load_source {
     mason_download \
-        http://sqlite.org/2015/sqlite-autoconf-3080803.tar.gz \
+        https://sqlite.org/2015/sqlite-autoconf-3080803.tar.gz \
         55d0c095e5bf76ed7b450265261b367228bbd0ba
 
     mason_extract_tar_gz

--- a/scripts/tbb/43_20150316/script.sh
+++ b/scripts/tbb/43_20150316/script.sh
@@ -33,7 +33,7 @@ function mason_compile {
     # libtbb does not support -fvisibility=hidden
     CXXFLAGS="${CXXFLAGS//-fvisibility=hidden}"
     #patch -N -p1 <  ${PATCHES}/tbb_compiler_override.diff || true
-    # note: static linking not allowed: http://www.threadingbuildingblocks.org/faq/11
+    # note: static linking not allowed: https://www.threadingbuildingblocks.org/faq/11
     if [[ $(uname -s) == 'Darwin' ]]; then
       make -j${MASON_CONCURRENCY} tbb_build_prefix=BUILDPREFIX arch=intel64 cpp0x=1 stdlib=libc++ compiler=clang tbb_build_dir=$(pwd)/build
     else

--- a/scripts/valgrind/3.12.0/script.sh
+++ b/scripts/valgrind/3.12.0/script.sh
@@ -9,7 +9,7 @@ MASON_IGNORE_OSX_SDK=true
 
 function mason_load_source {
     mason_download \
-        http://valgrind.org/downloads/valgrind-${MASON_VERSION}.tar.bz2 \
+        https://valgrind.org/downloads/valgrind-${MASON_VERSION}.tar.bz2 \
         9d10673077704b02513d216672ecb64d3719f537
 
     mason_extract_tar_bz2

--- a/scripts/webp/0.4.2/script.sh
+++ b/scripts/webp/0.4.2/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/libwebp.pc
 
 function mason_load_source {
     mason_download \
-        http://downloads.webmproject.org/releases/webp/libwebp-0.4.2.tar.gz \
+        https://downloads.webmproject.org/releases/webp/libwebp-0.4.2.tar.gz \
         fdc496dcbcb03c9f26c2d9ce771545fa557a40c8
 
     mason_extract_tar_gz

--- a/scripts/webp/0.5.0/script.sh
+++ b/scripts/webp/0.5.0/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/libwebp.pc
 
 function mason_load_source {
     mason_download \
-        http://downloads.webmproject.org/releases/webp/libwebp-$MASON_VERSION.tar.gz \
+        https://downloads.webmproject.org/releases/webp/libwebp-$MASON_VERSION.tar.gz \
         9e5a4130ff09d28f0217eba972dcca5a57525f03
 
     mason_extract_tar_gz

--- a/scripts/webp/0.5.1/script.sh
+++ b/scripts/webp/0.5.1/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/libwebp.pc
 
 function mason_load_source {
     mason_download \
-        http://downloads.webmproject.org/releases/webp/libwebp-$MASON_VERSION.tar.gz \
+        https://downloads.webmproject.org/releases/webp/libwebp-$MASON_VERSION.tar.gz \
         7c2350c6524e8419e6b541a9087607c91c957377
 
     mason_extract_tar_gz

--- a/scripts/webp/0.6.0/script.sh
+++ b/scripts/webp/0.6.0/script.sh
@@ -9,7 +9,7 @@ MASON_PKGCONFIG_FILE=lib/pkgconfig/libwebp.pc
 
 function mason_load_source {
     mason_download \
-        http://downloads.webmproject.org/releases/webp/libwebp-$MASON_VERSION.tar.gz \
+        https://downloads.webmproject.org/releases/webp/libwebp-$MASON_VERSION.tar.gz \
         7669dc9a7c110cafc9e352d3abc1753bcb465dc0
 
     mason_extract_tar_gz

--- a/scripts/wget/1.19.2/script.sh
+++ b/scripts/wget/1.19.2/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=bin/wget
 
 function mason_load_source {
     mason_download \
-        http://ftp.gnu.org/gnu/${MASON_NAME}/${MASON_NAME}-${MASON_VERSION}.tar.gz \
+        https://ftp.gnu.org/gnu/${MASON_NAME}/${MASON_NAME}-${MASON_VERSION}.tar.gz \
         07a689125eaf3b050cd62fcb98662eeddc4982db
 
     mason_extract_tar_gz

--- a/scripts/xz/5.2.3/script.sh
+++ b/scripts/xz/5.2.3/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=lib/liblzma.a
 
 function mason_load_source {
     mason_download \
-        http://tukaani.org/xz/xz-${MASON_VERSION}.tar.gz \
+        https://tukaani.org/xz/xz-${MASON_VERSION}.tar.gz \
         147ce202755a3d846dc17479999671c7cadf0c2f
 
     mason_extract_tar_gz

--- a/scripts/zip/3.0.0/script.sh
+++ b/scripts/zip/3.0.0/script.sh
@@ -8,7 +8,7 @@ MASON_LIB_FILE=bin/zip
 
 function mason_load_source {
     mason_download \
-        http://sourceforge.net/projects/infozip/files/Zip%203.x%20%28latest%29/3.0/zip30.tar.gz/download \
+        https://sourceforge.net/projects/infozip/files/Zip%203.x%20%28latest%29/3.0/zip30.tar.gz/download \
         57f60be499bef90ccf84fe47d522d32504609e9b
 
     mason_extract_tar_gz

--- a/utils/new_boost.sh
+++ b/utils/new_boost.sh
@@ -69,7 +69,7 @@ function create() {
     export CACHE_PATH="mason_packages/.cache"
     mkdir -p "${CACHE_PATH}"
     if [[ ! -f ${CACHE_PATH}/boost-${NEW_VERSION} ]]; then
-        curl --retry 3 -f -S -L http://downloads.sourceforge.net/project/boost/boost/${NEW_VERSION}/boost_${BOOST_VERSION}.tar.bz2 -o ${CACHE_PATH}/boost-${NEW_VERSION}
+        curl --retry 3 -f -S -L https://downloads.sourceforge.net/project/boost/boost/${NEW_VERSION}/boost_${BOOST_VERSION}.tar.bz2 -o ${CACHE_PATH}/boost-${NEW_VERSION}
     fi
 
     NEW_SHASUM=$(git hash-object ${CACHE_PATH}/boost-${NEW_VERSION})


### PR DESCRIPTION
Fixes various old scripts that use `http:` instead of `https:`. Some of these may break since there is no upstream `https` endpoint. But nevertheless most should be https so I've changed them all.