### PR TITLE
mason_build: fix creating universal binary

### DIFF
--- a/mason.sh
+++ b/mason.sh
@@ -442,7 +442,7 @@ function mason_build {
 
         SIMULATOR_TARGETS="i386 x86_64"
         DEVICE_TARGETS="armv7 arm64"
-        LIB_FOLDERS=
+        local LIB_FOLDERS=
 
         for ARCH in ${SIMULATOR_TARGETS} ; do
             mason_substep "Building for iOS Simulator ${ARCH}..."
@@ -453,7 +453,7 @@ function mason_build {
             cd "${MASON_PREFIX}"
             mv lib "lib-isim-${ARCH}"
             for i in lib-isim-${ARCH}/*.a ; do lipo -info "$i" ; done
-            LIB_FOLDERS="${LIB_FOLDERS} lib-isim-${ARCH}"
+            LIB_FOLDERS+=" lib-isim-${ARCH}"
         done
 
         for ARCH in ${DEVICE_TARGETS} ; do
@@ -465,20 +465,20 @@ function mason_build {
             cd "${MASON_PREFIX}"
             mv lib lib-ios-${ARCH}
             for i in lib-ios-${ARCH}/*.a ; do lipo -info $i ; done
-            LIB_FOLDERS="${LIB_FOLDERS} lib-ios-${ARCH}"
+            LIB_FOLDERS+=" lib-ios-${ARCH}"
         done
 
         # Create universal binary
         mason_substep "Creating Universal Binary..."
         cd "${MASON_PREFIX}"
         mkdir -p lib
-        for LIB in $(find ${LIB_FOLDERS} -name "*.a" | xargs basename | sort | uniq) ; do
-            lipo -create $(find ${LIB_FOLDERS} -name "${LIB}") -output lib/${LIB}
+        for LIB in $(find ${LIB_FOLDERS} -name "*.a" | sed 's:.*/::' | sort -u); do
+            lipo -create $(find ${LIB_FOLDERS} -name ${LIB}) -output lib/${LIB}
             lipo -info "lib/${LIB}"
         done
 
         cd "${MASON_PREFIX}"
-        rm -rf "${LIB_FOLDERS}"
+        rm -rf -- ${LIB_FOLDERS}
     elif [ ${MASON_PLATFORM} = 'android' ]; then
         cd "${MASON_BUILD_PATH}"
         mason_compile


### PR DESCRIPTION
Forewarning: I'm not doing / testing anything with this `if [ "${MASON_PLATFORM}" = 'ios' ]` branch, so please someone double check these changes. I've just stumbled upon it while grepping for `basename` which is still giving me errors, and although those errors were coming from elsewhere (as I'm running it on linux), I decided to fix this part as well.

First simple stuff, I made `LIB_FOLDERS` local because it seems to only be used here, and changed to `+=` assignment because why not. (Originally I wanted to make that variable an array, but seeing how the rest of the code strongly assumes no spaces in paths, one array wouldn't change that).

Then this part:
```sh
find ${LIB_FOLDERS} -name "*.a" | xargs basename | sort | uniq
```
`basename suitable table` prints `sui`
`basename foo bar gaz` fails with `basename: extra operand ‘gaz’`
Maybe it was meant to be `xargs basename -a`, but POSIX basename doesn't know `-a`.
Luckily basename can easily be done with sed (here we don't even hit any weird cases so it's trivial).

`sort | uniq` is just an ancient way of saying `sort -u`.

And finally, this wasn't deleting anything:
```sh
rm -rf "${LIB_FOLDERS}"
```
