### PR TITLE
mason_clear_existing: delete regardless of file type

### DIFF
--- a/mason.sh
+++ b/mason.sh
@@ -306,7 +306,7 @@ function mason_check_installed {
 
 
 function mason_clear_existing {
-    if [ -d "${MASON_PREFIX}" ]; then
+    if [ -e "${MASON_PREFIX}" ] || [ -h "${MASON_PREFIX}" ]; then
         mason_step "Removing existing package... ${MASON_PREFIX}"
         rm -rf "${MASON_PREFIX}"
     fi


### PR DESCRIPTION
Currently `$MASON_PREFIX` is only deleted if it's a directory. It should be deleted even if it's a regular file, a broken link, or worst of all, a link to another directory.
