### PR TITLE
Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# global owners
+*       @mapbox/tilesets-api


### PR DESCRIPTION
## Context

Adds a `CODEOWNERS` file to this repo with owner @mapbox/tilesets-api.