### PR TITLE
more robust BOOST_TOOLSET name guessing from from CC, CXX

### DIFF
--- a/scripts/boost/1.61.0/base.sh
+++ b/scripts/boost/1.61.0/base.sh
@@ -4,7 +4,7 @@
 
 export MASON_VERSION=1.61.0
 export BOOST_VERSION=${MASON_VERSION//./_}
-export BOOST_TOOLSET=$(basename ${CC})
-export BOOST_TOOLSET_CXX=$(basename ${CXX})
+export BOOST_TOOLSET=$(CC=${CC#ccache }; basename -- ${CC%% *})
+export BOOST_TOOLSET_CXX=$(CXX=${CXX#ccache }; basename -- ${CXX%% *})
 export BOOST_ARCH="x86"
 export BOOST_SHASUM=0a72c541e468d76a957adc14e54688dd695d566f

--- a/scripts/boost/1.62.0/base.sh
+++ b/scripts/boost/1.62.0/base.sh
@@ -4,8 +4,8 @@
 
 export MASON_VERSION=1.62.0
 export BOOST_VERSION=${MASON_VERSION//./_}
-export BOOST_TOOLSET=$(basename ${CC})
-export BOOST_TOOLSET_CXX=$(basename ${CXX})
+export BOOST_TOOLSET=$(CC=${CC#ccache }; basename -- ${CC%% *})
+export BOOST_TOOLSET_CXX=$(CXX=${CXX#ccache }; basename -- ${CXX%% *})
 export BOOST_ARCH="x86"
 export BOOST_SHASUM=f4151eec3e9394146b7bebcb17b83149de0a6c23
 # special override to ensure each library shares the cached download

--- a/scripts/boost/1.63.0/base.sh
+++ b/scripts/boost/1.63.0/base.sh
@@ -4,8 +4,8 @@
 
 export MASON_VERSION=1.63.0
 export BOOST_VERSION=${MASON_VERSION//./_}
-export BOOST_TOOLSET=$(basename ${CC})
-export BOOST_TOOLSET_CXX=$(basename ${CXX})
+export BOOST_TOOLSET=$(CC=${CC#ccache }; basename -- ${CC%% *})
+export BOOST_TOOLSET_CXX=$(CXX=${CXX#ccache }; basename -- ${CXX%% *})
 export BOOST_ARCH="x86"
 export BOOST_SHASUM=5c5cf0fd35a5950ed9e00ba54153df47747803f9
 # special override to ensure each library shares the cached download

--- a/scripts/boost/1.64.0/base.sh
+++ b/scripts/boost/1.64.0/base.sh
@@ -4,8 +4,8 @@
 
 export MASON_VERSION=1.64.0
 export BOOST_VERSION=${MASON_VERSION//./_}
-export BOOST_TOOLSET=$(basename ${CC})
-export BOOST_TOOLSET_CXX=$(basename ${CXX})
+export BOOST_TOOLSET=$(CC=${CC#ccache }; basename -- ${CC%% *})
+export BOOST_TOOLSET_CXX=$(CXX=${CXX#ccache }; basename -- ${CXX%% *})
 export BOOST_ARCH="x86"
 export BOOST_SHASUM=6e4dad39f14937af73ace20d2279e2468aad14d8
 # special override to ensure each library shares the cached download

--- a/scripts/boost/1.65.1/base.sh
+++ b/scripts/boost/1.65.1/base.sh
@@ -4,8 +4,8 @@
 
 export MASON_VERSION=1.65.1
 export BOOST_VERSION=${MASON_VERSION//./_}
-export BOOST_TOOLSET=$(basename ${CC})
-export BOOST_TOOLSET_CXX=$(basename ${CXX})
+export BOOST_TOOLSET=$(CC=${CC#ccache }; basename -- ${CC%% *})
+export BOOST_TOOLSET_CXX=$(CXX=${CXX#ccache }; basename -- ${CXX%% *})
 export BOOST_ARCH="x86"
 export BOOST_SHASUM=094a03dd6f07e740719b944cfe01a278f5326315
 # special override to ensure each library shares the cached download

--- a/scripts/boost/1.66.0/base.sh
+++ b/scripts/boost/1.66.0/base.sh
@@ -4,8 +4,8 @@
 
 export MASON_VERSION=1.66.0
 export BOOST_VERSION=${MASON_VERSION//./_}
-export BOOST_TOOLSET=$(basename ${CC})
-export BOOST_TOOLSET_CXX=$(basename ${CXX})
+export BOOST_TOOLSET=$(CC=${CC#ccache }; basename -- ${CC%% *})
+export BOOST_TOOLSET_CXX=$(CXX=${CXX#ccache }; basename -- ${CXX%% *})
 export BOOST_ARCH="x86"
 export BOOST_SHASUM=5552748d2f0aede9ad1dfbb7f16832bbb054ca4d
 # special override to ensure each library shares the cached download

--- a/scripts/boost/1.67.0/base.sh
+++ b/scripts/boost/1.67.0/base.sh
@@ -4,8 +4,8 @@
 
 export MASON_VERSION=1.67.0
 export BOOST_VERSION=${MASON_VERSION//./_}
-export BOOST_TOOLSET=$(basename ${CC})
-export BOOST_TOOLSET_CXX=$(basename ${CXX})
+export BOOST_TOOLSET=$(CC=${CC#ccache }; basename -- ${CC%% *})
+export BOOST_TOOLSET_CXX=$(CXX=${CXX#ccache }; basename -- ${CXX%% *})
 export BOOST_ARCH="x86"
 export BOOST_SHASUM=6dde6a5f874a5dfa75865e4430ff9248a43cab07
 # special override to ensure each library shares the cached download


### PR DESCRIPTION
There are two issues with `basename $CC`.

If `CC` is two words (e.g. `ccache gcc`), basename returns the first (the second word is treated as a suffix to remove, most often it doesn't match so you don't notice).
If `CC` is more than two words, basename complains there's too many arguments.

This PR first strips `ccache` if it's the first word, and then calls basename with only the first word of the rest.
