### PR TITLE
Boost 1.75.0

### DIFF
--- a/scripts/boost/1.74.0/patch.diff
+++ b/scripts/boost/1.74.0/patch.diff
@@ -63,3 +63,375 @@ index 9c7018c..bb073f4 100644
  
    template <typename Ex>
    static bool equal_ex(const any_executor_base& ex1,
+
+diff --git a/boost/property_tree/detail/ptree_implementation.hpp b/boost/property_tree/detail/ptree_implementation.hpp
+index dd9fd37..71ce6b5 100644
+--- a/boost/property_tree/detail/ptree_implementation.hpp
++++ b/boost/property_tree/detail/ptree_implementation.hpp
+@@ -15,6 +15,7 @@
+ #include <boost/iterator/reverse_iterator.hpp>
+ #include <boost/assert.hpp>
+ #include <boost/utility/swap.hpp>
++#include <boost/type_index.hpp>
+ #include <memory>
+ 
+ #if (defined(BOOST_MSVC) && \
+@@ -669,7 +670,8 @@ namespace boost { namespace property_tree
+         }
+         BOOST_PROPERTY_TREE_THROW(ptree_bad_data(
+             std::string("conversion of data to type \"") +
+-            typeid(Type).name() + "\" failed", data()));
++            boost::typeindex::type_id<Type>().pretty_name() + 
++            "\" failed", data()));
+     }
+ 
+     template<class K, class D, class C>
+@@ -824,7 +826,8 @@ namespace boost { namespace property_tree
+             data() = *o;
+         } else {
+             BOOST_PROPERTY_TREE_THROW(ptree_bad_data(
+-                std::string("conversion of type \"") + typeid(Type).name() +
++                std::string("conversion of type \"") + 
++                boost::typeindex::type_id<Type>().pretty_name() +
+                 "\" to data failed", boost::any()));
+         }
+     }
+diff --git a/boost/property_tree/detail/info_parser_read.hpp b/boost/property_tree/detail/info_parser_read.hpp
+index 87ef2cd..c3446b4 100644
+--- a/boost/property_tree/detail/info_parser_read.hpp
++++ b/boost/property_tree/detail/info_parser_read.hpp
+@@ -13,6 +13,8 @@
+ #include "boost/property_tree/ptree.hpp"
+ #include "boost/property_tree/detail/info_parser_error.hpp"
+ #include "boost/property_tree/detail/info_parser_utils.hpp"
++#include "boost/core/ignore_unused.hpp"
++#include "boost/core/no_exceptions_support.hpp"
+ #include <iterator>
+ #include <string>
+ #include <stack>
+@@ -210,7 +212,13 @@ namespace boost { namespace property_tree { namespace info_parser
+         std::stack<Ptree *> stack;
+         stack.push(&pt);                // Push root ptree on stack initially
+ 
+-        try {
++        // When compiling without exception support there is no formal
++        // parameter "e" in the catch handler.  Declaring a local variable
++        // here does not hurt and will be "used" to make the code in the
++        // handler  compilable although the code will never be executed.
++        info_parser_error e("", "", 0); ignore_unused(e);
++
++        BOOST_TRY {
+             // While there are characters in the stream
+             while (stream.good()) {
+                 // Read one line from stream
+@@ -372,7 +380,7 @@ namespace boost { namespace property_tree { namespace info_parser
+                 BOOST_PROPERTY_TREE_THROW(info_parser_error("unmatched {", "", 0));
+ 
+         }
+-        catch (info_parser_error &e)
++        BOOST_CATCH (info_parser_error &e)
+         {
+             // If line undefined rethrow error with correct filename and line
+             if (e.line() == 0)
+@@ -383,6 +391,7 @@ namespace boost { namespace property_tree { namespace info_parser
+                 BOOST_PROPERTY_TREE_THROW(e);
+ 
+         }
++        BOOST_CATCH_END
+ 
+     }
+ 
+diff --git a/boost/property_tree/detail/rapidxml.hpp b/boost/property_tree/detail/rapidxml.hpp
+index 9e3d76a..e890feb 100644
+--- a/boost/property_tree/detail/rapidxml.hpp
++++ b/boost/property_tree/detail/rapidxml.hpp
+@@ -28,7 +28,7 @@
+     
+ #include <exception>    // For std::exception
+ 
+-#define BOOST_PROPERTY_TREE_RAPIDXML_PARSE_ERROR(what, where) throw parse_error(what, where)
++#define BOOST_PROPERTY_TREE_RAPIDXML_PARSE_ERROR(what, where) boost::throw_exception(parse_error(what, where))
+ 
+ namespace boost { namespace property_tree { namespace detail {namespace rapidxml
+ {
+diff --git a/boost/property_tree/detail/xml_parser_read_rapidxml.hpp b/boost/property_tree/detail/xml_parser_read_rapidxml.hpp
+index 9c04219..a6b005a 100644
+--- a/boost/property_tree/detail/xml_parser_read_rapidxml.hpp
++++ b/boost/property_tree/detail/xml_parser_read_rapidxml.hpp
+@@ -15,6 +15,8 @@
+ #include <boost/property_tree/detail/xml_parser_flags.hpp>
+ #include <boost/property_tree/detail/xml_parser_utils.hpp>
+ #include <boost/property_tree/detail/rapidxml.hpp>
++#include <boost/core/ignore_unused.hpp>
++#include <boost/core/no_exceptions_support.hpp>
+ #include <vector>
+ 
+ namespace boost { namespace property_tree { namespace xml_parser
+@@ -101,7 +103,13 @@ namespace boost { namespace property_tree { namespace xml_parser
+                 xml_parser_error("read error", filename, 0));
+         v.push_back(0); // zero-terminate
+ 
+-        try {
++        // When compiling without exception support there is no formal
++        // parameter "e" in the catch handler.  Declaring a local variable
++        // here does not hurt and will be "used" to make the code in the
++        // handler compilable although the code will never be executed.
++        parse_error e(NULL, NULL); ignore_unused(e);
++        
++        BOOST_TRY {
+             // Parse using appropriate flags
+             const int f_tws = parse_normalize_whitespace
+                             | parse_trim_whitespace;
+@@ -131,12 +139,13 @@ namespace boost { namespace property_tree { namespace xml_parser
+ 
+             // Swap local and result ptrees
+             pt.swap(local);
+-        } catch (parse_error &e) {
++        } BOOST_CATCH (parse_error &e) {
+             long line = static_cast<long>(
+                 std::count(&v.front(), e.where<Ch>(), Ch('\n')) + 1);
+             BOOST_PROPERTY_TREE_THROW(
+                 xml_parser_error(e.what(), filename, line));  
+         }
++        BOOST_CATCH_END
+     }
+ 
+ } } }
+diff --git a/boost/property_tree/info_parser.hpp b/boost/property_tree/info_parser.hpp
+index 683ddad..abdc8a3 100644
+--- a/boost/property_tree/info_parser.hpp
++++ b/boost/property_tree/info_parser.hpp
+@@ -15,6 +15,7 @@
+ #include <boost/property_tree/detail/info_parser_writer_settings.hpp>
+ #include <boost/property_tree/detail/info_parser_read.hpp>
+ #include <boost/property_tree/detail/info_parser_write.hpp>
++#include <boost/core/no_exceptions_support.hpp>
+ #include <istream>
+ 
+ namespace boost { namespace property_tree { namespace info_parser
+@@ -43,11 +44,12 @@ namespace boost { namespace property_tree { namespace info_parser
+     void read_info(std::basic_istream<Ch> &stream, Ptree &pt,
+                    const Ptree &default_ptree)
+     {
+-        try {
++        BOOST_TRY {
+             read_info(stream, pt);
+-        } catch(file_parser_error &) {
++        } BOOST_CATCH(file_parser_error &) {
+             pt = default_ptree;
+         }
++        BOOST_CATCH_END
+     }
+ 
+     /**
+@@ -87,11 +89,12 @@ namespace boost { namespace property_tree { namespace info_parser
+                    const Ptree &default_ptree,
+                    const std::locale &loc = std::locale())
+     {
+-        try {
++        BOOST_TRY {
+             read_info(filename, pt, loc);
+-        } catch(file_parser_error &) {
++        } BOOST_CATCH(file_parser_error &) {
+             pt = default_ptree;
+         }
++        BOOST_CATCH_END
+     }
+ 
+     /**
+diff --git a/boost/property_tree/ini_parser.hpp b/boost/property_tree/ini_parser.hpp
+index 50d3c97..5142dbf 100644
+--- a/boost/property_tree/ini_parser.hpp
++++ b/boost/property_tree/ini_parser.hpp
+@@ -14,6 +14,8 @@
+ #include <boost/property_tree/ptree.hpp>
+ #include <boost/property_tree/detail/ptree_utils.hpp>
+ #include <boost/property_tree/detail/file_parser_error.hpp>
++#include <boost/core/ignore_unused.hpp>
++#include <boost/core/no_exceptions_support.hpp>
+ #include <fstream>
+ #include <string>
+ #include <sstream>
+@@ -165,13 +167,21 @@ namespace boost { namespace property_tree { namespace ini_parser
+             BOOST_PROPERTY_TREE_THROW(ini_parser_error(
+                 "cannot open file", filename, 0));
+         stream.imbue(loc);
+-        try {
++
++        // When compiling without exception support there is no formal
++        // parameter "e" in the catch handler.  Declaring a local variable
++        // here does not hurt and will be "used" to make the code in the
++        // handler compilable although the code will never be executed.
++        ini_parser_error e("", "", 0); ignore_unused(e);
++
++        BOOST_TRY {
+             read_ini(stream, pt);
+         }
+-        catch (ini_parser_error &e) {
++        BOOST_CATCH (ini_parser_error &e) {
+             BOOST_PROPERTY_TREE_THROW(ini_parser_error(
+                 e.message(), filename, e.line()));
+         }
++        BOOST_CATCH_END
+     }
+ 
+     namespace detail
+@@ -313,13 +323,21 @@ namespace boost { namespace property_tree { namespace ini_parser
+             BOOST_PROPERTY_TREE_THROW(ini_parser_error(
+                 "cannot open file", filename, 0));
+         stream.imbue(loc);
+-        try {
++
++        // When compiling without exception support there is no formal
++        // parameter "e" in the catch handler.  Declaring a local variable
++        // here does not hurt and will be "used" to make the code in the
++        // handler  compilable although the code will never be executed.
++        ini_parser_error e("", "", 0); ignore_unused(e);
++
++        BOOST_TRY {
+             write_ini(stream, pt, flags);
+         }
+-        catch (ini_parser_error &e) {
++        BOOST_CATCH (ini_parser_error &e) {
+             BOOST_PROPERTY_TREE_THROW(ini_parser_error(
+                 e.message(), filename, e.line()));
+         }
++        BOOST_CATCH_END
+     }
+ 
+ } } }
+
+diff --git a/boost/property_tree/detail/info_parser_read.hpp b/boost/property_tree/detail/info_parser_read.hpp
+index c3446b4..b46643a 100644
+--- a/boost/property_tree/detail/info_parser_read.hpp
++++ b/boost/property_tree/detail/info_parser_read.hpp
+@@ -13,7 +13,6 @@
+ #include "boost/property_tree/ptree.hpp"
+ #include "boost/property_tree/detail/info_parser_error.hpp"
+ #include "boost/property_tree/detail/info_parser_utils.hpp"
+-#include "boost/core/ignore_unused.hpp"
+ #include "boost/core/no_exceptions_support.hpp"
+ #include <iterator>
+ #include <string>
+@@ -212,12 +211,6 @@ namespace boost { namespace property_tree { namespace info_parser
+         std::stack<Ptree *> stack;
+         stack.push(&pt);                // Push root ptree on stack initially
+ 
+-        // When compiling without exception support there is no formal
+-        // parameter "e" in the catch handler.  Declaring a local variable
+-        // here does not hurt and will be "used" to make the code in the
+-        // handler  compilable although the code will never be executed.
+-        info_parser_error e("", "", 0); ignore_unused(e);
+-
+         BOOST_TRY {
+             // While there are characters in the stream
+             while (stream.good()) {
+@@ -382,6 +375,7 @@ namespace boost { namespace property_tree { namespace info_parser
+         }
+         BOOST_CATCH (info_parser_error &e)
+         {
++    #ifndef BOOST_NO_EXCEPTIONS
+             // If line undefined rethrow error with correct filename and line
+             if (e.line() == 0)
+             {
+@@ -389,7 +383,7 @@ namespace boost { namespace property_tree { namespace info_parser
+             }
+             else
+                 BOOST_PROPERTY_TREE_THROW(e);
+-
++    #endif
+         }
+         BOOST_CATCH_END
+ 
+diff --git a/boost/property_tree/detail/xml_parser_read_rapidxml.hpp b/boost/property_tree/detail/xml_parser_read_rapidxml.hpp
+index a6b005a..b6f5820 100644
+--- a/boost/property_tree/detail/xml_parser_read_rapidxml.hpp
++++ b/boost/property_tree/detail/xml_parser_read_rapidxml.hpp
+@@ -15,7 +15,6 @@
+ #include <boost/property_tree/detail/xml_parser_flags.hpp>
+ #include <boost/property_tree/detail/xml_parser_utils.hpp>
+ #include <boost/property_tree/detail/rapidxml.hpp>
+-#include <boost/core/ignore_unused.hpp>
+ #include <boost/core/no_exceptions_support.hpp>
+ #include <vector>
+ 
+@@ -103,12 +102,6 @@ namespace boost { namespace property_tree { namespace xml_parser
+                 xml_parser_error("read error", filename, 0));
+         v.push_back(0); // zero-terminate
+ 
+-        // When compiling without exception support there is no formal
+-        // parameter "e" in the catch handler.  Declaring a local variable
+-        // here does not hurt and will be "used" to make the code in the
+-        // handler compilable although the code will never be executed.
+-        parse_error e(NULL, NULL); ignore_unused(e);
+-        
+         BOOST_TRY {
+             // Parse using appropriate flags
+             const int f_tws = parse_normalize_whitespace
+@@ -140,10 +133,12 @@ namespace boost { namespace property_tree { namespace xml_parser
+             // Swap local and result ptrees
+             pt.swap(local);
+         } BOOST_CATCH (parse_error &e) {
++    #ifndef BOOST_NO_EXCEPTIONS
+             long line = static_cast<long>(
+                 std::count(&v.front(), e.where<Ch>(), Ch('\n')) + 1);
+             BOOST_PROPERTY_TREE_THROW(
+                 xml_parser_error(e.what(), filename, line));  
++    #endif
+         }
+         BOOST_CATCH_END
+     }
+diff --git a/boost/property_tree/ini_parser.hpp b/boost/property_tree/ini_parser.hpp
+index 5142dbf..cb63fcc 100644
+--- a/boost/property_tree/ini_parser.hpp
++++ b/boost/property_tree/ini_parser.hpp
+@@ -14,7 +14,6 @@
+ #include <boost/property_tree/ptree.hpp>
+ #include <boost/property_tree/detail/ptree_utils.hpp>
+ #include <boost/property_tree/detail/file_parser_error.hpp>
+-#include <boost/core/ignore_unused.hpp>
+ #include <boost/core/no_exceptions_support.hpp>
+ #include <fstream>
+ #include <string>
+@@ -168,18 +167,14 @@ namespace boost { namespace property_tree { namespace ini_parser
+                 "cannot open file", filename, 0));
+         stream.imbue(loc);
+ 
+-        // When compiling without exception support there is no formal
+-        // parameter "e" in the catch handler.  Declaring a local variable
+-        // here does not hurt and will be "used" to make the code in the
+-        // handler compilable although the code will never be executed.
+-        ini_parser_error e("", "", 0); ignore_unused(e);
+-
+         BOOST_TRY {
+             read_ini(stream, pt);
+         }
+         BOOST_CATCH (ini_parser_error &e) {
++    #ifndef BOOST_NO_EXCEPTIONS
+             BOOST_PROPERTY_TREE_THROW(ini_parser_error(
+                 e.message(), filename, e.line()));
++    #endif
+         }
+         BOOST_CATCH_END
+     }
+@@ -324,18 +319,14 @@ namespace boost { namespace property_tree { namespace ini_parser
+                 "cannot open file", filename, 0));
+         stream.imbue(loc);
+ 
+-        // When compiling without exception support there is no formal
+-        // parameter "e" in the catch handler.  Declaring a local variable
+-        // here does not hurt and will be "used" to make the code in the
+-        // handler  compilable although the code will never be executed.
+-        ini_parser_error e("", "", 0); ignore_unused(e);
+-
+         BOOST_TRY {
+             write_ini(stream, pt, flags);
+         }
+         BOOST_CATCH (ini_parser_error &e) {
++    #ifndef BOOST_NO_EXCEPTIONS
+             BOOST_PROPERTY_TREE_THROW(ini_parser_error(
+                 e.message(), filename, e.line()));
++    #endif
+         }
+         BOOST_CATCH_END
+     }

--- a/scripts/boost/1.75.0/.travis.yml
+++ b/scripts/boost/1.75.0/.travis.yml
@@ -1,0 +1,7 @@
+jobs:
+  include:
+    - os: linux
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost/1.75.0/base.sh
+++ b/scripts/boost/1.75.0/base.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# NOTE: use the ./utils/new_boost.sh script to create new versions
+
+export MASON_VERSION=1.75.0
+export BOOST_VERSION=${MASON_VERSION//./_}
+export BOOST_TOOLSET=$(CC=${CC#ccache }; basename -- ${CC%% *})
+export BOOST_TOOLSET_CXX=$(CXX=${CXX#ccache }; basename -- ${CXX%% *})
+export BOOST_ARCH="x86"
+export BOOST_SHASUM=1a5d6590555afdfada1428f1469ec2a8053e10b5
+# special override to ensure each library shares the cached download
+export MASON_DOWNLOAD_SLUG="boost-${MASON_VERSION}"

--- a/scripts/boost/1.75.0/common.sh
+++ b/scripts/boost/1.75.0/common.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+function mason_load_source {
+    mason_download \
+        https://dl.bintray.com/boostorg/release/${MASON_VERSION}/source/boost_${BOOST_VERSION}.tar.bz2 \
+        ${BOOST_SHASUM}
+
+    export MASON_BUILD_PATH=${MASON_ROOT}/.build/boost_${BOOST_VERSION}
+
+    mason_extract_tar_bz2
+}
+
+function gen_config() {
+  echo "using $1 : : $(which $2)" > user-config.jam
+  if [[ "${AR:-false}" != false ]] || [[ "${RANLIB:-false}" != false ]]; then
+      echo ' : ' >> user-config.jam
+      if [[ "${AR:-false}" != false ]]; then
+          echo "<archiver>${AR} " >> user-config.jam
+      fi
+      if [[ "${RANLIB:-false}" != false ]]; then
+          echo "<ranlib>${RANLIB} " >> user-config.jam
+      fi
+  fi
+  echo ' ;' >> user-config.jam
+}
+
+function mason_compile {
+    gen_config ${BOOST_TOOLSET} ${BOOST_TOOLSET_CXX}
+    if [[ ! -f ./b2 ]] ; then
+        ./bootstrap.sh
+    fi
+    ./b2 \
+        --with-${BOOST_LIBRARY} \
+        --prefix=${MASON_PREFIX} \
+        -j${MASON_CONCURRENCY} \
+        -d0 \
+        --ignore-site-config --user-config=user-config.jam \
+        architecture="${BOOST_ARCH}" \
+        toolset="${BOOST_TOOLSET}" \
+        link=static \
+        variant=release \
+        linkflags="${LDFLAGS:-" "}" \
+        cxxflags="${CXXFLAGS:-" "}" \
+        stage
+    mkdir -p $(dirname ${MASON_PREFIX}/${MASON_LIB_FILE})
+    mv stage/${MASON_LIB_FILE} ${MASON_PREFIX}/${MASON_LIB_FILE}
+}
+
+function mason_prefix {
+    echo "${MASON_PREFIX}"
+}
+
+function mason_cflags {
+    echo "-I${MASON_PREFIX}/include"
+}
+
+function mason_ldflags {
+    local LOCAL_LDFLAGS
+    LOCAL_LDFLAGS="-L${MASON_PREFIX}/lib"
+    if [[ ${BOOST_LIBRARY:-false} != false ]]; then
+        LOCAL_LDFLAGS="${LOCAL_LDFLAGS} -lboost_${BOOST_LIBRARY}"
+    fi
+    echo $LOCAL_LDFLAGS
+}

--- a/scripts/boost/1.75.0/patch.diff
+++ b/scripts/boost/1.75.0/patch.diff
@@ -1,0 +1,371 @@
+diff --git a/boost/property_tree/detail/ptree_implementation.hpp b/boost/property_tree/detail/ptree_implementation.hpp
+index dd9fd37..71ce6b5 100644
+--- a/boost/property_tree/detail/ptree_implementation.hpp
++++ b/boost/property_tree/detail/ptree_implementation.hpp
+@@ -15,6 +15,7 @@
+ #include <boost/iterator/reverse_iterator.hpp>
+ #include <boost/assert.hpp>
+ #include <boost/utility/swap.hpp>
++#include <boost/type_index.hpp>
+ #include <memory>
+ 
+ #if (defined(BOOST_MSVC) && \
+@@ -669,7 +670,8 @@ namespace boost { namespace property_tree
+         }
+         BOOST_PROPERTY_TREE_THROW(ptree_bad_data(
+             std::string("conversion of data to type \"") +
+-            typeid(Type).name() + "\" failed", data()));
++            boost::typeindex::type_id<Type>().pretty_name() + 
++            "\" failed", data()));
+     }
+ 
+     template<class K, class D, class C>
+@@ -824,7 +826,8 @@ namespace boost { namespace property_tree
+             data() = *o;
+         } else {
+             BOOST_PROPERTY_TREE_THROW(ptree_bad_data(
+-                std::string("conversion of type \"") + typeid(Type).name() +
++                std::string("conversion of type \"") + 
++                boost::typeindex::type_id<Type>().pretty_name() +
+                 "\" to data failed", boost::any()));
+         }
+     }
+diff --git a/boost/property_tree/detail/info_parser_read.hpp b/boost/property_tree/detail/info_parser_read.hpp
+index 87ef2cd..c3446b4 100644
+--- a/boost/property_tree/detail/info_parser_read.hpp
++++ b/boost/property_tree/detail/info_parser_read.hpp
+@@ -13,6 +13,8 @@
+ #include "boost/property_tree/ptree.hpp"
+ #include "boost/property_tree/detail/info_parser_error.hpp"
+ #include "boost/property_tree/detail/info_parser_utils.hpp"
++#include "boost/core/ignore_unused.hpp"
++#include "boost/core/no_exceptions_support.hpp"
+ #include <iterator>
+ #include <string>
+ #include <stack>
+@@ -210,7 +212,13 @@ namespace boost { namespace property_tree { namespace info_parser
+         std::stack<Ptree *> stack;
+         stack.push(&pt);                // Push root ptree on stack initially
+ 
+-        try {
++        // When compiling without exception support there is no formal
++        // parameter "e" in the catch handler.  Declaring a local variable
++        // here does not hurt and will be "used" to make the code in the
++        // handler  compilable although the code will never be executed.
++        info_parser_error e("", "", 0); ignore_unused(e);
++
++        BOOST_TRY {
+             // While there are characters in the stream
+             while (stream.good()) {
+                 // Read one line from stream
+@@ -372,7 +380,7 @@ namespace boost { namespace property_tree { namespace info_parser
+                 BOOST_PROPERTY_TREE_THROW(info_parser_error("unmatched {", "", 0));
+ 
+         }
+-        catch (info_parser_error &e)
++        BOOST_CATCH (info_parser_error &e)
+         {
+             // If line undefined rethrow error with correct filename and line
+             if (e.line() == 0)
+@@ -383,6 +391,7 @@ namespace boost { namespace property_tree { namespace info_parser
+                 BOOST_PROPERTY_TREE_THROW(e);
+ 
+         }
++        BOOST_CATCH_END
+ 
+     }
+ 
+diff --git a/boost/property_tree/detail/rapidxml.hpp b/boost/property_tree/detail/rapidxml.hpp
+index 9e3d76a..e890feb 100644
+--- a/boost/property_tree/detail/rapidxml.hpp
++++ b/boost/property_tree/detail/rapidxml.hpp
+@@ -28,7 +28,7 @@
+     
+ #include <exception>    // For std::exception
+ 
+-#define BOOST_PROPERTY_TREE_RAPIDXML_PARSE_ERROR(what, where) throw parse_error(what, where)
++#define BOOST_PROPERTY_TREE_RAPIDXML_PARSE_ERROR(what, where) boost::throw_exception(parse_error(what, where))
+ 
+ namespace boost { namespace property_tree { namespace detail {namespace rapidxml
+ {
+diff --git a/boost/property_tree/detail/xml_parser_read_rapidxml.hpp b/boost/property_tree/detail/xml_parser_read_rapidxml.hpp
+index 9c04219..a6b005a 100644
+--- a/boost/property_tree/detail/xml_parser_read_rapidxml.hpp
++++ b/boost/property_tree/detail/xml_parser_read_rapidxml.hpp
+@@ -15,6 +15,8 @@
+ #include <boost/property_tree/detail/xml_parser_flags.hpp>
+ #include <boost/property_tree/detail/xml_parser_utils.hpp>
+ #include <boost/property_tree/detail/rapidxml.hpp>
++#include <boost/core/ignore_unused.hpp>
++#include <boost/core/no_exceptions_support.hpp>
+ #include <vector>
+ 
+ namespace boost { namespace property_tree { namespace xml_parser
+@@ -101,7 +103,13 @@ namespace boost { namespace property_tree { namespace xml_parser
+                 xml_parser_error("read error", filename, 0));
+         v.push_back(0); // zero-terminate
+ 
+-        try {
++        // When compiling without exception support there is no formal
++        // parameter "e" in the catch handler.  Declaring a local variable
++        // here does not hurt and will be "used" to make the code in the
++        // handler compilable although the code will never be executed.
++        parse_error e(NULL, NULL); ignore_unused(e);
++        
++        BOOST_TRY {
+             // Parse using appropriate flags
+             const int f_tws = parse_normalize_whitespace
+                             | parse_trim_whitespace;
+@@ -131,12 +139,13 @@ namespace boost { namespace property_tree { namespace xml_parser
+ 
+             // Swap local and result ptrees
+             pt.swap(local);
+-        } catch (parse_error &e) {
++        } BOOST_CATCH (parse_error &e) {
+             long line = static_cast<long>(
+                 std::count(&v.front(), e.where<Ch>(), Ch('\n')) + 1);
+             BOOST_PROPERTY_TREE_THROW(
+                 xml_parser_error(e.what(), filename, line));  
+         }
++        BOOST_CATCH_END
+     }
+ 
+ } } }
+diff --git a/boost/property_tree/info_parser.hpp b/boost/property_tree/info_parser.hpp
+index 683ddad..abdc8a3 100644
+--- a/boost/property_tree/info_parser.hpp
++++ b/boost/property_tree/info_parser.hpp
+@@ -15,6 +15,7 @@
+ #include <boost/property_tree/detail/info_parser_writer_settings.hpp>
+ #include <boost/property_tree/detail/info_parser_read.hpp>
+ #include <boost/property_tree/detail/info_parser_write.hpp>
++#include <boost/core/no_exceptions_support.hpp>
+ #include <istream>
+ 
+ namespace boost { namespace property_tree { namespace info_parser
+@@ -43,11 +44,12 @@ namespace boost { namespace property_tree { namespace info_parser
+     void read_info(std::basic_istream<Ch> &stream, Ptree &pt,
+                    const Ptree &default_ptree)
+     {
+-        try {
++        BOOST_TRY {
+             read_info(stream, pt);
+-        } catch(file_parser_error &) {
++        } BOOST_CATCH(file_parser_error &) {
+             pt = default_ptree;
+         }
++        BOOST_CATCH_END
+     }
+ 
+     /**
+@@ -87,11 +89,12 @@ namespace boost { namespace property_tree { namespace info_parser
+                    const Ptree &default_ptree,
+                    const std::locale &loc = std::locale())
+     {
+-        try {
++        BOOST_TRY {
+             read_info(filename, pt, loc);
+-        } catch(file_parser_error &) {
++        } BOOST_CATCH(file_parser_error &) {
+             pt = default_ptree;
+         }
++        BOOST_CATCH_END
+     }
+ 
+     /**
+diff --git a/boost/property_tree/ini_parser.hpp b/boost/property_tree/ini_parser.hpp
+index 50d3c97..5142dbf 100644
+--- a/boost/property_tree/ini_parser.hpp
++++ b/boost/property_tree/ini_parser.hpp
+@@ -14,6 +14,8 @@
+ #include <boost/property_tree/ptree.hpp>
+ #include <boost/property_tree/detail/ptree_utils.hpp>
+ #include <boost/property_tree/detail/file_parser_error.hpp>
++#include <boost/core/ignore_unused.hpp>
++#include <boost/core/no_exceptions_support.hpp>
+ #include <fstream>
+ #include <string>
+ #include <sstream>
+@@ -165,13 +167,21 @@ namespace boost { namespace property_tree { namespace ini_parser
+             BOOST_PROPERTY_TREE_THROW(ini_parser_error(
+                 "cannot open file", filename, 0));
+         stream.imbue(loc);
+-        try {
++
++        // When compiling without exception support there is no formal
++        // parameter "e" in the catch handler.  Declaring a local variable
++        // here does not hurt and will be "used" to make the code in the
++        // handler compilable although the code will never be executed.
++        ini_parser_error e("", "", 0); ignore_unused(e);
++
++        BOOST_TRY {
+             read_ini(stream, pt);
+         }
+-        catch (ini_parser_error &e) {
++        BOOST_CATCH (ini_parser_error &e) {
+             BOOST_PROPERTY_TREE_THROW(ini_parser_error(
+                 e.message(), filename, e.line()));
+         }
++        BOOST_CATCH_END
+     }
+ 
+     namespace detail
+@@ -313,13 +323,21 @@ namespace boost { namespace property_tree { namespace ini_parser
+             BOOST_PROPERTY_TREE_THROW(ini_parser_error(
+                 "cannot open file", filename, 0));
+         stream.imbue(loc);
+-        try {
++
++        // When compiling without exception support there is no formal
++        // parameter "e" in the catch handler.  Declaring a local variable
++        // here does not hurt and will be "used" to make the code in the
++        // handler  compilable although the code will never be executed.
++        ini_parser_error e("", "", 0); ignore_unused(e);
++
++        BOOST_TRY {
+             write_ini(stream, pt, flags);
+         }
+-        catch (ini_parser_error &e) {
++        BOOST_CATCH (ini_parser_error &e) {
+             BOOST_PROPERTY_TREE_THROW(ini_parser_error(
+                 e.message(), filename, e.line()));
+         }
++        BOOST_CATCH_END
+     }
+ 
+ } } }
+
+diff --git a/boost/property_tree/detail/info_parser_read.hpp b/boost/property_tree/detail/info_parser_read.hpp
+index c3446b4..b46643a 100644
+--- a/boost/property_tree/detail/info_parser_read.hpp
++++ b/boost/property_tree/detail/info_parser_read.hpp
+@@ -13,7 +13,6 @@
+ #include "boost/property_tree/ptree.hpp"
+ #include "boost/property_tree/detail/info_parser_error.hpp"
+ #include "boost/property_tree/detail/info_parser_utils.hpp"
+-#include "boost/core/ignore_unused.hpp"
+ #include "boost/core/no_exceptions_support.hpp"
+ #include <iterator>
+ #include <string>
+@@ -212,12 +211,6 @@ namespace boost { namespace property_tree { namespace info_parser
+         std::stack<Ptree *> stack;
+         stack.push(&pt);                // Push root ptree on stack initially
+ 
+-        // When compiling without exception support there is no formal
+-        // parameter "e" in the catch handler.  Declaring a local variable
+-        // here does not hurt and will be "used" to make the code in the
+-        // handler  compilable although the code will never be executed.
+-        info_parser_error e("", "", 0); ignore_unused(e);
+-
+         BOOST_TRY {
+             // While there are characters in the stream
+             while (stream.good()) {
+@@ -382,6 +375,7 @@ namespace boost { namespace property_tree { namespace info_parser
+         }
+         BOOST_CATCH (info_parser_error &e)
+         {
++    #ifndef BOOST_NO_EXCEPTIONS
+             // If line undefined rethrow error with correct filename and line
+             if (e.line() == 0)
+             {
+@@ -389,7 +383,7 @@ namespace boost { namespace property_tree { namespace info_parser
+             }
+             else
+                 BOOST_PROPERTY_TREE_THROW(e);
+-
++    #endif
+         }
+         BOOST_CATCH_END
+ 
+diff --git a/boost/property_tree/detail/xml_parser_read_rapidxml.hpp b/boost/property_tree/detail/xml_parser_read_rapidxml.hpp
+index a6b005a..b6f5820 100644
+--- a/boost/property_tree/detail/xml_parser_read_rapidxml.hpp
++++ b/boost/property_tree/detail/xml_parser_read_rapidxml.hpp
+@@ -15,7 +15,6 @@
+ #include <boost/property_tree/detail/xml_parser_flags.hpp>
+ #include <boost/property_tree/detail/xml_parser_utils.hpp>
+ #include <boost/property_tree/detail/rapidxml.hpp>
+-#include <boost/core/ignore_unused.hpp>
+ #include <boost/core/no_exceptions_support.hpp>
+ #include <vector>
+ 
+@@ -103,12 +102,6 @@ namespace boost { namespace property_tree { namespace xml_parser
+                 xml_parser_error("read error", filename, 0));
+         v.push_back(0); // zero-terminate
+ 
+-        // When compiling without exception support there is no formal
+-        // parameter "e" in the catch handler.  Declaring a local variable
+-        // here does not hurt and will be "used" to make the code in the
+-        // handler compilable although the code will never be executed.
+-        parse_error e(NULL, NULL); ignore_unused(e);
+-        
+         BOOST_TRY {
+             // Parse using appropriate flags
+             const int f_tws = parse_normalize_whitespace
+@@ -140,10 +133,12 @@ namespace boost { namespace property_tree { namespace xml_parser
+             // Swap local and result ptrees
+             pt.swap(local);
+         } BOOST_CATCH (parse_error &e) {
++    #ifndef BOOST_NO_EXCEPTIONS
+             long line = static_cast<long>(
+                 std::count(&v.front(), e.where<Ch>(), Ch('\n')) + 1);
+             BOOST_PROPERTY_TREE_THROW(
+                 xml_parser_error(e.what(), filename, line));  
++    #endif
+         }
+         BOOST_CATCH_END
+     }
+diff --git a/boost/property_tree/ini_parser.hpp b/boost/property_tree/ini_parser.hpp
+index 5142dbf..cb63fcc 100644
+--- a/boost/property_tree/ini_parser.hpp
++++ b/boost/property_tree/ini_parser.hpp
+@@ -14,7 +14,6 @@
+ #include <boost/property_tree/ptree.hpp>
+ #include <boost/property_tree/detail/ptree_utils.hpp>
+ #include <boost/property_tree/detail/file_parser_error.hpp>
+-#include <boost/core/ignore_unused.hpp>
+ #include <boost/core/no_exceptions_support.hpp>
+ #include <fstream>
+ #include <string>
+@@ -168,18 +167,14 @@ namespace boost { namespace property_tree { namespace ini_parser
+                 "cannot open file", filename, 0));
+         stream.imbue(loc);
+ 
+-        // When compiling without exception support there is no formal
+-        // parameter "e" in the catch handler.  Declaring a local variable
+-        // here does not hurt and will be "used" to make the code in the
+-        // handler compilable although the code will never be executed.
+-        ini_parser_error e("", "", 0); ignore_unused(e);
+-
+         BOOST_TRY {
+             read_ini(stream, pt);
+         }
+         BOOST_CATCH (ini_parser_error &e) {
++    #ifndef BOOST_NO_EXCEPTIONS
+             BOOST_PROPERTY_TREE_THROW(ini_parser_error(
+                 e.message(), filename, e.line()));
++    #endif
+         }
+         BOOST_CATCH_END
+     }
+@@ -324,18 +319,14 @@ namespace boost { namespace property_tree { namespace ini_parser
+                 "cannot open file", filename, 0));
+         stream.imbue(loc);
+ 
+-        // When compiling without exception support there is no formal
+-        // parameter "e" in the catch handler.  Declaring a local variable
+-        // here does not hurt and will be "used" to make the code in the
+-        // handler  compilable although the code will never be executed.
+-        ini_parser_error e("", "", 0); ignore_unused(e);
+-
+         BOOST_TRY {
+             write_ini(stream, pt, flags);
+         }
+         BOOST_CATCH (ini_parser_error &e) {
++    #ifndef BOOST_NO_EXCEPTIONS
+             BOOST_PROPERTY_TREE_THROW(ini_parser_error(
+                 e.message(), filename, e.line()));
++    #endif
+         }
+         BOOST_CATCH_END
+     }

--- a/scripts/boost/1.75.0/script.sh
+++ b/scripts/boost/1.75.0/script.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# inherit from boost base (used for all boost library packages)
+source ${HERE}/base.sh
+
+# this package is the one that is header-only
+MASON_NAME=boost
+MASON_HEADER_ONLY=true
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${HERE}/common.sh
+
+# override default unpacking to just unpack headers
+function mason_load_source {
+    mason_download \
+        https://dl.bintray.com/boostorg/release/${MASON_VERSION}/source/boost_${BOOST_VERSION}.tar.bz2 \
+        ${BOOST_SHASUM}
+
+    mason_extract_tar_bz2 boost_${BOOST_VERSION}/boost
+
+    MASON_BUILD_PATH=${MASON_ROOT}/.build/boost_${BOOST_VERSION}
+}
+
+# override default "compile" target for just the header install
+function mason_compile {
+    patch -N -p1  < ${MASON_DIR}/scripts/${MASON_NAME}/${MASON_VERSION}/patch.diff
+    mkdir -p ${MASON_PREFIX}/include
+    cp -r ${MASON_ROOT}/.build/boost_${BOOST_VERSION}/boost ${MASON_PREFIX}/include
+}
+
+function mason_ldflags {
+    :
+}
+
+function mason_static_libs {
+    :
+}
+
+mason_run "$@"

--- a/scripts/boost_libatomic/1.75.0/.travis.yml
+++ b/scripts/boost_libatomic/1.75.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode11
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libatomic/1.75.0/script.sh
+++ b/scripts/boost_libatomic/1.75.0/script.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+BOOST_LIBRARY=${THIS_DIR#boost_lib}
+MASON_NAME=boost_lib${BOOST_LIBRARY}
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+mason_run "$@"

--- a/scripts/boost_libchrono/1.75.0/.travis.yml
+++ b/scripts/boost_libchrono/1.75.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode11
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libchrono/1.75.0/script.sh
+++ b/scripts/boost_libchrono/1.75.0/script.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+BOOST_LIBRARY=${THIS_DIR#boost_lib}
+MASON_NAME=boost_lib${BOOST_LIBRARY}
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+mason_run "$@"

--- a/scripts/boost_libdate_time/1.75.0/.travis.yml
+++ b/scripts/boost_libdate_time/1.75.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode11
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libdate_time/1.75.0/script.sh
+++ b/scripts/boost_libdate_time/1.75.0/script.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+BOOST_LIBRARY=${THIS_DIR#boost_lib}
+MASON_NAME=boost_lib${BOOST_LIBRARY}
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+mason_run "$@"

--- a/scripts/boost_libfilesystem/1.75.0/.travis.yml
+++ b/scripts/boost_libfilesystem/1.75.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode11
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libfilesystem/1.75.0/script.sh
+++ b/scripts/boost_libfilesystem/1.75.0/script.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+BOOST_LIBRARY=${THIS_DIR#boost_lib}
+MASON_NAME=boost_lib${BOOST_LIBRARY}
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+mason_run "$@"

--- a/scripts/boost_libiostreams/1.75.0/.travis.yml
+++ b/scripts/boost_libiostreams/1.75.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode11
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libiostreams/1.75.0/script.sh
+++ b/scripts/boost_libiostreams/1.75.0/script.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+BOOST_LIBRARY=${THIS_DIR#boost_lib}
+MASON_NAME=boost_lib${BOOST_LIBRARY}
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+mason_run "$@"

--- a/scripts/boost_libprogram_options/1.75.0/.travis.yml
+++ b/scripts/boost_libprogram_options/1.75.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode11
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libprogram_options/1.75.0/script.sh
+++ b/scripts/boost_libprogram_options/1.75.0/script.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+BOOST_LIBRARY=${THIS_DIR#boost_lib}
+MASON_NAME=boost_lib${BOOST_LIBRARY}
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+mason_run "$@"

--- a/scripts/boost_libpython/1.75.0/.travis.yml
+++ b/scripts/boost_libpython/1.75.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode11
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libpython/1.75.0/patch.diff
+++ b/scripts/boost_libpython/1.75.0/patch.diff
@@ -1,0 +1,12 @@
+--- libs/python/src/converter/builtin_converters.cpp	2012-12-07 11:51:06.000000000 -0800
++++ libs/python/src/converter/builtin_converters.cpp	2014-04-01 17:24:37.000000000 -0700
+@@ -32,7 +32,9 @@
+ 
+ void shared_ptr_deleter::operator()(void const*)
+ {
++    PyGILState_STATE gil = PyGILState_Ensure();
+     owner.reset();
++    PyGILState_Release(gil);
+ }
+ 
+ namespace

--- a/scripts/boost_libpython/1.75.0/script.sh
+++ b/scripts/boost_libpython/1.75.0/script.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+BOOST_LIBRARY=${THIS_DIR#boost_lib}
+MASON_NAME=boost_lib${BOOST_LIBRARY}
+PYTHON_VERSION="2.7"
+PYTHON_VERSION_NO_DOT=${PYTHON_VERSION/.}
+# NOTE: as of boost 1.67.0 it appears the static library has the python version embedded
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+function write_python_config() {
+# usage:
+# write_python_config <user-config.jam> <version> <base> <variant>
+local PYTHON_VERSION=$2
+# note: apple pythons need '/System'
+PYTHON_BASE=$3
+# note: python 3 uses 'm'
+PYTHON_VARIANT=$4
+if [[ $(uname -s) == 'Darwin' ]]; then
+    echo "
+      using python
+           : ${PYTHON_VERSION} # version
+           : ${PYTHON_BASE}/Library/Frameworks/Python.framework/Versions/${PYTHON_VERSION}/bin/python${PYTHON_VERSION}${PYTHON_VARIANT} # cmd-or-prefix
+           : ${PYTHON_BASE}/Library/Frameworks/Python.framework/Versions/${PYTHON_VERSION}/include/python${PYTHON_VERSION}${PYTHON_VARIANT} # includes
+           : ${PYTHON_BASE}/Library/Frameworks/Python.framework/Versions/${PYTHON_VERSION}/lib/python${PYTHON_VERSION}/config${PYTHON_VARIANT} # a lib actually symlink
+           : <toolset>${BOOST_TOOLSET} # condition
+           ;
+    " >> $1
+else
+  if [[ $(uname -s) == 'FreeBSD' ]]; then
+      echo "
+        using python
+             : ${PYTHON_VERSION} # version
+             : /usr/local/bin/python${PYTHON_VERSION}${PYTHON_VARIANT} # cmd-or-prefix
+             : /usr/local/include/python${PYTHON_VERSION} # includes
+             : /usr/local/lib/python${PYTHON_VERSION}/config${PYTHON_VARIANT}
+             : <toolset>${BOOST_TOOLSET} # condition
+             ;
+      " >> $1
+  else
+      echo "
+        using python
+             : ${PYTHON_VERSION} # version
+             : /usr/bin/python${PYTHON_VERSION}${PYTHON_VARIANT} # cmd-or-prefix
+             : /usr/include/python${PYTHON_VERSION} # includes
+             : /usr/lib/python${PYTHON_VERSION}/config${PYTHON_VARIANT}
+             : <toolset>${BOOST_TOOLSET} # condition
+             ;
+      " >> $1
+  fi
+fi
+}
+
+function mason_compile {
+    # patch to workaround crashes in python.input
+    # https://github.com/mapnik/mapnik/issues/1968
+    mason_step "Loading patch ${MASON_DIR}/scripts/${MASON_NAME}/${MASON_VERSION}/patch.diff"
+    patch -N -p0 < ${MASON_DIR}/scripts/${MASON_NAME}/${MASON_VERSION}/patch.diff
+    write_python_config user-config.jam ${PYTHON_VERSION} "/System" ""
+    gen_config ${BOOST_TOOLSET} ${BOOST_TOOLSET_CXX}
+    if [[ ! -f ./b2 ]] ; then
+        ./bootstrap.sh
+    fi
+    ./b2 \
+        --with-${BOOST_LIBRARY} \
+        --prefix=${MASON_PREFIX} \
+        -j${MASON_CONCURRENCY} \
+        -d0 \
+        --ignore-site-config --user-config=user-config.jam \
+        architecture="${BOOST_ARCH}" \
+        toolset="${BOOST_TOOLSET}" \
+        link=static \
+        variant=release \
+        linkflags="${LDFLAGS:-" "}" \
+        cxxflags="${CXXFLAGS:-" "}" \
+        stage
+    mkdir -p $(dirname ${MASON_PREFIX}/${MASON_LIB_FILE})
+    # NOTE: we strip the python version to make linking easier
+    mv stage/lib/libboost_${BOOST_LIBRARY}${PYTHON_VERSION_NO_DOT}.a ${MASON_PREFIX}/${MASON_LIB_FILE}
+}
+
+mason_run "$@"

--- a/scripts/boost_libregex/1.75.0/.travis.yml
+++ b/scripts/boost_libregex/1.75.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode11
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libregex/1.75.0/script.sh
+++ b/scripts/boost_libregex/1.75.0/script.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+BOOST_LIBRARY=${THIS_DIR#boost_lib}
+MASON_NAME=boost_lib${BOOST_LIBRARY}
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+mason_run "$@"

--- a/scripts/boost_libregex_icu/1.75.0/.travis.yml
+++ b/scripts/boost_libregex_icu/1.75.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode11
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libregex_icu/1.75.0/script.sh
+++ b/scripts/boost_libregex_icu/1.75.0/script.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+# Note: cannot deduce from directory since it is named in a custom way
+#BOOST_LIBRARY=${THIS_DIR#boost_lib}
+BOOST_LIBRARY=regex
+MASON_NAME=boost_lib${BOOST_LIBRARY}_icu
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+function mason_prepare_compile {
+    ${MASON_DIR}/mason install icu 55.1
+    MASON_ICU=$(${MASON_DIR}/mason prefix icu 55.1)
+}
+
+# custom compile that gets icu working
+function mason_compile {
+    gen_config ${BOOST_TOOLSET} ${BOOST_TOOLSET_CXX}
+    if [[ ! -f ./b2 ]] ; then
+        ./bootstrap.sh
+    fi
+    echo 'int main() { return 0; }' > libs/regex/build/has_icu_test.cpp
+    ./b2 \
+        --with-${BOOST_LIBRARY} \
+        --prefix=${MASON_PREFIX} \
+        -j${MASON_CONCURRENCY} \
+        -sHAVE_ICU=1 -sICU_PATH=${MASON_ICU} --reconfigure --debug-configuration \
+        -d0 \
+        --ignore-site-config --user-config=user-config.jam \
+        architecture="${BOOST_ARCH}" \
+        toolset="${BOOST_TOOLSET}" \
+        link=static \
+        variant=release \
+        linkflags="${LDFLAGS:-" "}" \
+        cxxflags="${CXXFLAGS:-" "}" \
+        stage
+    mkdir -p $(dirname ${MASON_PREFIX}/${MASON_LIB_FILE})
+    mv stage/${MASON_LIB_FILE} ${MASON_PREFIX}/${MASON_LIB_FILE}
+}
+
+mason_run "$@"

--- a/scripts/boost_libregex_icu57/1.75.0/.travis.yml
+++ b/scripts/boost_libregex_icu57/1.75.0/.travis.yml
@@ -1,0 +1,18 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode11
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libregex_icu57/1.75.0/script.sh
+++ b/scripts/boost_libregex_icu57/1.75.0/script.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+# Note: cannot deduce from directory since it is named in a custom way
+#BOOST_LIBRARY=${THIS_DIR#boost_lib}
+BOOST_LIBRARY=regex
+MASON_NAME=boost_lib${BOOST_LIBRARY}_icu57
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+function mason_prepare_compile {
+    ${MASON_DIR}/mason install icu 57.1
+    MASON_ICU=$(${MASON_DIR}/mason prefix icu 57.1)
+}
+
+# custom compile that gets icu working
+function mason_compile {
+    gen_config ${BOOST_TOOLSET} ${BOOST_TOOLSET_CXX}
+    if [[ ! -f ./b2 ]] ; then
+        ./bootstrap.sh
+    fi
+    echo 'int main() { return 0; }' > libs/regex/build/has_icu_test.cpp
+    ./b2 \
+        --with-${BOOST_LIBRARY} \
+        --prefix=${MASON_PREFIX} \
+        -j${MASON_CONCURRENCY} \
+        -sHAVE_ICU=1 -sICU_PATH=${MASON_ICU} --reconfigure --debug-configuration \
+        -d0 -a \
+        --ignore-site-config --user-config=user-config.jam \
+        architecture="${BOOST_ARCH}" \
+        toolset="${BOOST_TOOLSET}" \
+        link=static \
+        variant=release \
+        linkflags="${LDFLAGS:-" "}" \
+        cxxflags="-fvisibility=hidden ${CXXFLAGS:-" "}" \
+        stage
+    mkdir -p $(dirname ${MASON_PREFIX}/${MASON_LIB_FILE})
+    mv stage/${MASON_LIB_FILE} ${MASON_PREFIX}/${MASON_LIB_FILE}
+}
+
+mason_run "$@"

--- a/scripts/boost_libregex_icu58/1.75.0/.travis.yml
+++ b/scripts/boost_libregex_icu58/1.75.0/.travis.yml
@@ -1,0 +1,18 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode11
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-6-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libregex_icu58/1.75.0/script.sh
+++ b/scripts/boost_libregex_icu58/1.75.0/script.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+# Note: cannot deduce from directory since it is named in a custom way
+#BOOST_LIBRARY=${THIS_DIR#boost_lib}
+BOOST_LIBRARY=regex
+MASON_NAME=boost_lib${BOOST_LIBRARY}_icu58
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+function mason_prepare_compile {
+    ${MASON_DIR}/mason install icu 58.1
+    MASON_ICU=$(${MASON_DIR}/mason prefix icu 58.1)
+}
+
+# custom compile that gets icu working
+function mason_compile {
+    gen_config ${BOOST_TOOLSET} ${BOOST_TOOLSET_CXX}
+    if [[ ! -f ./b2 ]] ; then
+        ./bootstrap.sh
+    fi
+    echo 'int main() { return 0; }' > libs/regex/build/has_icu_test.cpp
+    ./b2 \
+        --with-${BOOST_LIBRARY} \
+        --prefix=${MASON_PREFIX} \
+        -j${MASON_CONCURRENCY} \
+        -sHAVE_ICU=1 -sICU_PATH=${MASON_ICU} --reconfigure --debug-configuration \
+        -d0 -a \
+        --ignore-site-config --user-config=user-config.jam \
+        architecture="${BOOST_ARCH}" \
+        toolset="${BOOST_TOOLSET}" \
+        link=static \
+        variant=release \
+        linkflags="${LDFLAGS:-" "}" \
+        cxxflags="-fvisibility=hidden ${CXXFLAGS:-" "}" \
+        stage
+    mkdir -p $(dirname ${MASON_PREFIX}/${MASON_LIB_FILE})
+    mv stage/${MASON_LIB_FILE} ${MASON_PREFIX}/${MASON_LIB_FILE}
+}
+
+mason_run "$@"

--- a/scripts/boost_libsystem/1.75.0/.travis.yml
+++ b/scripts/boost_libsystem/1.75.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode11
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libsystem/1.75.0/script.sh
+++ b/scripts/boost_libsystem/1.75.0/script.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+BOOST_LIBRARY=${THIS_DIR#boost_lib}
+MASON_NAME=boost_lib${BOOST_LIBRARY}
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+mason_run "$@"

--- a/scripts/boost_libtest/1.75.0/.travis.yml
+++ b/scripts/boost_libtest/1.75.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode11
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libtest/1.75.0/script.sh
+++ b/scripts/boost_libtest/1.75.0/script.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+BOOST_LIBRARY=${THIS_DIR#boost_lib}
+MASON_NAME=boost_lib${BOOST_LIBRARY}
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+mason_run "$@"

--- a/scripts/boost_libthread/1.75.0/.travis.yml
+++ b/scripts/boost_libthread/1.75.0/.travis.yml
@@ -1,0 +1,19 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode11
+      compiler: clang
+    - os: linux
+      sudo: false
+      addons:
+        apt:
+          sources:
+           - ubuntu-toolchain-r-test
+          packages:
+           - libstdc++-5-dev
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/boost_libthread/1.75.0/script.sh
+++ b/scripts/boost_libthread/1.75.0/script.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# dynamically determine the path to this package
+HERE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+
+# key properties unique to this library
+THIS_DIR=$(basename $(dirname $HERE))
+BOOST_LIBRARY=${THIS_DIR#boost_lib}
+MASON_NAME=boost_lib${BOOST_LIBRARY}
+MASON_LIB_FILE=lib/libboost_${BOOST_LIBRARY}.a
+# hack for inconsistently named test lib
+if [[ ${MASON_LIB_FILE} == "lib/libboost_test.a" ]]; then
+    MASON_LIB_FILE=lib/libboost_unit_test_framework.a
+fi
+
+# inherit from boost base (used for all boost library packages)
+BASE_PATH=${HERE}/../../boost/$(basename $HERE)
+source ${BASE_PATH}/base.sh
+
+# setup mason env
+. ${MASON_DIR}/mason.sh
+
+# source common build functions
+source ${BASE_PATH}/common.sh
+
+mason_run "$@"


### PR DESCRIPTION
This builds off https://github.com/mapbox/mason/pull/735 by:

 - carrying over the ptree patch to 1.75.0 from @averkhaturau 
 - removing the asio patch from @brunoabinader that is already in 1.75.0

I've tested the @averkhaturau patch locally by doing:

```
./mason build boost 1.75.0
```

And then viewing `mason_packages/.build/boost_1_75_0/boost/property_tree/detail/ptree_implementation.hpp` to confirm it applied okay.

This is ready to test by downstream users. @artemp I think depends on ptree, so would be good to confirm this does not break things for mapnik.