### PR TITLE
Mbgl and deps

### DIFF
--- a/scripts/ccache/3.7.2/.travis.yml
+++ b/scripts/ccache/3.7.2/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode7.3
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-4.9-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/ccache/3.7.2/.travis.yml
+++ b/scripts/ccache/3.7.2/.travis.yml
@@ -3,7 +3,7 @@ language: generic
 matrix:
   include:
     - os: osx
-      osx_image: xcode7.3
+      osx_image: xcode9.2
       compiler: clang
     - os: linux
       sudo: false

--- a/scripts/ccache/3.7.2/script.sh
+++ b/scripts/ccache/3.7.2/script.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+MASON_NAME=ccache
+MASON_VERSION=3.7.1
+MASON_LIB_FILE=bin/ccache
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        https://github.com/${MASON_NAME}/${MASON_NAME}/releases/download/v${MASON_VERSION}/${MASON_NAME}-${MASON_VERSION}.tar.gz \
+        287db660ed7e45aeb824d69596711927a6a29221
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
+}
+
+function mason_compile {
+    # Add optimization flags since CFLAGS overrides the default (-g -O2)
+    export CFLAGS="${CFLAGS} -O3 -DNDEBUG"
+    ./configure \
+        --prefix=${MASON_PREFIX} \
+        ${MASON_HOST_ARG} \
+        --with-bundled-zlib
+    make V=1 -j${MASON_CONCURRENCY}
+    make install
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_cflags {
+    :
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"

--- a/scripts/cmake/3.15.2/.travis.yml
+++ b/scripts/cmake/3.15.2/.travis.yml
@@ -1,0 +1,18 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+    - os: linux
+      compiler: clang
+      sudo: false
+      addons:
+        apt:
+          sources: [ 'ubuntu-toolchain-r-test' ]
+          packages: [ 'libstdc++-4.9-dev' ]
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/cmake/3.15.2/script.sh
+++ b/scripts/cmake/3.15.2/script.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+MASON_NAME=cmake
+MASON_VERSION=3.15.2
+MASON_LIB_FILE=bin/cmake
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        https://www.cmake.org/files/v3.15/cmake-${MASON_VERSION}.tar.gz \
+        7427ef92a046c97304c9f529d44c4b4707440c6c
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
+}
+
+function mason_prepare_compile {
+    ${MASON_DIR}/mason install ccache 3.3.4
+    export PATH=$(${MASON_DIR}/mason prefix ccache 3.3.4)/bin:${PATH}
+}
+function mason_compile {
+    # Add optimization flags since CFLAGS overrides the default (-g -O2)
+    export CFLAGS="${CFLAGS} -O3 -DNDEBUG"
+    export CXXFLAGS="${CXXFLAGS} -O3 -DNDEBUG"
+    # TODO - use mason deps
+    ./configure --prefix=${MASON_PREFIX} \
+      --no-system-libs \
+      --parallel=${MASON_CONCURRENCY} \
+      --enable-ccache
+    make -j${MASON_CONCURRENCY} VERBOSE=1
+    make install
+    # remove non-essential things to save on package size
+    rm -f ${MASON_PREFIX}/bin/ccmake
+    rm -f ${MASON_PREFIX}/bin/cmakexbuild
+    rm -f ${MASON_PREFIX}/bin/cpack
+    rm -f ${MASON_PREFIX}/bin/ctest
+    rm -rf ${MASON_PREFIX}/share/cmake-*/Help
+    ls -lh ${MASON_PREFIX}/bin/
+}
+
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"

--- a/scripts/mbgl-core/a3a661e-asan/.travis.yml
+++ b/scripts/mbgl-core/a3a661e-asan/.travis.yml
@@ -1,0 +1,27 @@
+language: generic
+
+addons:
+  apt:
+    sources: [ 'ubuntu-toolchain-r-test' ]
+    packages: [ 'libstdc++-5-dev',
+                'libxi-dev',
+                'libglu1-mesa-dev',
+                'x11proto-randr-dev',
+                'x11proto-xext-dev',
+                'libxrandr-dev',
+                'x11proto-xf86vidmode-dev',
+                'libxxf86vm-dev',
+                'libxcursor-dev',
+                'libxinerama-dev' ]
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode9.2
+    - os: linux
+      dist: trusty
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/mbgl-core/a3a661e-asan/script.sh
+++ b/scripts/mbgl-core/a3a661e-asan/script.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+MASON_NAME=mbgl-core
+MASON_VERSION=a3a661e-asan
+MASON_VERSION2=a3a661e
+MASON_LIB_FILE=lib/libmbgl-core.a
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+  export MASON_BUILD_PATH=${MASON_ROOT}/.build/mbgl-${MASON_VERSION2}
+   if [[ ! -d ${MASON_BUILD_PATH} ]]; then
+      git clone https://github.com/mapbox/mapbox-gl-native ${MASON_BUILD_PATH}
+      (cd ${MASON_BUILD_PATH} && git checkout ${MASON_VERSION2} && git submodule update --init)
+  fi
+}
+
+function mason_prepare_compile {
+    CCACHE_VERSION=3.7.2
+    CMAKE_VERSION=3.15.2
+    NINJA_VERSION=1.9.0
+    LLVM_VERSION=8.0.0
+    ${MASON_DIR}/mason install clang++ ${LLVM_VERSION}
+    MASON_LLVM=$(${MASON_DIR}/mason prefix clang++ ${LLVM_VERSION})
+    ${MASON_DIR}/mason install ccache ${CCACHE_VERSION}
+    MASON_CCACHE=$(${MASON_DIR}/mason prefix ccache ${CCACHE_VERSION})
+    ${MASON_DIR}/mason install cmake ${CMAKE_VERSION}
+    MASON_CMAKE=$(${MASON_DIR}/mason prefix cmake ${CMAKE_VERSION})
+    ${MASON_DIR}/mason install ninja ${NINJA_VERSION}
+    MASON_NINJA=$(${MASON_DIR}/mason prefix ninja ${NINJA_VERSION})
+}
+
+function mason_compile {
+    mkdir -p build
+    rm -rf build/*
+    cd build
+    # MBGL uses c++14
+    export CXXFLAGS="${CXXFLAGS//-std=c++11}"
+    # MBGL uses 10.11
+    export CXXFLAGS="${CXXFLAGS//-mmacosx-version-min=10.8}"
+    export CXXFLAGS="-fsanitize=address,undefined,integer,leak ${CXXFLAGS}"
+    export LDFLAGS="-fsanitize=address,undefined,integer,leak ${LDFLAGS}"
+    ${MASON_CMAKE}/bin/cmake ../ \
+      -DCMAKE_INSTALL_PREFIX=${MASON_PREFIX} -DCMAKE_BUILD_TYPE=Debug \
+      -DWITH_NODEJS=OFF -DWITH_ERROR=OFF \
+      -G Ninja -DCMAKE_MAKE_PROGRAM=${MASON_NINJA}/bin/ninja \
+      -DCMAKE_CXX_COMPILER_LAUNCHER=${MASON_CCACHE}/bin/ccache \
+      -DCMAKE_CXX_COMPILER="${MASON_LLVM}/bin/clang++" \
+      -DCMAKE_C_COMPILER="${MASON_LLVM}/bin/clang"
+    ${MASON_NINJA}/bin/ninja mbgl-core -j4 -v
+    mkdir -p ${MASON_PREFIX}/include
+    mkdir -p ${MASON_PREFIX}/share
+    mkdir -p ${MASON_PREFIX}/lib
+    cp libmbgl-core.a ${MASON_PREFIX}/lib/
+    # linux does not vendor icu, but rather pulls from mason
+    if [ ${MASON_PLATFORM} != 'linux' ]; then
+      cp libicu.a ${MASON_PREFIX}/lib/
+    fi
+    cp -r ../include ${MASON_PREFIX}/
+    cp -r ../platform ${MASON_PREFIX}/include/mbgl/
+    cp -r ../src ${MASON_PREFIX}/include/mbgl/
+    cp -r ../vendor ${MASON_PREFIX}/include/mbgl/
+}
+
+function mason_cflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"

--- a/scripts/mbgl-core/a3a661e/.travis.yml
+++ b/scripts/mbgl-core/a3a661e/.travis.yml
@@ -1,0 +1,26 @@
+language: generic
+
+addons:
+  apt:
+    sources: [ 'ubuntu-toolchain-r-test' ]
+    packages: [ 'libstdc++-5-dev',
+                'libxi-dev',
+                'libglu1-mesa-dev',
+                'x11proto-randr-dev',
+                'x11proto-xext-dev',
+                'libxrandr-dev',
+                'x11proto-xf86vidmode-dev',
+                'libxxf86vm-dev',
+                'libxcursor-dev',
+                'libxinerama-dev' ]
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode9.2
+    - os: linux
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/mbgl-core/a3a661e/.travis.yml
+++ b/scripts/mbgl-core/a3a661e/.travis.yml
@@ -19,6 +19,7 @@ matrix:
     - os: osx
       osx_image: xcode9.2
     - os: linux
+      dist: trusty
       sudo: false
 
 script:

--- a/scripts/mbgl-core/a3a661e/script.sh
+++ b/scripts/mbgl-core/a3a661e/script.sh
@@ -47,7 +47,10 @@ function mason_compile {
     mkdir -p ${MASON_PREFIX}/share
     mkdir -p ${MASON_PREFIX}/lib
     cp libmbgl-core.a ${MASON_PREFIX}/lib/
-    cp libicu.a ${MASON_PREFIX}/lib/
+    # linux does not vendor icu, but rather pulls from mason
+    if [ ${MASON_PLATFORM} != 'linux' ]; then
+      cp libicu.a ${MASON_PREFIX}/lib/
+    fi
     cp -r ../include ${MASON_PREFIX}/
     cp -r ../platform ${MASON_PREFIX}/include/mbgl/
     cp -r ../src ${MASON_PREFIX}/include/mbgl/

--- a/scripts/mbgl-core/a3a661e/script.sh
+++ b/scripts/mbgl-core/a3a661e/script.sh
@@ -30,6 +30,11 @@ function mason_compile {
     mkdir -p build
     rm -rf build/*
     cd build
+    # MBGL uses c++14
+    export CXXFLAGS="${CXXFLAGS//-std=c++11}"
+    # MBGL uses 10.11
+    export CXXFLAGS="${CXXFLAGS//-mmacosx-version-min=10.8}"
+    
     ${MASON_CMAKE}/bin/cmake ../ \
       -DCMAKE_INSTALL_PREFIX=${MASON_PREFIX} -DCMAKE_BUILD_TYPE=Release \
       -DWITH_NODEJS=OFF -DWITH_ERROR=OFF \
@@ -37,11 +42,12 @@ function mason_compile {
       -DCMAKE_CXX_COMPILER_LAUNCHER=${MASON_CCACHE}/bin/ccache \
       -DCMAKE_CXX_COMPILER="$CXX" \
       -DCMAKE_C_COMPILER="$CC"
-    ${MASON_NINJA}/bin/ninja mbgl-core -j4
+    ${MASON_NINJA}/bin/ninja mbgl-core -j4 -v
     mkdir -p ${MASON_PREFIX}/include
     mkdir -p ${MASON_PREFIX}/share
     mkdir -p ${MASON_PREFIX}/lib
     cp libmbgl-core.a ${MASON_PREFIX}/lib/
+    cp libicu.a ${MASON_PREFIX}/lib/
     cp -r ../include ${MASON_PREFIX}/
     cp -r ../platform ${MASON_PREFIX}/include/mbgl/
     cp -r ../src ${MASON_PREFIX}/include/mbgl/

--- a/scripts/mbgl-core/a3a661e/script.sh
+++ b/scripts/mbgl-core/a3a661e/script.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+MASON_NAME=mbgl-core
+MASON_VERSION=a3a661e
+MASON_LIB_FILE=lib/libmbgl-core.a
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+  export MASON_BUILD_PATH=${MASON_ROOT}/.build/mbgl-${MASON_VERSION}
+   if [[ ! -d ${MASON_BUILD_PATH} ]]; then
+      git clone https://github.com/mapbox/mapbox-gl-native ${MASON_BUILD_PATH}
+      (cd ${MASON_BUILD_PATH} && git checkout ${MASON_VERSION} && git submodule update --init)
+  fi
+}
+
+function mason_prepare_compile {
+    CCACHE_VERSION=3.7.2
+    CMAKE_VERSION=3.15.2
+    NINJA_VERSION=1.9.0
+    ${MASON_DIR}/mason install ccache ${CCACHE_VERSION}
+    MASON_CCACHE=$(${MASON_DIR}/mason prefix ccache ${CCACHE_VERSION})
+    ${MASON_DIR}/mason install cmake ${CMAKE_VERSION}
+    MASON_CMAKE=$(${MASON_DIR}/mason prefix cmake ${CMAKE_VERSION})
+    ${MASON_DIR}/mason install ninja ${NINJA_VERSION}
+    MASON_NINJA=$(${MASON_DIR}/mason prefix ninja ${NINJA_VERSION})
+}
+
+function mason_compile {
+    mkdir -p build
+    rm -rf build/*
+    cd build
+    ${MASON_CMAKE}/bin/cmake ../ \
+      -DCMAKE_INSTALL_PREFIX=${MASON_PREFIX} -DCMAKE_BUILD_TYPE=Release \
+      -DWITH_NODEJS=OFF -DWITH_ERROR=OFF \
+      -G Ninja -DCMAKE_MAKE_PROGRAM=${MASON_NINJA}/bin/ninja \
+      -DCMAKE_CXX_COMPILER_LAUNCHER=${MASON_CCACHE}/bin/ccache \
+      -DCMAKE_CXX_COMPILER="$CXX" \
+      -DCMAKE_C_COMPILER="$CC"
+    ${MASON_NINJA}/bin/ninja mbgl-core -j4
+    mkdir -p ${MASON_PREFIX}/include
+    mkdir -p ${MASON_PREFIX}/share
+    mkdir -p ${MASON_PREFIX}/lib
+    cp libmbgl-core.a ${MASON_PREFIX}/lib/
+    cp -r ../include ${MASON_PREFIX}/
+    cp -r ../platform ${MASON_PREFIX}/include/mbgl/
+    cp -r ../src ${MASON_PREFIX}/include/mbgl/
+    cp -r ../vendor ${MASON_PREFIX}/include/mbgl/
+}
+
+function mason_cflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_clean {
+    make clean
+}
+
+mason_run "$@"

--- a/scripts/ninja/1.9.0/.travis.yml
+++ b/scripts/ninja/1.9.0/.travis.yml
@@ -1,0 +1,13 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.2
+      compiler: clang
+    - os: linux
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/ninja/1.9.0/script.sh
+++ b/scripts/ninja/1.9.0/script.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+MASON_NAME=ninja
+MASON_VERSION=1.9.0
+MASON_LIB_FILE=bin/ninja
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        https://github.com/ninja-build/ninja/archive/v${MASON_VERSION}.tar.gz \
+        794274ddac80ccfff85c3aa0c6ff5004a98a0142
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${MASON_VERSION}
+}
+
+function mason_compile {
+    ./configure.py --bootstrap
+    mkdir -p ${MASON_PREFIX}/bin/
+    cp ./ninja ${MASON_PREFIX}/bin/
+}
+
+function mason_cflags {
+    :
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
+mason_run "$@"


### PR DESCRIPTION
This adds the latest MBGL Native application core to mason.  It also updates to use the latest cmake, ninja, and ccache release. The overall goal of this PR is to:

 - Be able to upgrade mbgl in mapbox/vtshaver (refs https://github.com/mapbox/vtshaver/issues/9)
 - Be able to explore what it looks like to build alternative bindings to https://github.com/mapbox/mapbox-gl-native/tree/master/platform/node/src, outside of the mapbox-gl-native repo