### PR TITLE
add script for protobuf 3.5.1 with shared enabled

### DIFF
--- a/scripts/protobuf/3.5.1-shared/.travis.yml
+++ b/scripts/protobuf/3.5.1-shared/.travis.yml
@@ -1,0 +1,42 @@
+sudo: false
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.2
+      compiler: clang
+    - os: osx
+      env: MASON_PLATFORM=ios
+      osx_image: xcode8.2
+      compiler: clang
+    - os: linux
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v5
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v7
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v8
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=x86
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=x86-64
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=mips
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=mips-64
+
+addons:
+  apt:
+    sources:
+     - ubuntu-toolchain-r-test
+    packages:
+     - libstdc++-5-dev
+
+script:
+- |
+  if [[ ${MASON_PLATFORM} == 'ios' ]] || [[ ${MASON_PLATFORM} == 'android' ]]; then
+    MASON_PLATFORM= MASON_ANDROID_ABI= ./mason install ${MASON_NAME} ${MASON_VERSION}
+    export PATH=`MASON_PLATFORM= MASON_ANDROID_ABI= ./mason prefix ${MASON_NAME} ${MASON_VERSION}`/bin:$PATH
+  fi
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/protobuf/3.5.1-shared/script.sh
+++ b/scripts/protobuf/3.5.1-shared/script.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+LIB_VERSION=3.5.1
+
+MASON_NAME=protobuf
+MASON_VERSION=${LIB_VERSION}-shared
+
+if [ "${MASON_PLATFORM}" == "ios" ]; then
+    MASON_LIB_FILE=lib-isim-i386/libprotobuf.a
+    MASON_PKGCONFIG_FILE=lib-isim-i386/pkgconfig/protobuf.pc
+else
+    MASON_LIB_FILE=lib/libprotobuf.a
+    MASON_PKGCONFIG_FILE=lib/pkgconfig/protobuf.pc
+fi
+
+. ${MASON_DIR}/mason.sh
+
+function mason_load_source {
+    mason_download \
+        https://github.com/google/protobuf/releases/download/v${LIB_VERSION}/protobuf-cpp-${LIB_VERSION}.tar.gz \
+        567b4000dc3666fb9de712beddfcf24a80e857f0
+
+    mason_extract_tar_gz
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/${MASON_NAME}-${LIB_VERSION}
+}
+
+function mason_compile {
+    # note CFLAGS overrides defaults (-O2 -g -DNDEBUG) so we need to add optimization flags back
+    export CFLAGS="${CFLAGS} -O3 -DNDEBUG"
+    export CXXFLAGS="${CXXFLAGS} -O3 -DNDEBUG"
+
+    if [ "${MASON_PLATFORM}" == "android" ]; then
+        export LDFLAGS="${LDFLAGS} -llog"
+    fi
+
+    if [ ${MASON_PLATFORM} == 'android' ] || [ ${MASON_PLATFORM} == 'ios' ]; then
+        local PREFIX=$(MASON_PLATFORM= MASON_PLATFORM_VERSION= ${MASON_DIR}/mason prefix ${MASON_NAME} ${MASON_VERSION})
+        if [ ! -d ${PREFIX} ]; then
+            $(MASON_PLATFORM= MASON_PLATFORM_VERSION= ${MASON_DIR}/mason install ${MASON_NAME} ${MASON_VERSION})
+        fi
+        export PROTOBUF_XC_ARG="--with-protoc=${PREFIX}/bin/protoc"
+    fi
+
+    if [ "${MASON_PLATFORM}" == "ios" ]; then
+        export MACOSX_DEPLOYMENT_TARGET="10.8"
+    fi
+
+    if [ -f Makefile ]; then
+        make distclean
+    fi
+
+    ./configure \
+        --prefix=${MASON_PREFIX} \
+        ${MASON_HOST_ARG} \
+        ${PROTOBUF_XC_ARG:-} \
+        --disable-debug --without-zlib \
+        --disable-dependency-tracking
+
+    make V=1 -j${MASON_CONCURRENCY}
+    make install -j${MASON_CONCURRENCY}
+}
+
+function mason_clean {
+    make clean
+}
+
+function mason_config_custom {
+    if [ ${MASON_PLATFORM} == 'android' ]; then
+        MASON_CONFIG_LDFLAGS="${MASON_CONFIG_LDFLAGS} -llog"
+    fi
+}
+
+mason_run "$@"


### PR DESCRIPTION
I'm working on a project where I need to provide protobuf@3.5.1 with shared enabled so that it can be used by apache/orc in a node module. Currently I'm doing this by compiling protobuf each time I build. @artemp mentioned that I should consider using mason but both the `3.5.1` and the `3.5.1-cxx11abi` builds have `--disabled-shared`. This PR introduces a new protobuf version `3.5.1-shared` which is based on `3.5.1` with the default protobuf configure options for static and sharing in place.