### PR TITLE
another take on guessing BOOST_TOOLSET

### DIFF
--- a/scripts/boost/1.61.0/base.sh
+++ b/scripts/boost/1.61.0/base.sh
@@ -1,10 +1,17 @@
 #!/usr/bin/env bash
 
-# NOTE: use the ./util/new_boost.sh script to create new versions
+# NOTE: use the ./utils/new_boost.sh script to create new versions
+
+function guess_compiler_name() {
+    case $1 in
+        ccache| */ccache) shift;;
+    esac
+    printf '%s' "${1##*/}"
+}
 
 export MASON_VERSION=1.61.0
 export BOOST_VERSION=${MASON_VERSION//./_}
-export BOOST_TOOLSET=$(CC=${CC#ccache }; basename -- ${CC%% *})
-export BOOST_TOOLSET_CXX=$(CXX=${CXX#ccache }; basename -- ${CXX%% *})
+export BOOST_TOOLSET=$(guess_compiler_name $CC)
+export BOOST_TOOLSET_CXX=$(guess_compiler_name $CXX)
 export BOOST_ARCH="x86"
 export BOOST_SHASUM=0a72c541e468d76a957adc14e54688dd695d566f

--- a/scripts/boost/1.62.0/base.sh
+++ b/scripts/boost/1.62.0/base.sh
@@ -2,10 +2,17 @@
 
 # NOTE: use the ./utils/new_boost.sh script to create new versions
 
+function guess_compiler_name() {
+    case $1 in
+        ccache| */ccache) shift;;
+    esac
+    printf '%s' "${1##*/}"
+}
+
 export MASON_VERSION=1.62.0
 export BOOST_VERSION=${MASON_VERSION//./_}
-export BOOST_TOOLSET=$(CC=${CC#ccache }; basename -- ${CC%% *})
-export BOOST_TOOLSET_CXX=$(CXX=${CXX#ccache }; basename -- ${CXX%% *})
+export BOOST_TOOLSET=$(guess_compiler_name $CC)
+export BOOST_TOOLSET_CXX=$(guess_compiler_name $CXX)
 export BOOST_ARCH="x86"
 export BOOST_SHASUM=f4151eec3e9394146b7bebcb17b83149de0a6c23
 # special override to ensure each library shares the cached download

--- a/scripts/boost/1.63.0/base.sh
+++ b/scripts/boost/1.63.0/base.sh
@@ -2,10 +2,17 @@
 
 # NOTE: use the ./utils/new_boost.sh script to create new versions
 
+function guess_compiler_name() {
+    case $1 in
+        ccache| */ccache) shift;;
+    esac
+    printf '%s' "${1##*/}"
+}
+
 export MASON_VERSION=1.63.0
 export BOOST_VERSION=${MASON_VERSION//./_}
-export BOOST_TOOLSET=$(CC=${CC#ccache }; basename -- ${CC%% *})
-export BOOST_TOOLSET_CXX=$(CXX=${CXX#ccache }; basename -- ${CXX%% *})
+export BOOST_TOOLSET=$(guess_compiler_name $CC)
+export BOOST_TOOLSET_CXX=$(guess_compiler_name $CXX)
 export BOOST_ARCH="x86"
 export BOOST_SHASUM=5c5cf0fd35a5950ed9e00ba54153df47747803f9
 # special override to ensure each library shares the cached download

--- a/scripts/boost/1.64.0/base.sh
+++ b/scripts/boost/1.64.0/base.sh
@@ -2,10 +2,17 @@
 
 # NOTE: use the ./utils/new_boost.sh script to create new versions
 
+function guess_compiler_name() {
+    case $1 in
+        ccache| */ccache) shift;;
+    esac
+    printf '%s' "${1##*/}"
+}
+
 export MASON_VERSION=1.64.0
 export BOOST_VERSION=${MASON_VERSION//./_}
-export BOOST_TOOLSET=$(CC=${CC#ccache }; basename -- ${CC%% *})
-export BOOST_TOOLSET_CXX=$(CXX=${CXX#ccache }; basename -- ${CXX%% *})
+export BOOST_TOOLSET=$(guess_compiler_name $CC)
+export BOOST_TOOLSET_CXX=$(guess_compiler_name $CXX)
 export BOOST_ARCH="x86"
 export BOOST_SHASUM=6e4dad39f14937af73ace20d2279e2468aad14d8
 # special override to ensure each library shares the cached download

--- a/scripts/boost/1.65.1/base.sh
+++ b/scripts/boost/1.65.1/base.sh
@@ -2,10 +2,17 @@
 
 # NOTE: use the ./utils/new_boost.sh script to create new versions
 
+function guess_compiler_name() {
+    case $1 in
+        ccache| */ccache) shift;;
+    esac
+    printf '%s' "${1##*/}"
+}
+
 export MASON_VERSION=1.65.1
 export BOOST_VERSION=${MASON_VERSION//./_}
-export BOOST_TOOLSET=$(CC=${CC#ccache }; basename -- ${CC%% *})
-export BOOST_TOOLSET_CXX=$(CXX=${CXX#ccache }; basename -- ${CXX%% *})
+export BOOST_TOOLSET=$(guess_compiler_name $CC)
+export BOOST_TOOLSET_CXX=$(guess_compiler_name $CXX)
 export BOOST_ARCH="x86"
 export BOOST_SHASUM=094a03dd6f07e740719b944cfe01a278f5326315
 # special override to ensure each library shares the cached download

--- a/scripts/boost/1.66.0/base.sh
+++ b/scripts/boost/1.66.0/base.sh
@@ -2,10 +2,17 @@
 
 # NOTE: use the ./utils/new_boost.sh script to create new versions
 
+function guess_compiler_name() {
+    case $1 in
+        ccache| */ccache) shift;;
+    esac
+    printf '%s' "${1##*/}"
+}
+
 export MASON_VERSION=1.66.0
 export BOOST_VERSION=${MASON_VERSION//./_}
-export BOOST_TOOLSET=$(CC=${CC#ccache }; basename -- ${CC%% *})
-export BOOST_TOOLSET_CXX=$(CXX=${CXX#ccache }; basename -- ${CXX%% *})
+export BOOST_TOOLSET=$(guess_compiler_name $CC)
+export BOOST_TOOLSET_CXX=$(guess_compiler_name $CXX)
 export BOOST_ARCH="x86"
 export BOOST_SHASUM=5552748d2f0aede9ad1dfbb7f16832bbb054ca4d
 # special override to ensure each library shares the cached download

--- a/scripts/boost/1.67.0/base.sh
+++ b/scripts/boost/1.67.0/base.sh
@@ -2,10 +2,17 @@
 
 # NOTE: use the ./utils/new_boost.sh script to create new versions
 
+function guess_compiler_name() {
+    case $1 in
+        ccache| */ccache) shift;;
+    esac
+    printf '%s' "${1##*/}"
+}
+
 export MASON_VERSION=1.67.0
 export BOOST_VERSION=${MASON_VERSION//./_}
-export BOOST_TOOLSET=$(CC=${CC#ccache }; basename -- ${CC%% *})
-export BOOST_TOOLSET_CXX=$(CXX=${CXX#ccache }; basename -- ${CXX%% *})
+export BOOST_TOOLSET=$(guess_compiler_name $CC)
+export BOOST_TOOLSET_CXX=$(guess_compiler_name $CXX)
 export BOOST_ARCH="x86"
 export BOOST_SHASUM=6dde6a5f874a5dfa75865e4430ff9248a43cab07
 # special override to ensure each library shares the cached download


### PR DESCRIPTION
Follow-up to #692. I was still getting basename errors from `mason install boost ...` and `mason link boost ...`. The culprit was that I didn't set CC and CXX, and so basename complained about missing operand. install/link action finished successfully despite the errors. I think it's ok for the toolset variables to remain empty if CC/CXX are empty, and not complain about it right at the start, when it's not known whether they'll be needed.

This PR actually fixes #515, the previous one didn't.
Below is the commit message:

    guess_compiler_name $CXX

Function guess_compiler_name prints the "basename" of its first argument
(or second argument if the first is ccache).
Passing non-quoted $CXX takes care of word splitting.

The "basename" is extracted with simple shell parameter expansion.
It differs from how POSIX basename command works, but in good ways:

    guess_compiler_name x/  # prints ''
    command basename x/     # prints 'x'

    guess_compiler_name ''  # prints ''
    command basename ''     # ??

POSIX leaves unspecified whether the resulting string is '.' or ''.

    guess_compiler_name     # prints ''
    command basename        # error: missing operand

Parameter expansion just works, with basename command we would need to
check that the compiler variable is set and non-null.