### PR TITLE
#749 fixes link libpng 1.6.32 and added 1.6.39

### DIFF
--- a/scripts/libpng/1.6.39/.travis.yml
+++ b/scripts/libpng/1.6.39/.travis.yml
@@ -1,0 +1,45 @@
+language: generic
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8.2
+      compiler: clang
+    - os: linux
+      env: MASON_PLATFORM_VERSION=cortex_a9
+      sudo: false
+    - os: linux
+      env: MASON_PLATFORM_VERSION=i686
+      sudo: false
+      addons:
+        apt:
+          packages: [ 'zlib1g-dev:i386' ]
+    - os: linux
+      env: MASON_PLATFORM=linux
+      compiler: clang
+      sudo: false
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v5
+      sudo: false
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v7
+      sudo: false
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=arm-v8
+      sudo: false
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=x86
+      sudo: false
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=x86-64
+      sudo: false
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=mips
+      sudo: false
+    - os: linux
+      env: MASON_PLATFORM=android MASON_ANDROID_ABI=mips-64
+      sudo: false
+
+script:
+- ./mason build ${MASON_NAME} ${MASON_VERSION}
+- ./mason publish ${MASON_NAME} ${MASON_VERSION}

--- a/scripts/libpng/1.6.39/script.sh
+++ b/scripts/libpng/1.6.39/script.sh
@@ -13,7 +13,7 @@ ZLIB_SHARED_VERSION=1.2.8
 function mason_load_source {
     mason_download \
         https://downloads.sourceforge.net/project/libpng/libpng16/${MASON_VERSION}/libpng-${MASON_VERSION}.tar.gz \
-        752b19285db1aab9d0b8f5ef2312390734f71e70
+        d7381b740d41de6ca31eec5143205c1a75b0f445
 
     mason_extract_tar_gz
 

--- a/scripts/libpng/1.6.39/script.sh
+++ b/scripts/libpng/1.6.39/script.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 MASON_NAME=libpng
-MASON_VERSION=1.6.32
+MASON_VERSION=1.6.39
 MASON_LIB_FILE=lib/libpng.a
 MASON_PKGCONFIG_FILE=lib/pkgconfig/libpng.pc
 
@@ -12,7 +12,7 @@ ZLIB_SHARED_VERSION=1.2.8
 
 function mason_load_source {
     mason_download \
-        https://downloads.sourceforge.net/project/libpng/libpng16/older-releases/${MASON_VERSION}/libpng-${MASON_VERSION}.tar.gz \
+        https://downloads.sourceforge.net/project/libpng/libpng16/${MASON_VERSION}/libpng-${MASON_VERSION}.tar.gz \
         752b19285db1aab9d0b8f5ef2312390734f71e70
 
     mason_extract_tar_gz


### PR DESCRIPTION
- fix link: libpng 1.6.32 down to older-releases
- added libpng 1.6.39 (current release)